### PR TITLE
Fix pattern binder order bug in JSONPB instance generation for oneof

### DIFF
--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -635,18 +635,14 @@ toJSONPBMessageInstD _ctxt parentIdent msgIdent messageParts = do
   msgName    <- nestedTypeName parentIdent =<< dpIdentUnqualName msgIdent
   qualFields <- getQualifiedFields msgName messageParts
 
-  let normalFields =
-        [ (nm, "f" ++ show num) | QualifiedField _ (FieldNormal nm num _ _) <- qualFields ]
-
-  let oneofFields  =
-        [ fld | QualifiedField _ (FieldOneOf fld) <- qualFields ]
   -- E.g.
-  -- "another" .= f2
-  let dpairE fldNm varNm =
-        HsInfixApp (HsLit (HsString (coerce fldNm))) toJSONPBOp (HsVar (unqual_ varNm))
-
+  -- "another" .= f2 -- always succeeds (produces default value on missing field)
+  let defPairE fldName fldNum =
+        HsInfixApp (HsLit (HsString (coerce fldName)))
+                   toJSONPBOp
+                   (HsVar (unqual_ (fieldBinder fldNum)))
   -- E.g.
-  -- HsJSONPB.pair "name" f4
+  -- HsJSONPB.pair "name" f4 -- fails on missing field
   let pairE fldNm varNm =
         apply (HsVar (jsonpbName "pair"))
               [ HsLit (HsString (coerce fldNm))
@@ -671,28 +667,24 @@ toJSONPBMessageInstD _ctxt parentIdent msgIdent messageParts = do
                              $ HsPApp (unqual_ conName) [patVar patVarNm]
                            ]
                    )
-                   (HsUnGuardedAlt (pairE pbFldName patVarNm))
+                   (HsUnGuardedAlt (pairE pbFldNm patVarNm))
                    []
-            | sub@(OneofSubfield _ conName pbFldName _ _) <- subfields
+            | sub@(OneofSubfield _ conName pbFldNm _ _) <- subfields
             ]
-          disjunctName = HsVar (unqual_ (oneofSubBinderDisjunct subfields))
+          disjunctName = HsVar (unqual_ (oneofSubDisjunctBinder subfields))
           fallThruE =
             alt_ (HsPApp (haskellName "Nothing") [])
                  (HsUnGuardedAlt memptyE)
                  []
 
-  let toEncodingPBE = fieldsPBE (normalEncEs <> oneofEncEs)
-        where
-          normalEncEs     = uncurry dpairE <$> normalFields
-          oneofEncEs      = oneofCaseE     <$> oneofFields
-          fieldsPBE encEs = apply (HsVar (jsonpbName "fieldsPB")) [ HsList encEs ]
+  let toEncodingPBE = apply (HsVar (jsonpbName "fieldsPB"))
+                            [ HsList (onQF defPairE oneofCaseE <$> qualFields) ]
+
+  let patBinder = onQF (const fieldBinder) (oneofSubDisjunctBinder . subfields)
 
   let toEncodingPBDecl =
         match_ (HsIdent "toEncodingPB")
