### PR TITLE
Oneof support

### DIFF
--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -461,12 +461,12 @@ dotProtoMessageD ctxt parentIdent messageIdent message =
                               dpIdentUnqualName fieldName
                   fullTy <- hsTypeFromDotProto ctxt' ty
                   pure [ ([HsIdent fullName], HsUnBangedTy fullTy ) ]
-           messagePartFieldD (DotProtoMessageOneOf {}) =
-             -- unimplementedError "oneof"
-             trace
-               ("WARNING: ignoring oneof construct since support for it is unimplemented! "
-                <> "Continuing with CG, but note that it is _NOT FAITHFUL_ to the input .proto!)")
-               (pure [])
+           messagePartFieldD (DotProtoMessageOneOf fieldName _) =
+               do fullName <- prefixedFieldName messageName =<<
+                              dpIdentUnqualName fieldName
+                  fullTy <- prefixedConName messageName =<<
+                            dpIdentUnqualName fieldName
+                  pure [ ([HsIdent fullName], HsUnBangedTy (type_ fullTy) ) ]
            messagePartFieldD _ = pure []
 
            nestedDecls :: DotProtoDefinition -> CompileResult [HsDecl]

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -850,8 +850,8 @@ dotProtoFieldC, primC, optionalC, repeatedC, nestedRepeatedC, namedC,
   identifierC, stringLitC, intLitC, floatLitC, boolLitC, trueC, falseC,
   unaryHandlerC, clientStreamHandlerC, serverStreamHandlerC, biDiStreamHandlerC,
   methodNameC, nothingC, justC, mconcatE, encodeMessageFieldE, fromStringE,
-  decodeMessageFieldE, pureE, atE, succErrorE, predErrorE, toEnumErrorE, fmapE,
-  defaultOptionsE, serverLoopE, convertServerHandlerE,
+  decodeMessageFieldE, pureE, atE, oneofE, succErrorE, predErrorE, toEnumErrorE,
+  fmapE, defaultOptionsE, serverLoopE, convertServerHandlerE,
   convertServerReaderHandlerE, convertServerWriterHandlerE,
   convertServerRWHandlerE, clientRegisterMethodE, clientRequestE :: HsExp
 dotProtoFieldC        = HsVar (protobufName "DotProtoField")
@@ -885,6 +885,7 @@ justC                 = HsVar (haskellName "Just")
 encodeMessageFieldE   = HsVar (protobufName "encodeMessageField")
 decodeMessageFieldE   = HsVar (protobufName "decodeMessageField")
 atE                   = HsVar (protobufName "at")
+oneofE                = HsVar (protobufName "oneof")
 mconcatE              = HsVar (haskellName "mconcat")
 fromStringE           = HsVar (haskellName "fromString")
 pureE                 = HsVar (haskellName "pure")

--- a/test-files/test_proto_oneof.proto
+++ b/test-files/test_proto_oneof.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+package TestProtoOneof;
+
+message Something {
+  sint64 value = 1;
+  sint32 another = 2;
+  oneof name_or_id {
+    string name = 4;
+    int32 someid = 9;
+  }
+}

--- a/tests/SimpleDecodeDotProto.hs
+++ b/tests/SimpleDecodeDotProto.hs
@@ -16,6 +16,7 @@ import System.Exit
 
 import TestProto
 import qualified TestProtoImport
+import qualified TestProtoOneof
 
 main :: IO ()
 main = do putStr "\n"
@@ -23,13 +24,14 @@ main = do putStr "\n"
 
 tests, testCase1, testCase2, testCase3, testCase4, testCase5,
     testCase6, testCase8, testCase9, testCase10, testCase11,
-    testCase12, testCase13, testCase14, testCase15 :: TestTree
+    testCase12, testCase13, testCase14, testCase15, testCase16,
+    testCase17 :: TestTree
 tests = testGroup "Decode protobuf messages from Python"
           [  testCase1,  testCase2, testCaseSignedInts
           ,  testCase3,  testCase4,  testCase5,  testCase6
           ,  testCase7,  testCase8,  testCase9, testCase10
           , testCase11, testCase12, testCase13, testCase14
-          , testCase15, testCase16
+          , testCase15, testCase16, testCase17
           , allTestsDone -- this should always run last
           ]
 
@@ -229,6 +231,17 @@ testCase16 = testCase "Proper resolution of shadowed message names" $
                  (Just (TestProtoImport.WithNesting_Nested 1 2))
                  (Just (TestProtoImport.WithNesting_Nested 3 4)))
        usingImportedLocalNesting @?= Just (WithNesting (Just (WithNesting_Nested "field" 0xBEEF [] [])))
