### PR TITLE
Fix `CanonicalRank` default signature for GHC 8.2

### DIFF
--- a/tools/canonicalize-proto-file/Main.hs
+++ b/tools/canonicalize-proto-file/Main.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE RecordWildCards        #-}
 {-# LANGUAGE ScopedTypeVariables    #-}
 {-# LANGUAGE StandaloneDeriving     #-}
+{-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE TypeOperators          #-}
 
 module Main (main) where
@@ -42,7 +43,7 @@ class Canonicalize a where
 
 class Ord r => CanonicalRank a r | a -> r where
   canonicalRank :: a -> r
-  default canonicalRank :: Ord a => a -> a
+  default canonicalRank :: (Ord a, a ~ r) => a -> r
   canonicalRank = id
 
 canonicalSort :: (CanonicalRank a r, Canonicalize a) => [a] -> [a]


### PR DESCRIPTION
GHC 8.2 became more restrictive when checking default signatures, demanding an
explicit equality constraint here. See also:

https://github.com/ekmett/lens/issues/712

Referenced there:
https://ghc.haskell.org/trac/ghc/ticket/13258
https://ghc.haskell.org/trac/ghc/ticket/13249