-               [ HsPApp (unqual_ msgName) $
-                   [ patVar varNm | (_, varNm) <- normalFields ]
-                   <>
-                   [ patVar (oneofSubBinderDisjunct subs) | OneofField subs <- oneofFields ]
+               [ HsPApp (unqual_ msgName) (patVar . patBinder  <$> qualFields)
                ]
                (HsUnGuardedRhs toEncodingPBE) []
 
@@ -709,40 +701,35 @@ fromJSONPBMessageInstD _ctxt parentIdent msgIdent messageParts = do
   msgName    <- nestedTypeName parentIdent =<< dpIdentUnqualName msgIdent
   qualFields <- getQualifiedFields msgName messageParts
 
-  let normalParserEs =
-        normalParserE <$> [ nm | QualifiedField _ (FieldNormal nm _ _ _) <- qualFields ]
-        where
-          normalParserE nm = HsInfixApp (HsVar (unqual_ "obj"))
-                                        parseJSONPBOp
-                                        (HsLit (HsString (coerce nm)))
-
   -- E.g., for message Something{ oneof name_or_id { string name = _; int32 someid = _; } }:
-  -- [ Hs.msum
-  --     [ Just . SomethingPickOneName   <$> (HsJSONPB.parseField obj "name")
-  --     , Just . SomethingPickOneSomeid <$> (HsJSONPB.parseField obj "someid")
-  --     , pure Nothing
-  --     ]
-  -- ]
-  let oneofParserEs = oneofParserE <$> [ fld | QualifiedField _ (FieldOneOf fld) <- qualFields ]
+  -- Hs.msum
+  --   [ Just . SomethingPickOneName   <$> (HsJSONPB.parseField obj "name")
+  --   , Just . SomethingPickOneSomeid <$> (HsJSONPB.parseField obj "someid")
+  --   , pure Nothing
+  --   ]
+  let oneofParserE fld =
+        HsApp msumE (HsList ((subParserEs <> fallThruE) fld))
         where
-          oneofParserE
-            = HsApp msumE . HsList . (subParserEs <> fallThruE)
           fallThruE OneofField{}
-            = [HsApp pureE (HsVar (haskellName "Nothing")) ]
+            = [ HsApp pureE (HsVar (haskellName "Nothing")) ]
           subParserEs OneofField{subfields}
             = subParserE <$> subfields
           subParserE OneofSubfield{subfieldConsName, subfieldName}
             = HsInfixApp (HsInfixApp
                             (HsVar (haskellName "Just"))
                             composeOp
-                            (HsVar (unqual_ subfieldConsName))
-                         )
+                            (HsVar (unqual_ subfieldConsName)))
                          fmapOp
                          (apply (HsVar (jsonpbName "parseField"))
                                 [ HsVar (unqual_ "obj")
                                 , HsLit (HsString (coerce subfieldName))
-                                ]
-                         )
+                                ])
+
+  -- E.g. obj .: "someid"
+  let normalParserE fldNm _ =
+        HsInfixApp (HsVar (unqual_ "obj"))
+                   parseJSONPBOp
+                   (HsLit (HsString (coerce fldNm)))
 
   let parseJSONPBE =
         apply (HsVar (jsonpbName "withObject"))
@@ -752,10 +739,10 @@ fromJSONPBMessageInstD _ctxt parentIdent msgIdent messageParts = do
         where
           fieldAps = foldl (\f -> HsInfixApp f apOp)
                            (apply pureE [ HsVar (unqual_ msgName) ])
-                           (normalParserEs <> oneofParserEs)
+                           (onQF normalParserE oneofParserE <$> qualFields)
 
   let parseJSONPBDecl =