+
+testCase17 = testCase "Oneof" $
+    do TestProtoOneof.Something { .. } <- readProto
+       somethingValue @?= 42
+       somethingAnother @?= 4242
+       somethingNameOrId @?= TestProtoOneof.SomethingNameOrIdName "hello world"
+
+       TestProtoOneof.Something { .. } <- readProto
+       somethingValue @?= 1
+       somethingAnother @?= 2
+       somethingNameOrId @?= TestProtoOneof.SomethingNameOrIdSomeid 3
 
 allTestsDone = testCase "Receive end of test suite sentinel message" $
    do MultipleFields{..} <- readProto

--- a/tests/SimpleEncodeDotProto.hs
+++ b/tests/SimpleEncodeDotProto.hs
@@ -5,6 +5,7 @@ module Main where
 
 import           TestProto
 import qualified TestProtoImport
+import qualified TestProtoOneof
 import           Proto3.Suite
 import qualified Data.ByteString.Lazy as BL
 
@@ -132,6 +133,17 @@ testCase16 =
                                , usingImportedLocalNesting =
                                    Just (WithNesting (Just (WithNesting_Nested "field" 0xBEEF [] []))) })
 
+testCase17 :: IO ()
+testCase17 = do
+  outputMessage (TestProtoOneof.Something { TestProtoOneof.somethingValue = 42
+                                          , TestProtoOneof.somethingAnother = 4242
+                                          , TestProtoOneof.somethingNameOrId = TestProtoOneof.SomethingNameOrIdName "hello world"
+                                          })
+  outputMessage (TestProtoOneof.Something { TestProtoOneof.somethingValue = 1
+                                          , TestProtoOneof.somethingAnother = 2
+                                          , TestProtoOneof.somethingNameOrId = TestProtoOneof.SomethingNameOrIdSomeid 3
+                                          })
+
 main :: IO ()
 main = do testCase1
           testCase2
@@ -152,5 +164,6 @@ main = do testCase1
           -- Tests using imported messages
           testCase15
           testCase16
+          testCase17
 
           outputMessage (MultipleFields 0 0 0 0 "All tests complete" False)

--- a/tests/TestCodeGen.hs
+++ b/tests/TestCodeGen.hs
@@ -47,6 +47,7 @@ simpleEncodeDotProto =
 
        (@?= ExitSuccess) =<< proc "tests/encode.sh" [hsTmpDir] empty
        (@?= ExitSuccess) =<< shell (T.concat ["protoc --python_out=", pyTmpDir, " --proto_path=test-files", " test-files/test_proto.proto"]) empty
+       (@?= ExitSuccess) =<< shell (T.concat ["protoc --python_out=", pyTmpDir, " --proto_path=test-files", " test-files/test_proto_oneof.proto"]) empty
        (@?= ExitSuccess) =<< shell (T.concat ["protoc --python_out=", pyTmpDir, " --proto_path=test-files", " test-files/test_proto_import.proto"]) empty
        touch (pyTmpDir </> "__init__.py")
 
@@ -75,6 +76,7 @@ simpleDecodeDotProto =
 
        (@?= ExitSuccess) =<< proc "tests/decode.sh" [hsTmpDir] empty
        (@?= ExitSuccess) =<< shell (T.concat ["protoc --python_out=", pyTmpDir, " --proto_path=test-files", " test-files/test_proto.proto"]) empty
+       (@?= ExitSuccess) =<< shell (T.concat ["protoc --python_out=", pyTmpDir, " --proto_path=test-files", " test-files/test_proto_oneof.proto"]) empty
        (@?= ExitSuccess) =<< shell (T.concat ["protoc --python_out=", pyTmpDir, " --proto_path=test-files", " test-files/test_proto_import.proto"]) empty
        touch (pyTmpDir </> "__init__.py")
 
@@ -99,4 +101,5 @@ pyTmpDir = "test-files/py-tmp"
 compileTestDotProtos :: IO ()
 compileTestDotProtos = do
   compileDotProtoFileOrDie hsTmpDir ["test-files"] "test_proto.proto"
+  compileDotProtoFileOrDie hsTmpDir ["test-files"] "test_proto_oneof.proto"
   compileDotProtoFileOrDie hsTmpDir ["test-files"] "test_proto_import.proto"

--- a/tests/check_simple_dot_proto.py
+++ b/tests/check_simple_dot_proto.py
@@ -249,13 +249,13 @@ assert case16.localNesting.nestedMessage.nestedPacked == []
 assert case16.localNesting.nestedMessage.nestedUnpacked == []
 
 # Test case 17: Oneof
