### PR TITLE
Use protobuf enum field names as they occur in `.proto` files

### DIFF
--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -22,8 +22,9 @@ module Proto3.Suite.DotProto.Generate
   , readDotProtoWithContext
 
   -- * Exposed for unit-testing
-  , typeLikeName
   , fieldLikeName
+  , prefixedEnumFieldName
+  , typeLikeName
   ) where
 
 import           Control.Applicative
@@ -395,6 +396,9 @@ fieldLikeName ident@(firstChar:_)
   | isUpper firstChar = let (prefix, suffix) = span isUpper ident
                         in map toLower prefix ++ suffix
 fieldLikeName ident = ident
+
+prefixedEnumFieldName :: String -> String -> CompileResult String
+prefixedEnumFieldName enumName fieldName = pure (enumName <> fieldName)
 
 prefixedConName :: String -> String -> CompileResult String
 prefixedConName msgName conName =
@@ -909,7 +913,7 @@ dotProtoEnumD parentIdent enumIdent enumParts =
                  dpIdentUnqualName enumIdent
 
      enumCons <- sortBy (comparing fst) <$>
-                 sequence [ (i,) <$> (prefixedConName enumName =<<
+                 sequence [ (i,) <$> (prefixedEnumFieldName enumName =<<
                                       dpIdentUnqualName conIdent)
                           | DotProtoEnumField conIdent i <- enumParts ]
 

--- a/tests/TestCodeGen.hs
+++ b/tests/TestCodeGen.hs
@@ -27,7 +27,8 @@ import qualified Turtle.Format             as F
 codeGenTests :: TestTree
 codeGenTests = testGroup "Code generator unit tests"
   [ camelCaseMessageNames
-  , camelCaseFieldNames
+  , camelCaseMessageFieldNames
+  , don'tAlterEnumFieldNames
   , simpleEncodeDotProto
   , simpleDecodeDotProto
   ]
@@ -42,10 +43,27 @@ camelCaseMessageNames = testGroup "CamelCasing of message names"
   , testCase "Preserves trailing underscore" (typeLikeName "message_name_" @?= Right "MessageName_") ]
 
 
-camelCaseFieldNames :: TestTree
-camelCaseFieldNames = testGroup "camelCasing of field names"
+camelCaseMessageFieldNames :: TestTree
+camelCaseMessageFieldNames = testGroup "camelCasing of field names"
   [ testCase "Preserves capitalization patterns" (fieldLikeName "IP" @?= "ip")
   , testCase "Preserves underscores"             (fieldLikeName "IP_address" @?= "ip_address") ]
+
+don'tAlterEnumFieldNames :: TestTree
+don'tAlterEnumFieldNames
+  = testGroup "Do not alter enumeration field names"
+  $ tc <$> [ "fnord"
+           , "FNORD"
+           , "PascalCase"
+           , "camelCase"
+           , "VOCIFEROUS_SNAKE_CASE"
+           , "snake_case"
+           , "snake_case_"
+           ]
+  where
+    enumName     = "MyEnum"
+    tc fieldName = testCase fieldName
+                 $ prefixedEnumFieldName enumName fieldName
+                     @?= Right (enumName <> fieldName)
 
 simpleEncodeDotProto :: TestTree
 simpleEncodeDotProto =


### PR DESCRIPTION
The main reason for this change is so that we can use `Generic`-based introspection to recover the original enum field names from generated datatypes (e.g., via the `Finite` typeclass), which is important for JSONPB encoding, among other things.

This PR also resolves issue https://github.com/awakesecurity/proto3-suite/issues/22.