-          match_ (HsIdent "parseJSONPB") [] (HsUnGuardedRhs parseJSONPBE) []
+        match_ (HsIdent "parseJSONPB") [] (HsUnGuardedRhs parseJSONPBE) []
 
   pure (instDecl_ (jsonpbName "FromJSONPB")
                  [ type_ msgName ]
@@ -813,11 +800,22 @@ getQualifiedFields msgName msgParts = fmap catMaybes . forM msgParts $ \case
   _ ->
     pure Nothing
 
-oneofSubBinder :: OneofSubfield -> String
-oneofSubBinder = ("f" ++) . show . subfieldNumber
+-- | Project qualified fields, given a projection function per field type.
+onQF :: (FieldName -> FieldNumber -> a) -- ^ projection for normal fields
+     -> (OneofField -> a)               -- ^ projection for oneof fields
+     -> QualifiedField
+     -> a
+onQF f _ (QualifiedField _ (FieldNormal fldName fldNum _ _)) = f fldName fldNum
+onQF _ g (QualifiedField _ (FieldOneOf fld))                 = g fld
 
-oneofSubBinderDisjunct :: [OneofSubfield] -> String
-oneofSubBinderDisjunct = intercalate "_or_" . fmap oneofSubBinder
+fieldBinder :: FieldNumber -> String
+fieldBinder = ("f" ++) . show
+
+oneofSubBinder :: OneofSubfield -> String
+oneofSubBinder = fieldBinder . subfieldNumber
+
+oneofSubDisjunctBinder :: [OneofSubfield] -> String
+oneofSubDisjunctBinder = intercalate "_or_" . fmap oneofSubBinder
 
 -- ** Helpers to wrap/unwrap types for protobuf (de-)serialization
 

--- a/test-files/test_proto_oneof.proto
+++ b/test-files/test_proto_oneof.proto
@@ -11,6 +11,8 @@ enum DummyEnum {
   DUMMY1 = 1;
 }
 
+// Also handles the case where the oneof field is syntatically the last one in
+// the message (this exercises field ordering logic in the code generator)
 message Something {
   sint64 value          = 1;
   sint32 another        = 2;
@@ -21,6 +23,27 @@ message Something {
     DummyMsg  dummyMsg2 = 11;
     DummyEnum dummyEnum = 12;
   }
+}
+
+// Handles the case where the oneof field is syntatically the first one in the
+// message (this exercises field ordering logic in the code generator)
+message OneofFirst {
+  oneof first {
+    string choice1 = 1;
+    string choice2 = 2;
+  }
+  int32 last = 3;
+}
+
+// Handles the case where the oneof field is syntatically between other fields
+// in the message (this exercises field ordering logic in the code generator)
+message OneofMiddle {
+  int32 first = 1;
+  oneof middle {
+    string choice1 = 2;
+    string choice2 = 3;
+  }
+  int32 last = 4;
 }
 
 message WithImported {

--- a/tests/TestProtoOneof.hs
+++ b/tests/TestProtoOneof.hs
@@ -25,13 +25,13 @@ import qualified Data.Word as Hs (Word16, Word32, Word64)
 import qualified GHC.Generics as Hs
 import qualified GHC.Enum as Hs
 import qualified TestProtoOneofImport
-
+ 
 data DummyMsg = DummyMsg{dummyMsgDummy :: Hs.Int32}
               deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
-
+ 
 instance HsProtobuf.Named DummyMsg where
         nameOf _ = (Hs.fromString "DummyMsg")
-
+ 
 instance HsProtobuf.Message DummyMsg where
         encodeMessage _ DummyMsg{dummyMsgDummy = dummyMsgDummy}
           = (Hs.mconcat
@@ -47,22 +47,22 @@ instance HsProtobuf.Message DummyMsg where
                 (HsProtobuf.Single "dummy")
                 []
                 Hs.Nothing)]
-
+ 
 instance HsJSONPB.ToJSONPB DummyMsg where
         toEncodingPB (DummyMsg f1) = (HsJSONPB.fieldsPB ["dummy" .= f1])
-
+ 
 instance HsJSONPB.FromJSONPB DummyMsg where
         parseJSONPB
           = (HsJSONPB.withObject "DummyMsg"
                (\ obj -> (Hs.pure DummyMsg) <*> obj .: "dummy"))
-
+ 
 data DummyEnum = DummyEnumDUMMY0
                | DummyEnumDUMMY1
                deriving (Hs.Show, Hs.Bounded, Hs.Eq, Hs.Ord, Hs.Generic)
-
+ 
 instance HsProtobuf.Named DummyEnum where
         nameOf _ = (Hs.fromString "DummyEnum")
-
+ 
 instance Hs.Enum DummyEnum where
         toEnum 0 = DummyEnumDUMMY0
         toEnum 1 = DummyEnumDUMMY1
@@ -73,23 +73,23 @@ instance Hs.Enum DummyEnum where
         succ _ = Hs.succError "DummyEnum"
         pred (DummyEnumDUMMY1) = DummyEnumDUMMY0
         pred _ = Hs.predError "DummyEnum"
-
+ 
 instance HsJSONPB.ToJSONPB DummyEnum where
         toEncodingPB x _ = HsJSONPB.namedEncoding x
-
+ 
 instance HsJSONPB.FromJSONPB DummyEnum where
         parseJSONPB (HsJSONPB.String "DUMMY0") = Hs.pure DummyEnumDUMMY0
         parseJSONPB (HsJSONPB.String "DUMMY1") = Hs.pure DummyEnumDUMMY1
         parseJSONPB v = (HsJSONPB.typeMismatch "DummyEnum" v)
-
+ 
 data Something = Something{somethingValue :: Hs.Int64,
                            somethingAnother :: Hs.Int32,
                            somethingPickOne :: Hs.Maybe SomethingPickOne}
                deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
-
+ 
 instance HsProtobuf.Named Something where
         nameOf _ = (Hs.fromString "Something")
-
+ 
 instance HsProtobuf.Message Something where
         encodeMessage _
           Something{somethingValue = somethingValue,
@@ -156,7 +156,7 @@ instance HsProtobuf.Message Something where
                 (HsProtobuf.Single "another")
                 []
                 Hs.Nothing)]
