### PR TITLE
Provide a `toJSONPB` analog to `Data.Aeson.toJSON`

### DIFF
--- a/src/Proto3/Suite/JSONPB.hs
+++ b/src/Proto3/Suite/JSONPB.hs
@@ -13,9 +13,11 @@ module Proto3.Suite.JSONPB
   , eitherDecode
   , encode
     -- * Helper functions
-  , fieldsPB
-  , namedEncoding
+  , enumFieldEncoding
+  , enumFieldString
+  , object
   , pair
+  , pairs
   , parseField
     -- * Aeson re-exports
   , A.Value(..)

--- a/src/Proto3/Suite/JSONPB/Class.hs
+++ b/src/Proto3/Suite/JSONPB/Class.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE ViewPatterns        #-}
 
 -- | Support for the "JSONPB" canonical JSON encoding described at
 -- https://developers.google.com/protocol-buffers/docs/proto3#json.
@@ -29,7 +30,14 @@
 -- }
 --
 -- instance ToJSONPB Scalar32 where
---   toEncodingPB (Scalar32 i32 u32 s32 f32 sf32) = fieldsPB
+--   toJSONPB (Scalar32 i32 u32 s32 f32 sf32) = object
+--       [ "i32"  .= i32
+--       , "u32"  .= u32
+--       , "s32"  .= s32
+--       , "f32"  .= f32
+--       , "sf32" .= sf32
+--       ]
+--   toEncodingPB (Scalar32 i32 u32 s32 f32 sf32) = pairs
 --       [ "i32"  .= i32
 --       , "u32"  .= u32
 --       , "s32"  .= s32
@@ -58,10 +66,11 @@ import qualified Data.Aeson                       as A (Encoding, FromJSON (..),
 import qualified Data.Aeson.Encoding              as E
 import qualified Data.Aeson.Internal              as A (formatError, iparse)
 import qualified Data.Aeson.Parser                as A (eitherDecodeWith)
-import qualified Data.Aeson.Types                 as A (Object, Parser, Series,
+import qualified Data.Aeson.Types                 as A (Object, Pair, Parser,
+                                                        Series,
                                                         explicitParseField,
                                                         explicitParseFieldMaybe,
-                                                        typeMismatch)
+                                                        object, typeMismatch)
 import qualified Data.Attoparsec.ByteString       as Atto (skipWhile)
 import qualified Data.Attoparsec.ByteString.Char8 as Atto (Parser, endOfInput)
 import qualified Data.ByteString                  as BS
@@ -70,6 +79,7 @@ import qualified Data.ByteString.Lazy             as LBS
 import           Data.Coerce
 import           Data.Proxy
 import           Data.Text                        (Text)
+import qualified Data.Text                        as T
 import qualified Data.Text.Encoding               as T
 import qualified Data.Text.Lazy                   as TL
 import qualified Data.Text.Lazy.Encoding          as TL
@@ -84,11 +94,14 @@ import           Proto3.Suite.Types               (Enumerated (..), Fixed (..))
 
 -- | 'A.ToJSON' variant for JSONPB direct encoding via 'A.Encoding'
 class ToJSONPB a where
-  -- | 'A.toEncoding' variant for JSONPB encoders. Equivalent to 'A.toEncoding'
-  -- if an implementation is not provided.
+  -- | 'A.toJSON' variant for JSONPB encoders.
+  toJSONPB :: a -> Options -> A.Value
+
+  -- | 'A.toEncoding' variant for JSONPB encoders. If an implementation is not
+  -- provided, uses 'toJSONPB' (which is less efficient since it indirects
+  -- through the 'A.Value' IR).
   toEncodingPB :: a -> Options -> A.Encoding
-  default toEncodingPB :: (A.ToJSON a) => a -> Options -> A.Encoding
-  toEncodingPB a _ = A.toEncoding a
+  toEncodingPB x = A.toEncoding . toJSONPB x
 
 -- | 'A.FromJSON' variant for JSONPB decoding from the 'A.Value' IR
 class FromJSONPB a where
@@ -128,15 +141,19 @@ eitherDecode = eitherFormatError . A.eitherDecodeWith jsonEOF (A.iparse parseJSO
 
 -- * Operator definitions
 
-pair :: ToJSONPB v => Text -> v -> Options -> A.Series
-pair k v opts = E.pair k (toEncodingPB v opts)
+-- | JSONPB-encoded monoidal key-value pairs
+class Monoid m => KeyValuePB m where
+  pair :: ToJSONPB v => Text -> v -> Options -> m
 
--- | Construct a (field name, JSONPB-encoded value) tuple, respecting
--- default-valuedness options
-(.=) :: (HasDefault v, ToJSONPB v) => Text -> v -> Options -> A.Series
-k .= v = f
+instance KeyValuePB A.Series where pair k v opts = E.pair k (toEncodingPB v opts)
+instance KeyValuePB [A.Pair] where pair k v opts = pure (k, toJSONPB v opts)
+
+-- | Construct a monoidal key-value pair, using 'mempty' to represent omission
+-- of default values (unless the given 'Options' force their emission).
+(.=) :: (HasDefault v, ToJSONPB v, KeyValuePB kvp) => Text -> v -> Options -> kvp
+k .= v = mk
   where
-    f opts@Options{..}
+    mk opts@Options{..}
       | not optEmitDefaultValuedFields && isDefault v
         = mempty
       | otherwise
@@ -171,12 +188,17 @@ defaultOptions = Options
 dropNamedPrefix :: Named a => Proxy a -> String -> String
 dropNamedPrefix p = drop (length (nameOf p :: String))
 
--- | 'E.pairs'-wrapped mconcat to simplify instances
-fieldsPB :: [Options -> A.Series] -> Options -> A.Encoding
-fieldsPB fns = E.pairs . mconcat fns
+object :: [Options -> [A.Pair]] -> Options -> A.Value
+object fs = A.object . mconcat fs
 
-namedEncoding :: forall e. (Named e, Show e) => e -> A.Encoding
-namedEncoding = E.string . dropNamedPrefix (Proxy @e) . show
+pairs :: [Options -> A.Series] -> Options -> E.Encoding
+pairs fs = E.pairs . mconcat fs
+
+enumFieldString :: forall a. (Named a, Show a) => a -> A.Value
+enumFieldString = A.String . T.pack . dropNamedPrefix (Proxy @a) . show
+
+enumFieldEncoding :: forall a. (Named a, Show a) => a -> A.Encoding
+enumFieldEncoding = E.string . dropNamedPrefix (Proxy @a) . show
 
 -- | Parse a JSONPB floating point value; first parameter provides context for
 -- type mismatches
@@ -204,7 +226,10 @@ parseNumOrDecimalString tyDesc v = case v of
 --------------------------------------------------------------------------------
 -- Boolean scalar type
 
-instance ToJSONPB Bool
+instance ToJSONPB Bool where
+  toJSONPB     = const . A.toJSON
+  toEncodingPB = const . A.toEncoding
+
 instance FromJSONPB Bool
 
 --------------------------------------------------------------------------------
@@ -218,47 +243,59 @@ instance FromJSONPB Bool
 --
 
 -- int32 / sint32
-instance ToJSONPB Int32
+instance ToJSONPB Int32 where
+  toJSONPB     = const . A.toJSON
+  toEncodingPB = const . A.toEncoding
+
 instance FromJSONPB Int32 where
   parseJSONPB = parseNumOrDecimalString "int32 / sint32"
 
 -- uint32
-instance ToJSONPB Word32
+instance ToJSONPB Word32 where
+  toJSONPB     = const . A.toJSON
+  toEncodingPB = const . A.toEncoding
+
 instance FromJSONPB Word32 where
   parseJSONPB = parseNumOrDecimalString "uint32"
 
 -- int64 / sint64
 instance ToJSONPB Int64 where
+  toJSONPB x _     = A.String . T.pack . show $ x
   toEncodingPB x _ = E.string (show x)
 instance FromJSONPB Int64 where
   parseJSONPB = parseNumOrDecimalString "int64 / sint64"
 
 -- unit64
 instance ToJSONPB Word64 where
+  toJSONPB x _     = A.String . T.pack . show $ x
   toEncodingPB x _ = E.string (show x)
 instance FromJSONPB Word64 where
   parseJSONPB = parseNumOrDecimalString "int64 / sint64"
 
 -- fixed32
 instance ToJSONPB (Fixed Word32) where
+  toJSONPB     = coerce (toJSONPB @Word32)
   toEncodingPB = coerce (toEncodingPB @Word32)
 instance FromJSONPB (Fixed Word32) where
   parseJSONPB = coerce (parseJSONPB @Word32)
 
 -- fixed64
 instance ToJSONPB (Fixed Word64) where
+  toJSONPB = coerce (toJSONPB @Word64)
   toEncodingPB = coerce (toEncodingPB @Word64)
 instance FromJSONPB (Fixed Word64) where
   parseJSONPB = coerce (parseJSONPB @Word64)
 
 -- sfixed32
 instance ToJSONPB (Fixed Int32) where
+  toJSONPB = coerce (toJSONPB @Int32)
   toEncodingPB = coerce (toEncodingPB @Int32)
 instance FromJSONPB (Fixed Int32) where
   parseJSONPB = coerce (parseJSONPB @Int32)
 
 -- sfixed64
 instance ToJSONPB (Fixed Int64) where
+  toJSONPB = coerce (toJSONPB @Int64)
   toEncodingPB = coerce (toEncodingPB @Int64)
 instance FromJSONPB (Fixed Int64) where
   parseJSONPB = coerce (parseJSONPB @Int64)
@@ -271,12 +308,17 @@ instance FromJSONPB (Fixed Int64) where
 -- notation is also accepted.
 
 -- float
-instance ToJSONPB Float
+instance ToJSONPB Float where
+  toJSONPB     = const . A.toJSON
+  toEncodingPB = const . A.toEncoding
+
 instance FromJSONPB Float where
   parseJSONPB = parseFP "float"
 
 -- double
-instance ToJSONPB Double
+instance ToJSONPB Double where
+  toJSONPB     = const . A.toJSON
+  toEncodingPB = const . A.toEncoding
 instance FromJSONPB Double where
   parseJSONPB = parseFP "double"
 
@@ -284,16 +326,23 @@ instance FromJSONPB Double where
 -- Stringly types (string and bytes)
 
 -- string
-instance ToJSONPB TL.Text
+instance ToJSONPB TL.Text where
+  toJSONPB     = const . A.toJSON
+  toEncodingPB = const . A.toEncoding
 instance FromJSONPB TL.Text
 
 -- bytes
+
+bsToJSONPB :: BS.ByteString -> A.Value
+bsToJSONPB (T.decodeUtf8' . B64.encode -> ebs) = case ebs of
+  Right bs -> A.toJSON bs
+  Left e   -> error ("internal: failed to encode B64-encoded bytestring: " ++ show e)
+              -- NB: T.decodeUtf8' should never fail because we B64-encode the
+              -- incoming bytestring.
+
 instance ToJSONPB BS.ByteString where
-  toEncodingPB bs _ = case T.decodeUtf8' (B64.encode bs) of
-    Left e  -> error ("internal: failed to encode B64-encoded bytestring: " ++ show e)
-               -- T.decodeUtf8' should never fail because we B64-encode the
-               -- incoming bytestring.
-    Right t -> E.value (A.toJSON t)
+  toJSONPB bs _        = bsToJSONPB bs
+  toEncodingPB bs opts = E.value (toJSONPB bs opts)
 
 instance FromJSONPB BS.ByteString where
   parseJSONPB (A.String b64enc) = pure . B64.decodeLenient . T.encodeUtf8 $ b64enc
@@ -302,35 +351,42 @@ instance FromJSONPB BS.ByteString where
 --------------------------------------------------------------------------------
 -- Enumerated types
 
-instance (Named a, Show a, ToJSONPB a) => ToJSONPB (Enumerated a) where
-  toEncodingPB (Enumerated e) opts = case e of
-    Right x -> toEncodingPB x opts
-    Left  0 ->
-      {- TODO: Raise a compilation error when the first enum value in an
-               enumeration is not zero.
+enumToJSONPB :: (e -> Options -> a) -- ^ JSONPB encoder function to use
+             -> a                   -- ^ null value to use for out-of-range enums
+             -> Enumerated e        -- ^ the enumerated value to encode
+             -> Options             -- ^ JSONPB encoding options
+             -> a                   -- ^ the JSONPB-encoded value
+enumToJSONPB enc null_ (Enumerated e) opts = either err (\input -> enc input opts) e
+  where
+    err 0 = error "enumToJSONPB: The first enum value must be zero in proto3"
+            -- TODO: Raise a compilation error when the first enum value in an
+            -- enumeration is not zero.
+            --
+            -- See https://github.com/awakesecurity/proto3-suite/issues/28
+            --
+            -- The proto3 spec states that the default value is the first
+            -- defined enum value, which must be 0. Since we currently don't
+            -- raise a compilation error for this like we should, we have to
+            -- handle this case.
+            --
+            -- For now, die horribly to mimic what should be a compilation
+            -- error.
+    err _ = null_
+            -- From the JSONPB spec:
+            --
+            --   If a value is missing in the JSON-encoded data or if its value
+            --   is null, it will be interpreted as the appropriate default
+            --   value when parsed into a protocol buffer.
+            --
+            -- Thus, interpreting a wire value out of enum range as "missing",
+            -- we yield null here to mean the default value.
 
-               See https://github.com/awakesecurity/proto3-suite/issues/28
 
-         The proto3 spec states that the default value is the first defined enum
-         value, which must be 0. Since we currently don't raise a compilation
-         error for this like we should, we have to handle this case.
+instance ToJSONPB e => ToJSONPB (Enumerated e) where
+  toJSONPB     = enumToJSONPB toJSONPB A.Null
+  toEncodingPB = enumToJSONPB toEncodingPB E.null_
 
-         For now, die horribly to mimic what should be a compilation error.
-      -}
-      error "toEncodingPB Enumerated: The first enum value must be zero in proto3"
-    Left{}  ->
-      {- From the JSONPB spec:
-
-           If a value is missing in the JSON-encoded data or if its value is
-           null, it will be interpreted as the appropriate default value when
-           parsed into a protocol buffer.
-
-         Thus, interpreting a wire value out of enum range as "missing", we
-         yield the null encoding here to mean the default value.
-       -}
-      E.null_
-
-instance (Bounded a, Enum a, FromJSONPB a) => FromJSONPB (Enumerated a) where
+instance (Bounded e, Enum e, FromJSONPB e) => FromJSONPB (Enumerated e) where
   parseJSONPB A.Null = pure def -- So CG does not have to handle this case in
                                 -- every generated instance
   parseJSONPB v      = Enumerated . Right <$> parseJSONPB v
@@ -344,6 +400,7 @@ instance (Bounded a, Enum a, FromJSONPB a) => FromJSONPB (Enumerated a) where
 -- value is accepted as the empty list, @[]@.
 
 instance ToJSONPB a => ToJSONPB (V.Vector a) where
+  toJSONPB v opts     = A.Array (V.map (\x -> toJSONPB x opts) v)
   toEncodingPB v opts = E.list (\x -> toEncodingPB x opts) (V.toList v)
 instance FromJSONPB a => FromJSONPB (V.Vector a) where
   parseJSONPB (A.Array vs) = mapM parseJSONPB vs
@@ -354,6 +411,7 @@ instance FromJSONPB a => FromJSONPB (V.Vector a) where
 -- Instances for nested messages
 
 instance ToJSONPB a => ToJSONPB (Maybe a) where
+  toJSONPB mx opts     = maybe A.Null (\x -> toJSONPB x opts) mx
   toEncodingPB mx opts = maybe E.null_ (\x -> toEncodingPB x opts) mx
 instance FromJSONPB a => FromJSONPB (Maybe a) where
   parseJSONPB A.Null = pure Nothing

--- a/tests/TestProto.hs
+++ b/tests/TestProto.hs
@@ -49,8 +49,8 @@ instance HsProtobuf.Message Trivial where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB Trivial where
-        toEncodingPB (Trivial f1)
-          = (HsJSONPB.fieldsPB ["trivialField" .= f1])
+        toJSONPB (Trivial f1) = (HsJSONPB.object ["trivialField" .= f1])
+        toEncodingPB (Trivial f1) = (HsJSONPB.pairs ["trivialField" .= f1])
  
 instance HsJSONPB.FromJSONPB Trivial where
         parseJSONPB
@@ -143,8 +143,13 @@ instance HsProtobuf.Message MultipleFields where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB MultipleFields where
+        toJSONPB (MultipleFields f1 f2 f3 f4 f5 f6)
+          = (HsJSONPB.object
+               ["multiFieldDouble" .= f1, "multiFieldFloat" .= f2,
+                "multiFieldInt32" .= f3, "multiFieldInt64" .= f4,
+                "multiFieldString" .= f5, "multiFieldBool" .= f6])
         toEncodingPB (MultipleFields f1 f2 f3 f4 f5 f6)
-          = (HsJSONPB.fieldsPB
+          = (HsJSONPB.pairs
                ["multiFieldDouble" .= f1, "multiFieldFloat" .= f2,
                 "multiFieldInt32" .= f3, "multiFieldInt64" .= f4,
                 "multiFieldString" .= f5, "multiFieldBool" .= f6])
@@ -198,8 +203,10 @@ instance HsProtobuf.Message SignedInts where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB SignedInts where
+        toJSONPB (SignedInts f1 f2)
+          = (HsJSONPB.object ["signed32" .= f1, "signed64" .= f2])
         toEncodingPB (SignedInts f1 f2)
-          = (HsJSONPB.fieldsPB ["signed32" .= f1, "signed64" .= f2])
+          = (HsJSONPB.pairs ["signed32" .= f1, "signed64" .= f2])
  
 instance HsJSONPB.FromJSONPB SignedInts where
         parseJSONPB
@@ -231,8 +238,8 @@ instance HsProtobuf.Message WithEnum where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB WithEnum where
-        toEncodingPB (WithEnum f1)
-          = (HsJSONPB.fieldsPB ["enumField" .= f1])
+        toJSONPB (WithEnum f1) = (HsJSONPB.object ["enumField" .= f1])
+        toEncodingPB (WithEnum f1) = (HsJSONPB.pairs ["enumField" .= f1])
  
 instance HsJSONPB.FromJSONPB WithEnum where
         parseJSONPB
@@ -263,7 +270,8 @@ instance Hs.Enum WithEnum_TestEnum where
         pred _ = Hs.predError "WithEnum_TestEnum"
  
 instance HsJSONPB.ToJSONPB WithEnum_TestEnum where
-        toEncodingPB x _ = HsJSONPB.namedEncoding x
+        toJSONPB x _ = HsJSONPB.enumFieldString x
+        toEncodingPB x _ = HsJSONPB.enumFieldEncoding x
  
 instance HsJSONPB.FromJSONPB WithEnum_TestEnum where
         parseJSONPB (HsJSONPB.String "ENUM1")
@@ -300,8 +308,10 @@ instance HsProtobuf.Message WithNesting where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB WithNesting where
+        toJSONPB (WithNesting f1)
+          = (HsJSONPB.object ["nestedMessage" .= f1])
         toEncodingPB (WithNesting f1)
-          = (HsJSONPB.fieldsPB ["nestedMessage" .= f1])
+          = (HsJSONPB.pairs ["nestedMessage" .= f1])
  
 instance HsJSONPB.FromJSONPB WithNesting where
         parseJSONPB
@@ -375,8 +385,12 @@ instance HsProtobuf.Message WithNesting_Nested where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB WithNesting_Nested where
+        toJSONPB (WithNesting_Nested f1 f2 f3 f4)
+          = (HsJSONPB.object
+               ["nestedField1" .= f1, "nestedField2" .= f2, "nestedPacked" .= f3,
+                "nestedUnpacked" .= f4])
         toEncodingPB (WithNesting_Nested f1 f2 f3 f4)
-          = (HsJSONPB.fieldsPB
+          = (HsJSONPB.pairs
                ["nestedField1" .= f1, "nestedField2" .= f2, "nestedPacked" .= f3,
                 "nestedUnpacked" .= f4])
  
@@ -417,8 +431,10 @@ instance HsProtobuf.Message WithNestingRepeated where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB WithNestingRepeated where
+        toJSONPB (WithNestingRepeated f1)
+          = (HsJSONPB.object ["nestedMessages" .= f1])
         toEncodingPB (WithNestingRepeated f1)
-          = (HsJSONPB.fieldsPB ["nestedMessages" .= f1])
+          = (HsJSONPB.pairs ["nestedMessages" .= f1])
  
 instance HsJSONPB.FromJSONPB WithNestingRepeated where
         parseJSONPB
@@ -499,8 +515,12 @@ instance HsProtobuf.Message WithNestingRepeated_Nested where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB WithNestingRepeated_Nested where
+        toJSONPB (WithNestingRepeated_Nested f1 f2 f3 f4)
+          = (HsJSONPB.object
+               ["nestedField1" .= f1, "nestedField2" .= f2, "nestedPacked" .= f3,
+                "nestedUnpacked" .= f4])
         toEncodingPB (WithNestingRepeated_Nested f1 f2 f3 f4)
-          = (HsJSONPB.fieldsPB
+          = (HsJSONPB.pairs
                ["nestedField1" .= f1, "nestedField2" .= f2, "nestedPacked" .= f3,
                 "nestedUnpacked" .= f4])
  
@@ -549,8 +569,10 @@ instance HsProtobuf.Message NestedInts where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB NestedInts where
+        toJSONPB (NestedInts f1 f2)
+          = (HsJSONPB.object ["nestedInt1" .= f1, "nestedInt2" .= f2])
         toEncodingPB (NestedInts f1 f2)
-          = (HsJSONPB.fieldsPB ["nestedInt1" .= f1, "nestedInt2" .= f2])
+          = (HsJSONPB.pairs ["nestedInt1" .= f1, "nestedInt2" .= f2])
  
 instance HsJSONPB.FromJSONPB NestedInts where
         parseJSONPB
@@ -587,8 +609,10 @@ instance HsProtobuf.Message WithNestingRepeatedInts where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB WithNestingRepeatedInts where
+        toJSONPB (WithNestingRepeatedInts f1)
+          = (HsJSONPB.object ["nestedInts" .= f1])
         toEncodingPB (WithNestingRepeatedInts f1)
-          = (HsJSONPB.fieldsPB ["nestedInts" .= f1])
+          = (HsJSONPB.pairs ["nestedInts" .= f1])
  
 instance HsJSONPB.FromJSONPB WithNestingRepeatedInts where
         parseJSONPB
@@ -624,8 +648,10 @@ instance HsProtobuf.Message WithNestingInts where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB WithNestingInts where
+        toJSONPB (WithNestingInts f1)
+          = (HsJSONPB.object ["nestedInts" .= f1])
         toEncodingPB (WithNestingInts f1)
-          = (HsJSONPB.fieldsPB ["nestedInts" .= f1])
+          = (HsJSONPB.pairs ["nestedInts" .= f1])
  
 instance HsJSONPB.FromJSONPB WithNestingInts where
         parseJSONPB
@@ -659,8 +685,10 @@ instance HsProtobuf.Message WithRepetition where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB WithRepetition where
+        toJSONPB (WithRepetition f1)
+          = (HsJSONPB.object ["repeatedField1" .= f1])
         toEncodingPB (WithRepetition f1)
-          = (HsJSONPB.fieldsPB ["repeatedField1" .= f1])
+          = (HsJSONPB.pairs ["repeatedField1" .= f1])
  
 instance HsJSONPB.FromJSONPB WithRepetition where
         parseJSONPB
@@ -730,8 +758,11 @@ instance HsProtobuf.Message WithFixed where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB WithFixed where
+        toJSONPB (WithFixed f1 f2 f3 f4)
+          = (HsJSONPB.object
+               ["fixed1" .= f1, "fixed2" .= f2, "fixed3" .= f3, "fixed4" .= f4])
         toEncodingPB (WithFixed f1 f2 f3 f4)
-          = (HsJSONPB.fieldsPB
+          = (HsJSONPB.pairs
                ["fixed1" .= f1, "fixed2" .= f2, "fixed3" .= f3, "fixed4" .= f4])
  
 instance HsJSONPB.FromJSONPB WithFixed where
@@ -779,8 +810,10 @@ instance HsProtobuf.Message WithBytes where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB WithBytes where
+        toJSONPB (WithBytes f1 f2)
+          = (HsJSONPB.object ["bytes1" .= f1, "bytes2" .= f2])
         toEncodingPB (WithBytes f1 f2)
-          = (HsJSONPB.fieldsPB ["bytes1" .= f1, "bytes2" .= f2])
+          = (HsJSONPB.pairs ["bytes1" .= f1, "bytes2" .= f2])
  
 instance HsJSONPB.FromJSONPB WithBytes where
         parseJSONPB
@@ -829,8 +862,10 @@ instance HsProtobuf.Message WithPacking where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB WithPacking where
+        toJSONPB (WithPacking f1 f2)
+          = (HsJSONPB.object ["packing1" .= f1, "packing2" .= f2])
         toEncodingPB (WithPacking f1 f2)
-          = (HsJSONPB.fieldsPB ["packing1" .= f1, "packing2" .= f2])
+          = (HsJSONPB.pairs ["packing1" .= f1, "packing2" .= f2])
  
 instance HsJSONPB.FromJSONPB WithPacking where
         parseJSONPB
@@ -1000,8 +1035,14 @@ instance HsProtobuf.Message AllPackedTypes where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB AllPackedTypes where
+        toJSONPB (AllPackedTypes f1 f2 f3 f4 f5 f6 f7 f8 f9 f10)
+          = (HsJSONPB.object
+               ["packedWord32" .= f1, "packedWord64" .= f2, "packedInt32" .= f3,
+                "packedInt64" .= f4, "packedFixed32" .= f5, "packedFixed64" .= f6,
+                "packedFloat" .= f7, "packedDouble" .= f8, "packedSFixed32" .= f9,
+                "packedSFixed64" .= f10])
         toEncodingPB (AllPackedTypes f1 f2 f3 f4 f5 f6 f7 f8 f9 f10)
-          = (HsJSONPB.fieldsPB
+          = (HsJSONPB.pairs
                ["packedWord32" .= f1, "packedWord64" .= f2, "packedInt32" .= f3,
                 "packedInt64" .= f4, "packedFixed32" .= f5, "packedFixed64" .= f6,
                 "packedFloat" .= f7, "packedDouble" .= f8, "packedSFixed32" .= f9,
@@ -1086,8 +1127,12 @@ instance HsProtobuf.Message OutOfOrderFields where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB OutOfOrderFields where
+        toJSONPB (OutOfOrderFields f2001 f101 f30 f1002)
+          = (HsJSONPB.object
+               ["field1" .= f2001, "field2" .= f101, "field3" .= f30,
+                "field4" .= f1002])
         toEncodingPB (OutOfOrderFields f2001 f101 f30 f1002)
-          = (HsJSONPB.fieldsPB
+          = (HsJSONPB.pairs
                ["field1" .= f2001, "field2" .= f101, "field3" .= f30,
                 "field4" .= f1002])
  
@@ -1136,8 +1181,10 @@ instance HsProtobuf.Message ShadowedMessage where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB ShadowedMessage where
+        toJSONPB (ShadowedMessage f2 f1)
+          = (HsJSONPB.object ["name" .= f2, "value" .= f1])
         toEncodingPB (ShadowedMessage f2 f1)
-          = (HsJSONPB.fieldsPB ["name" .= f2, "value" .= f1])
+          = (HsJSONPB.pairs ["name" .= f2, "value" .= f1])
  
 instance HsJSONPB.FromJSONPB ShadowedMessage where
         parseJSONPB
@@ -1185,8 +1232,10 @@ instance HsProtobuf.Message MessageShadower where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB MessageShadower where
+        toJSONPB (MessageShadower f1 f2)
+          = (HsJSONPB.object ["shadowed_message" .= f1, "name" .= f2])
         toEncodingPB (MessageShadower f1 f2)
-          = (HsJSONPB.fieldsPB ["shadowed_message" .= f1, "name" .= f2])
+          = (HsJSONPB.pairs ["shadowed_message" .= f1, "name" .= f2])
  
 instance HsJSONPB.FromJSONPB MessageShadower where
         parseJSONPB
@@ -1235,8 +1284,10 @@ instance HsProtobuf.Message MessageShadower_ShadowedMessage where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB MessageShadower_ShadowedMessage where
+        toJSONPB (MessageShadower_ShadowedMessage f1 f2)
+          = (HsJSONPB.object ["name" .= f1, "value" .= f2])
         toEncodingPB (MessageShadower_ShadowedMessage f1 f2)
-          = (HsJSONPB.fieldsPB ["name" .= f1, "value" .= f2])
+          = (HsJSONPB.pairs ["name" .= f1, "value" .= f2])
  
 instance HsJSONPB.FromJSONPB MessageShadower_ShadowedMessage where
         parseJSONPB
@@ -1290,8 +1341,10 @@ instance HsProtobuf.Message WithQualifiedName where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB WithQualifiedName where
+        toJSONPB (WithQualifiedName f100 f200)
+          = (HsJSONPB.object ["qname1" .= f100, "qname2" .= f200])
         toEncodingPB (WithQualifiedName f100 f200)
-          = (HsJSONPB.fieldsPB ["qname1" .= f100, "qname2" .= f200])
+          = (HsJSONPB.pairs ["qname1" .= f100, "qname2" .= f200])
  
 instance HsJSONPB.FromJSONPB WithQualifiedName where
         parseJSONPB
@@ -1344,8 +1397,11 @@ instance HsProtobuf.Message UsingImported where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB UsingImported where
+        toJSONPB (UsingImported f100 f200)
+          = (HsJSONPB.object
+               ["importedNesting" .= f100, "localNesting" .= f200])
         toEncodingPB (UsingImported f100 f200)
-          = (HsJSONPB.fieldsPB
+          = (HsJSONPB.pairs
                ["importedNesting" .= f100, "localNesting" .= f200])
  
 instance HsJSONPB.FromJSONPB UsingImported where
@@ -1380,7 +1436,8 @@ instance HsProtobuf.Message Wrapped where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB Wrapped where
-        toEncodingPB (Wrapped f1) = (HsJSONPB.fieldsPB ["wrapped" .= f1])
+        toJSONPB (Wrapped f1) = (HsJSONPB.object ["wrapped" .= f1])
+        toEncodingPB (Wrapped f1) = (HsJSONPB.pairs ["wrapped" .= f1])
  
 instance HsJSONPB.FromJSONPB Wrapped where
         parseJSONPB

--- a/tests/TestProtoImport.hs
+++ b/tests/TestProtoImport.hs
@@ -65,8 +65,11 @@ instance HsProtobuf.Message WithNesting where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB WithNesting where
+        toJSONPB (WithNesting f1 f100)
+          = (HsJSONPB.object
+               ["nestedMessage1" .= f1, "nestedMessage2" .= f100])
         toEncodingPB (WithNesting f1 f100)
-          = (HsJSONPB.fieldsPB
+          = (HsJSONPB.pairs
                ["nestedMessage1" .= f1, "nestedMessage2" .= f100])
  
 instance HsJSONPB.FromJSONPB WithNesting where
@@ -114,8 +117,10 @@ instance HsProtobuf.Message WithNesting_Nested where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB WithNesting_Nested where
+        toJSONPB (WithNesting_Nested f1 f2)
+          = (HsJSONPB.object ["nestedField1" .= f1, "nestedField2" .= f2])
         toEncodingPB (WithNesting_Nested f1 f2)
-          = (HsJSONPB.fieldsPB ["nestedField1" .= f1, "nestedField2" .= f2])
+          = (HsJSONPB.pairs ["nestedField1" .= f1, "nestedField2" .= f2])
  
 instance HsJSONPB.FromJSONPB WithNesting_Nested where
         parseJSONPB

--- a/tests/TestProtoOneof.hs
+++ b/tests/TestProtoOneof.hs
@@ -49,7 +49,8 @@ instance HsProtobuf.Message DummyMsg where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB DummyMsg where
-        toEncodingPB (DummyMsg f1) = (HsJSONPB.fieldsPB ["dummy" .= f1])
+        toJSONPB (DummyMsg f1) = (HsJSONPB.object ["dummy" .= f1])
+        toEncodingPB (DummyMsg f1) = (HsJSONPB.pairs ["dummy" .= f1])
  
 instance HsJSONPB.FromJSONPB DummyMsg where
         parseJSONPB
@@ -75,7 +76,8 @@ instance Hs.Enum DummyEnum where
         pred _ = Hs.predError "DummyEnum"
  
 instance HsJSONPB.ToJSONPB DummyEnum where
-        toEncodingPB x _ = HsJSONPB.namedEncoding x
+        toJSONPB x _ = HsJSONPB.enumFieldString x
+        toEncodingPB x _ = HsJSONPB.enumFieldEncoding x
  
 instance HsJSONPB.FromJSONPB DummyEnum where
         parseJSONPB (HsJSONPB.String "DUMMY0") = Hs.pure DummyEnumDUMMY0
@@ -158,8 +160,21 @@ instance HsProtobuf.Message Something where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB Something where
+        toJSONPB (Something f1 f2 f4_or_f9_or_f10_or_f11_or_f12)
+          = (HsJSONPB.object
+               ["value" .= f1, "another" .= f2,
+                case f4_or_f9_or_f10_or_f11_or_f12 of
+                    Hs.Just (SomethingPickOneName f4) -> (HsJSONPB.pair "name" f4)
+                    Hs.Just (SomethingPickOneSomeid f9) -> (HsJSONPB.pair "someid" f9)
+                    Hs.Just (SomethingPickOneDummyMsg1 f10)
+                      -> (HsJSONPB.pair "dummyMsg1" f10)
+                    Hs.Just (SomethingPickOneDummyMsg2 f11)
+                      -> (HsJSONPB.pair "dummyMsg2" f11)
+                    Hs.Just (SomethingPickOneDummyEnum f12)
+                      -> (HsJSONPB.pair "dummyEnum" f12)
+                    Hs.Nothing -> Hs.mempty])
         toEncodingPB (Something f1 f2 f4_or_f9_or_f10_or_f11_or_f12)
-          = (HsJSONPB.fieldsPB
+          = (HsJSONPB.pairs
                ["value" .= f1, "another" .= f2,
                 case f4_or_f9_or_f10_or_f11_or_f12 of
                     Hs.Just (SomethingPickOneName f4) -> (HsJSONPB.pair "name" f4)
@@ -243,8 +258,15 @@ instance HsProtobuf.Message OneofFirst where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB OneofFirst where
+        toJSONPB (OneofFirst f1_or_f2 f3)
+          = (HsJSONPB.object
+               [case f1_or_f2 of
+                    Hs.Just (OneofFirstFirstChoice1 f1) -> (HsJSONPB.pair "choice1" f1)
+                    Hs.Just (OneofFirstFirstChoice2 f2) -> (HsJSONPB.pair "choice2" f2)
+                    Hs.Nothing -> Hs.mempty,
+                "last" .= f3])
         toEncodingPB (OneofFirst f1_or_f2 f3)
-          = (HsJSONPB.fieldsPB
+          = (HsJSONPB.pairs
                [case f1_or_f2 of
                     Hs.Just (OneofFirstFirstChoice1 f1) -> (HsJSONPB.pair "choice1" f1)
                     Hs.Just (OneofFirstFirstChoice2 f2) -> (HsJSONPB.pair "choice2" f2)
@@ -324,8 +346,18 @@ instance HsProtobuf.Message OneofMiddle where
                 Hs.Nothing)]
  
 instance HsJSONPB.ToJSONPB OneofMiddle where
+        toJSONPB (OneofMiddle f1 f2_or_f3 f4)
+          = (HsJSONPB.object
+               ["first" .= f1,
+                case f2_or_f3 of
+                    Hs.Just (OneofMiddleMiddleChoice1 f2)
+                      -> (HsJSONPB.pair "choice1" f2)
+                    Hs.Just (OneofMiddleMiddleChoice2 f3)
+                      -> (HsJSONPB.pair "choice2" f3)
+                    Hs.Nothing -> Hs.mempty,
+                "last" .= f4])
         toEncodingPB (OneofMiddle f1 f2_or_f3 f4)
-          = (HsJSONPB.fieldsPB
+          = (HsJSONPB.pairs
                ["first" .= f1,
                 case f2_or_f3 of
                     Hs.Just (OneofMiddleMiddleChoice1 f2)
@@ -385,8 +417,16 @@ instance HsProtobuf.Message WithImported where
         dotProto _ = []
  
 instance HsJSONPB.ToJSONPB WithImported where
+        toJSONPB (WithImported f1_or_f2)
+          = (HsJSONPB.object
+               [case f1_or_f2 of
+                    Hs.Just (WithImportedPickOneDummyMsg1 f1)
+                      -> (HsJSONPB.pair "dummyMsg1" f1)
+                    Hs.Just (WithImportedPickOneWithOneof f2)
+                      -> (HsJSONPB.pair "withOneof" f2)
+                    Hs.Nothing -> Hs.mempty])
         toEncodingPB (WithImported f1_or_f2)
-          = (HsJSONPB.fieldsPB
+          = (HsJSONPB.pairs
                [case f1_or_f2 of
                     Hs.Just (WithImportedPickOneDummyMsg1 f1)
                       -> (HsJSONPB.pair "dummyMsg1" f1)

--- a/tests/TestProtoOneofImport.hs
+++ b/tests/TestProtoOneofImport.hs
@@ -57,8 +57,14 @@ instance HsProtobuf.Message WithOneof where
         dotProto _ = []
  
 instance HsJSONPB.ToJSONPB WithOneof where
+        toJSONPB (WithOneof f1_or_f2)
+          = (HsJSONPB.object
+               [case f1_or_f2 of
+                    Hs.Just (WithOneofPickOneA f1) -> (HsJSONPB.pair "a" f1)
+                    Hs.Just (WithOneofPickOneB f2) -> (HsJSONPB.pair "b" f2)
+                    Hs.Nothing -> Hs.mempty])
         toEncodingPB (WithOneof f1_or_f2)
-          = (HsJSONPB.fieldsPB
+          = (HsJSONPB.pairs
                [case f1_or_f2 of
                     Hs.Just (WithOneofPickOneA f1) -> (HsJSONPB.pair "a" f1)
                     Hs.Just (WithOneofPickOneB f2) -> (HsJSONPB.pair "b" f2)


### PR DESCRIPTION
The preliminary JSONPB implementation only provided the `toEncoding`-like typeclass method, `toEncodingPB`, because we didn't think it was useful to render protobuf values to the `Data.Aeson.Value` intermediate representation.

However, it's become apparent that this was an oversight, as we would like to generate `aeson` instances in terms of the the JSONPB instances, and be able to use other packages (e.g. `aeson-pretty`) which rely on the `Data.Aeson.Value` IR.

This PR adds the `toJSONPB` function (analogous to `aeson`'s `toJSON`) to the `ToJSONPB` typeclass, and makes corresponding changes to code generation to provide implementations of the new function.
