### PR TITLE
Fix misc parsing/CG bugs

### DIFF
--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -30,6 +30,7 @@ import           Language.Haskell.Syntax
 import           Language.Haskell.Pretty
 import           System.FilePath
 import           Text.Parsec (ParseError)
+import           Debug.Trace (trace)
 
 -- * Public interface
 
@@ -374,7 +375,11 @@ dotProtoMessageD ctxt parentIdent messageIdent message =
                   fullTy <- hsTypeFromDotProto ctxt' ty
                   pure [ ([HsIdent fullName], HsUnBangedTy fullTy ) ]
            messagePartFieldD (DotProtoMessageOneOf {}) =
-             unimplementedError "oneof"
+             -- unimplementedError "oneof"
+             trace
+               ("WARNING: ignoring oneof construct since support for it is unimplemented! "
+                <> "Continuing with CG, but note that it is _NOT FAITHFUL_ to the input .proto!)")
+               (pure [])
            messagePartFieldD _ = pure []
 
            nestedDecls :: DotProtoDefinition -> CompileResult [HsDecl]
@@ -528,11 +533,11 @@ isUnpacked opts =
         Just (DotProtoOption _ (BoolLit x)) -> not x
         _ -> False
 
-internalError, invalidTypeNameError, unimplementedError
+internalError, invalidTypeNameError, _unimplementedError
     :: String -> CompileResult a
 internalError = Left . InternalError
 invalidTypeNameError = Left . InvalidTypeName
-unimplementedError = Left . Unimplemented
+_unimplementedError = Left . Unimplemented
 
 invalidMethodNameError, noSuchTypeError :: DotProtoIdentifier -> CompileResult a
 noSuchTypeError = Left . NoSuchType

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -912,8 +912,8 @@ defaultImports usesGrpc =
   , importDecl_ dataWordM                 True  (Just haskellNS)
                 (Just (False, [ importSym "Word16", importSym "Word32"
                               , importSym "Word64" ]))
-  , importDecl_ ghcGenericsM              False (Just haskellNS) Nothing
-  , importDecl_ ghcEnumM                  False (Just haskellNS) Nothing
+  , importDecl_ ghcGenericsM              True (Just haskellNS) Nothing
+  , importDecl_ ghcEnumM                  True (Just haskellNS) Nothing
   ] <>
   if usesGrpc
     then [ importDecl_ networkGrpcHighLevelGeneratedM   False (Just grpcNS) Nothing

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -573,7 +573,7 @@ dotProtoEnumD parentIdent enumIdent enumParts =
 
          toEnumDPatterns =
              [ match_ (HsIdent "toEnum")
-                      [ HsPLit (HsInt (fromIntegral conIdx)) ]
+                      [ intP conIdx ]
                       (HsUnGuardedRhs (HsVar (unqual_ conName))) []
              | (conIdx, conName) <- enumCons ]
 
@@ -826,7 +826,10 @@ apOp :: HsQOp
 apOp  = HsQVarOp (UnQual (HsSymbol "<*>"))
 
 intE :: Integral a => a -> HsExp
-intE = HsLit . HsInt . fromIntegral
+intE x = (if x < 0 then HsParen else id) . HsLit . HsInt . fromIntegral $ x
+
+intP :: Integral a => a -> HsPat
+intP x = (if x < 0 then HsPParen else id) . HsPLit . HsInt . fromIntegral $ x
 
 -- ** Expressions for protobuf-wire types
 

--- a/src/Proto3/Suite/DotProto/Parsing.hs
+++ b/src/Proto3/Suite/DotProto/Parsing.hs
@@ -2,6 +2,7 @@
 --   It uses String for easier compatibility with DotProto.Generator, which needs it for not very good reasons
 
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 
 module Proto3.Suite.DotProto.Parsing
@@ -228,10 +229,10 @@ rpcOptions :: Parser [DotProtoOption]
 rpcOptions = braces $ many topOption
 
 rpcClause :: Parser (DotProtoIdentifier, Streaming)
-rpcClause = do streaming <- (string "stream" $> Streaming) <|> pure NonStreaming
-               whiteSpace
-               name <- identifier
-               return $ (name, streaming)
+rpcClause = do
+  let sid ctx = (,ctx) <$> identifier
+  -- NB: Distinguish "stream stream.foo" from "stream.foo"
+  try (string "stream" *> whiteSpace *> sid Streaming) <|> sid NonStreaming
 
 rpc :: Parser DotProtoServicePart
 rpc = do string "rpc"

--- a/src/Proto3/Suite/DotProto/Parsing.hs
+++ b/src/Proto3/Suite/DotProto/Parsing.hs
@@ -51,13 +51,15 @@ _stripComments []             = []
 -- `_stripComments` above: it handles /* block comments /* with nesting */ */,
 -- "// string lits with comments in them", etc., and thus is closer to the
 -- protobuf3 grammar. The right solution is still to replace this with a proper
--- lexer -- extra credit for injecting comments into the AST so that they can be
--- marshaled into the generated code, and for ensuring that line numbers
--- reported in errors are correct. Although this is handy to toss out in the
--- interests of getting some .protos through, it's probably not worth
--- maintaining, and has an ad-hoc smell. If we find ourselves mucking with this
--- much at all in the very near short term, let's just pay the freight and use
--- `Text.Parsec.Token` or somesuch.
+-- lexer, but since we might switch to using the `protoc`-based `FileDescriptor`
+-- parsing instead, we should hold off. If we do decide to stick with this
+-- parser, we should also inject comments into the AST so that they can be
+-- marshaled into the generated code, and ensure that line numbers reported in
+-- errors are still correct. Although this implementation is handy to toss out
+-- in the interests of getting some more .protos parsable, it's probably not
+-- worth maintaining, and has an ad-hoc smell. If we find ourselves mucking with
+-- this much at all in the very near short term, let's just pay the freight and
+-- use `Text.Parsec.Token` or somesuch.
 data StripCommentState
        --               | starts  | ends | error on?       |
   = BC -- block comment | "/*"    | "*/" | mismatch        |


### PR DESCRIPTION
The individual commits should be self explanatory, but here's the gist:

- Demote fatal error about `oneof`'s unimplemented state in the code generator to a loud warning; that support is coming soon and it may be useful to be able to process input .protos which use the construct.

- CG: Emit parens around negative integral lits
- CG: Use qualified import for `GHC.Enum` and `GHC.Generics`
- Parser: Resolve ambiguity in `rpcClause` parser
- Parser: Improve comment stripping 