-
+ 
 instance HsJSONPB.ToJSONPB Something where
         toEncodingPB (Something f1 f2 f4_or_f9_or_f10_or_f11_or_f12)
           = (HsJSONPB.fieldsPB
@@ -171,7 +171,7 @@ instance HsJSONPB.ToJSONPB Something where
                     Hs.Just (SomethingPickOneDummyEnum f12)
                       -> (HsJSONPB.pair "dummyEnum" f12)
                     Hs.Nothing -> Hs.mempty])
-
+ 
 instance HsJSONPB.FromJSONPB Something where
         parseJSONPB
           = (HsJSONPB.withObject "Something"
@@ -189,7 +189,7 @@ instance HsJSONPB.FromJSONPB Something where
                        Hs.Just Hs.. SomethingPickOneDummyEnum <$>
                          (HsJSONPB.parseField obj "dummyEnum"),
                        Hs.pure Hs.Nothing]))
-
+ 
 data SomethingPickOne = SomethingPickOneName Hs.Text
                       | SomethingPickOneSomeid Hs.Int32
                       | SomethingPickOneDummyMsg1 TestProtoOneof.DummyMsg
@@ -197,14 +197,168 @@ data SomethingPickOne = SomethingPickOneName Hs.Text
                       | SomethingPickOneDummyEnum (HsProtobuf.Enumerated
                                                      TestProtoOneof.DummyEnum)
                       deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