-case17a = read_proto(ImportedOneOf)
+case17a = read_proto(ImportedOneof)
 assert case17a.value == 42
 assert case17a.another == 4242
 assert case17a.HasField('name')
 assert case17a.name == "hello world"
 
-case17b = read_proto(ImportedOneOf)
+case17b = read_proto(ImportedOneof)
 assert case17b.value == 1
 assert case17b.another == 2
 assert case17b.HasField('someid')

--- a/tests/check_simple_dot_proto.py
+++ b/tests/check_simple_dot_proto.py
@@ -3,6 +3,7 @@ import sys
 # Import protoc generated {de,}serializers (generated from test_proto{,_import}.proto)
 from test_proto_pb2 import *
 from test_proto_import_pb2 import WithNesting as ImportedWithNesting
+from test_proto_oneof_pb2 import Something as ImportedOneof
 
 def read_proto(cls):
     length = int(raw_input())
@@ -246,6 +247,19 @@ assert case16.localNesting.nestedMessage.nestedField1 == "field"
 assert case16.localNesting.nestedMessage.nestedField2 == 0xBEEF
 assert case16.localNesting.nestedMessage.nestedPacked == []
 assert case16.localNesting.nestedMessage.nestedUnpacked == []
+
+# Test case 17: Oneof
+case17a = read_proto(ImportedOneOf)
+assert case17a.value == 42
+assert case17a.another == 4242
+assert case17a.HasField('name')
+assert case17a.name == "hello world"
+
+case17b = read_proto(ImportedOneOf)
+assert case17b.value == 1
+assert case17b.another == 2
+assert case17b.HasField('someid')
+assert case17b.someid == 3
 
 # Wait for the special 'done' messsage
 done_msg = read_proto(MultipleFields)

--- a/tests/decode.sh
+++ b/tests/decode.sh
@@ -9,5 +9,6 @@ ghc                                         \
     -o $hsTmpDir/simpleDecodeDotProto       \
     $hsTmpDir/TestProto.hs                  \
     $hsTmpDir/TestProtoImport.hs            \
+    $hsTmpDir/TestProtoOneof.hs             \
     tests/SimpleDecodeDotProto.hs           \
     >/dev/null

--- a/tests/encode.sh
+++ b/tests/encode.sh
@@ -9,5 +9,6 @@ ghc                                         \
     -o $hsTmpDir/simpleEncodeDotProto       \
     $hsTmpDir/TestProto.hs                  \
     $hsTmpDir/TestProtoImport.hs            \
+    $hsTmpDir/TestProtoOneof.hs             \
     tests/SimpleEncodeDotProto.hs           \
     >/dev/null

--- a/tests/send_simple_dot_proto.py
+++ b/tests/send_simple_dot_proto.py
@@ -4,6 +4,7 @@ import os
 # Import protoc generated {de,}serializers (generated from test_proto{,_import}.proto)
 from test_proto_pb2 import *
 import test_proto_import_pb2 as test_proto_import
+import test_proto_oneof_pb2 as test_proto_oneof
 
 def write_proto(msg):
     out = msg.SerializeToString()
@@ -164,6 +165,10 @@ write_proto(test_proto_import.WithNesting(nestedMessage1 = test_proto_import.Wit
 write_proto(UsingImported(importedNesting = test_proto_import.WithNesting(nestedMessage1 = test_proto_import.WithNesting.Nested(nestedField1 = 1, nestedField2 = 2),
                                                                           nestedMessage2 = test_proto_import.WithNesting.Nested(nestedField1 = 3, nestedField2 = 4)),
                           localNesting = WithNesting(nestedMessage = WithNesting.Nested(nestedField1 = "field", nestedField2 = 0xBEEF, nestedPacked = [], nestedUnpacked = []))))
+
+# Test case 17: Oneof
+write_proto(test_proto_oneof.Something(value=42, another=4242, name="hello world"))
+write_proto(test_proto_oneof.Something(value=1, another=2, someid=3))
 
 # Send the special 'done' message
 write_proto(MultipleFields(multiFieldString = "All tests complete"))


### PR DESCRIPTION
Add most support for oneof in .proto file:

* Emit the field appropriately in the message type with an out of type definition
* Add the definition for the alternative as a simple sum type with all choice
* Modify instance of encode to pattern match on the alternative type and emit one of the value
* Modify instance of decode to get one of the fields using the `oneof` method in proto3-wire (depends on the https://github.com/awakesecurity/proto3-wire/pull/29)

TODO:

* [x] Add tests for oneof
* [ ] Discuss `dotProto` method. currently no field from a `oneof` get emited for `a`.
* [ ] Discuss default behavior of `oneof` when no field in the oneof group are present (currently use the first parser in the list default value)