-
+ 
+data OneofFirst = OneofFirst{oneofFirstFirst ::
+                             Hs.Maybe OneofFirstFirst,
+                             oneofFirstLast :: Hs.Int32}
+                deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+ 
+instance HsProtobuf.Named OneofFirst where
+        nameOf _ = (Hs.fromString "OneofFirst")
+ 
+instance HsProtobuf.Message OneofFirst where
+        encodeMessage _
+          OneofFirst{oneofFirstFirst = oneofFirstFirst,
+                     oneofFirstLast = oneofFirstLast}
+          = (Hs.mconcat
+               [case oneofFirstFirst of
+                    Hs.Nothing -> Hs.mempty
+                    Hs.Just x
+                      -> case x of
+                             OneofFirstFirstChoice1 y
+                               -> (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 1)
+                                     (HsProtobuf.ForceEmit y))
+                             OneofFirstFirstChoice2 y
+                               -> (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 2)
+                                     (HsProtobuf.ForceEmit y)),
+                (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 3)
+                   oneofFirstLast)])
+        decodeMessage _
+          = (Hs.pure OneofFirst) <*>
+              (HsProtobuf.oneof Hs.Nothing
+                 [((HsProtobuf.FieldNumber 1),
+                   (Hs.pure (Hs.Just Hs.. OneofFirstFirstChoice1)) <*>
+                     HsProtobuf.decodeMessageField),
+                  ((HsProtobuf.FieldNumber 2),
+                   (Hs.pure (Hs.Just Hs.. OneofFirstFirstChoice2)) <*>
+                     HsProtobuf.decodeMessageField)])
+              <*>
+              (HsProtobuf.at HsProtobuf.decodeMessageField
+                 (HsProtobuf.FieldNumber 3))
+        dotProto _
+          = [(HsProtobuf.DotProtoField (HsProtobuf.FieldNumber 3)
+                (HsProtobuf.Prim HsProtobuf.Int32)
+                (HsProtobuf.Single "last")
+                []
+                Hs.Nothing)]
+ 
+instance HsJSONPB.ToJSONPB OneofFirst where
+        toEncodingPB (OneofFirst f1_or_f2 f3)
+          = (HsJSONPB.fieldsPB
+               [case f1_or_f2 of
+                    Hs.Just (OneofFirstFirstChoice1 f1) -> (HsJSONPB.pair "choice1" f1)
+                    Hs.Just (OneofFirstFirstChoice2 f2) -> (HsJSONPB.pair "choice2" f2)
+                    Hs.Nothing -> Hs.mempty,
+                "last" .= f3])
+ 
+instance HsJSONPB.FromJSONPB OneofFirst where
+        parseJSONPB
+          = (HsJSONPB.withObject "OneofFirst"
+               (\ obj ->
+                  (Hs.pure OneofFirst) <*>
+                    Hs.msum
+                      [Hs.Just Hs.. OneofFirstFirstChoice1 <$>
+                         (HsJSONPB.parseField obj "choice1"),
+                       Hs.Just Hs.. OneofFirstFirstChoice2 <$>
+                         (HsJSONPB.parseField obj "choice2"),
+                       Hs.pure Hs.Nothing]
+                    <*> obj .: "last"))
+ 
+data OneofFirstFirst = OneofFirstFirstChoice1 Hs.Text
+                     | OneofFirstFirstChoice2 Hs.Text
+                     deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+ 
+data OneofMiddle = OneofMiddle{oneofMiddleFirst :: Hs.Int32,
+                               oneofMiddleMiddle :: Hs.Maybe OneofMiddleMiddle,
+                               oneofMiddleLast :: Hs.Int32}
+                 deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+ 
+instance HsProtobuf.Named OneofMiddle where
+        nameOf _ = (Hs.fromString "OneofMiddle")
+ 
+instance HsProtobuf.Message OneofMiddle where
+        encodeMessage _
+          OneofMiddle{oneofMiddleFirst = oneofMiddleFirst,
+                      oneofMiddleMiddle = oneofMiddleMiddle,
+                      oneofMiddleLast = oneofMiddleLast}
+          = (Hs.mconcat
+               [(HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 1)
+                   oneofMiddleFirst),
+                case oneofMiddleMiddle of
+                    Hs.Nothing -> Hs.mempty
+                    Hs.Just x
+                      -> case x of
+                             OneofMiddleMiddleChoice1 y
+                               -> (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 2)
+                                     (HsProtobuf.ForceEmit y))
+                             OneofMiddleMiddleChoice2 y
+                               -> (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 3)
+                                     (HsProtobuf.ForceEmit y)),
+                (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 4)
+                   oneofMiddleLast)])
+        decodeMessage _
+          = (Hs.pure OneofMiddle) <*>
+              (HsProtobuf.at HsProtobuf.decodeMessageField
+                 (HsProtobuf.FieldNumber 1))
+              <*>
+              (HsProtobuf.oneof Hs.Nothing
+                 [((HsProtobuf.FieldNumber 2),
+                   (Hs.pure (Hs.Just Hs.. OneofMiddleMiddleChoice1)) <*>
+                     HsProtobuf.decodeMessageField),
+                  ((HsProtobuf.FieldNumber 3),
+                   (Hs.pure (Hs.Just Hs.. OneofMiddleMiddleChoice2)) <*>
+                     HsProtobuf.decodeMessageField)])
+              <*>
+              (HsProtobuf.at HsProtobuf.decodeMessageField
+                 (HsProtobuf.FieldNumber 4))
+        dotProto _
+          = [(HsProtobuf.DotProtoField (HsProtobuf.FieldNumber 1)
+                (HsProtobuf.Prim HsProtobuf.Int32)
+                (HsProtobuf.Single "first")
+                []
+                Hs.Nothing),
+             (HsProtobuf.DotProtoField (HsProtobuf.FieldNumber 4)
+                (HsProtobuf.Prim HsProtobuf.Int32)
+                (HsProtobuf.Single "last")
+                []
+                Hs.Nothing)]
+ 
+instance HsJSONPB.ToJSONPB OneofMiddle where
+        toEncodingPB (OneofMiddle f1 f2_or_f3 f4)
+          = (HsJSONPB.fieldsPB
+               ["first" .= f1,
+                case f2_or_f3 of
+                    Hs.Just (OneofMiddleMiddleChoice1 f2)
+                      -> (HsJSONPB.pair "choice1" f2)
+                    Hs.Just (OneofMiddleMiddleChoice2 f3)
+                      -> (HsJSONPB.pair "choice2" f3)
+                    Hs.Nothing -> Hs.mempty,
+                "last" .= f4])
+ 
+instance HsJSONPB.FromJSONPB OneofMiddle where
+        parseJSONPB
+          = (HsJSONPB.withObject "OneofMiddle"
+               (\ obj ->
+                  (Hs.pure OneofMiddle) <*> obj .: "first" <*>
+                    Hs.msum
+                      [Hs.Just Hs.. OneofMiddleMiddleChoice1 <$>
+                         (HsJSONPB.parseField obj "choice1"),
+                       Hs.Just Hs.. OneofMiddleMiddleChoice2 <$>
+                         (HsJSONPB.parseField obj "choice2"),
+                       Hs.pure Hs.Nothing]
+                    <*> obj .: "last"))
+ 
+data OneofMiddleMiddle = OneofMiddleMiddleChoice1 Hs.Text
+                       | OneofMiddleMiddleChoice2 Hs.Text
+                       deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+ 
 data WithImported = WithImported{withImportedPickOne ::
                                  Hs.Maybe WithImportedPickOne}
                   deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
-
+ 
 instance HsProtobuf.Named WithImported where
         nameOf _ = (Hs.fromString "WithImported")
-
+ 
 instance HsProtobuf.Message WithImported where
         encodeMessage _
           WithImported{withImportedPickOne = withImportedPickOne}
@@ -229,7 +383,7 @@ instance HsProtobuf.Message WithImported where
                    (Hs.pure (Hs.fmap WithImportedPickOneWithOneof)) <*>
                      ((Hs.pure HsProtobuf.nested) <*> HsProtobuf.decodeMessageField))])
         dotProto _ = []
-
+ 
 instance HsJSONPB.ToJSONPB WithImported where
         toEncodingPB (WithImported f1_or_f2)
           = (HsJSONPB.fieldsPB
@@ -239,7 +393,7 @@ instance HsJSONPB.ToJSONPB WithImported where
                     Hs.Just (WithImportedPickOneWithOneof f2)
                       -> (HsJSONPB.pair "withOneof" f2)
                     Hs.Nothing -> Hs.mempty])
-
+ 
 instance HsJSONPB.FromJSONPB WithImported where
         parseJSONPB
           = (HsJSONPB.withObject "WithImported"
@@ -251,7 +405,7 @@ instance HsJSONPB.FromJSONPB WithImported where
                        Hs.Just Hs.. WithImportedPickOneWithOneof <$>
                          (HsJSONPB.parseField obj "withOneof"),
                        Hs.pure Hs.Nothing]))
-
+ 
 data WithImportedPickOne = WithImportedPickOneDummyMsg1 TestProtoOneof.DummyMsg
                          | WithImportedPickOneWithOneof TestProtoOneofImport.WithOneof
                          deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)

--- a/tests/TestProtoOneofImport.hs
+++ b/tests/TestProtoOneofImport.hs
@@ -24,14 +24,14 @@ import qualified Data.Int as Hs (Int16, Int32, Int64)
 import qualified Data.Word as Hs (Word16, Word32, Word64)
 import qualified GHC.Generics as Hs
 import qualified GHC.Enum as Hs
-
+ 
 data WithOneof = WithOneof{withOneofPickOne ::
                            Hs.Maybe WithOneofPickOne}
                deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
-
+ 
 instance HsProtobuf.Named WithOneof where
         nameOf _ = (Hs.fromString "WithOneof")
-
+ 
 instance HsProtobuf.Message WithOneof where
         encodeMessage _ WithOneof{withOneofPickOne = withOneofPickOne}
           = (Hs.mconcat
@@ -55,7 +55,7 @@ instance HsProtobuf.Message WithOneof where
                    (Hs.pure (Hs.Just Hs.. WithOneofPickOneB)) <*>
                      HsProtobuf.decodeMessageField)])
         dotProto _ = []
-
+ 
 instance HsJSONPB.ToJSONPB WithOneof where
         toEncodingPB (WithOneof f1_or_f2)
           = (HsJSONPB.fieldsPB
@@ -63,7 +63,7 @@ instance HsJSONPB.ToJSONPB WithOneof where
                     Hs.Just (WithOneofPickOneA f1) -> (HsJSONPB.pair "a" f1)
                     Hs.Just (WithOneofPickOneB f2) -> (HsJSONPB.pair "b" f2)
                     Hs.Nothing -> Hs.mempty])
-
+ 
 instance HsJSONPB.FromJSONPB WithOneof where
         parseJSONPB
           = (HsJSONPB.withObject "WithOneof"
@@ -73,7 +73,7 @@ instance HsJSONPB.FromJSONPB WithOneof where
                       [Hs.Just Hs.. WithOneofPickOneA <$> (HsJSONPB.parseField obj "a"),
                        Hs.Just Hs.. WithOneofPickOneB <$> (HsJSONPB.parseField obj "b"),
                        Hs.pure Hs.Nothing]))
-
+ 
 data WithOneofPickOne = WithOneofPickOneA Hs.Text
                       | WithOneofPickOneB Hs.Int32
                       deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)


### PR DESCRIPTION
We were incorrectly ordering pattern binders: pattern binders for normal fields came first, followed by pattern binders for oneof fields. The correct behavior is to order the pattern binders in syntactic order of their occurrence in the protobuf type definition (which is the same as the record field order in the corresponding generated Haskell type).

Also adds some additional tests and includes some misc improvements and some light refactoring/renames.
