### PR TITLE
Generate `aeson` instances for protobuf types

### DIFF
--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -368,7 +368,8 @@ nestedTypeName (Dots (Path parents)) nm =
     (<> ("_" <> nm)) <$> (intercalate "_" <$> mapM typeLikeName parents)
 nestedTypeName (Qualified {})  _  = internalError "nestedTypeName: Qualified"
 
-haskellName, jsonpbName, grpcName, protobufName :: String -> HsQName
+aesonName, haskellName, jsonpbName, grpcName, protobufName :: String -> HsQName
+aesonName    name = Qual (Module "HsAeson") (HsIdent name)
 haskellName  name = Qual (Module "Hs") (HsIdent name)
 jsonpbName   name = Qual (Module "HsJSONPB") (HsIdent name)
 grpcName     name = Qual (Module "HsGRPC") (HsIdent name)
@@ -526,6 +527,9 @@ dotProtoMessageD ctxt parentIdent messageIdent message =
               , messageInst
               , toJSONPBInst
               , fromJSONPBInst
+                -- Generate Aeson instances in terms of JSONPB instances
+              , toJSONInstDecl messageName
+              , fromJSONInstDecl messageName
               ]
               <> nestedOneofs_
               <> nestedDecls_
@@ -1009,6 +1013,9 @@ dotProtoEnumD parentIdent enumIdent enumParts =
                       ]
           , instDecl_ (jsonpbName "FromJSONPB") [ type_ enumName ]
                       [ HsFunBind parseJSONPBDecls ]
+          -- Generate Aeson instances in terms of JSONPB instances
+          , toJSONInstDecl enumName
+          , fromJSONInstDecl enumName
           ]
 
 -- ** Generate code for dot proto services
@@ -1259,6 +1266,27 @@ intE x = (if x < 0 then HsParen else id) . HsLit . HsInt . fromIntegral $ x
 intP :: Integral a => a -> HsPat
 intP x = (if x < 0 then HsPParen else id) . HsPLit . HsInt . fromIntegral $ x
 
+toJSONInstDecl :: String -> HsDecl
+toJSONInstDecl typeName =
+  instDecl_ (aesonName "ToJSON")
+            [ type_ typeName ]
+            [ HsFunBind [ match_ (HsIdent "toJSON") []
+                                 (HsUnGuardedRhs (HsVar (jsonpbName "toAesonValue"))) []
+                        ]
+            , HsFunBind [ match_ (HsIdent "toEncoding") []
+                                 (HsUnGuardedRhs (HsVar (jsonpbName "toAesonEncoding"))) []
+                        ]
+            ]
+
+
+fromJSONInstDecl :: String -> HsDecl
+fromJSONInstDecl typeName =
+  instDecl_ (aesonName "FromJSON")
+            [ type_ typeName ]
+            [ HsFunBind [match_ (HsIdent "parseJSON") [] (HsUnGuardedRhs (HsVar (jsonpbName "parseJSONPB"))) []
+                        ]
+            ]
+
 -- ** Expressions for protobuf-wire types
 
 forceEmitE :: HsExp -> HsExp
@@ -1354,6 +1382,7 @@ defaultImports usesGrpc =
                               , importSym "Word64" ]))
   , importDecl_ ghcGenericsM              True (Just haskellNS) Nothing
   , importDecl_ ghcEnumM                  True (Just haskellNS) Nothing
+  , importDecl_ dataAesonM                True (Just aesonNS) Nothing
   ] <>
   if usesGrpc
     then [ importDecl_ networkGrpcHighLevelGeneratedM   False (Just grpcNS) Nothing
@@ -1374,6 +1403,7 @@ defaultImports usesGrpc =
         controlMonadM             = Module "Control.Monad"
         dataTextM                 = Module "Data.Text.Lazy"
         dataByteStringM           = Module "Data.ByteString"
+        dataAesonM                = Module "Data.Aeson"
         dataStringM               = Module "Data.String"
         dataIntM                  = Module "Data.Int"
         dataVectorM               = Module "Data.Vector"
@@ -1386,6 +1416,7 @@ defaultImports usesGrpc =
         networkGrpcHighLevelServerUnregM = Module "Network.GRPC.HighLevel.Server.Unregistered"
         networkGrpcLowLevelCallM         = Module "Network.GRPC.LowLevel.Call"
 
+        aesonNS                   = Module "HsAeson"
         grpcNS                    = Module "HsGRPC"
         jsonpbNS                  = Module "HsJSONPB"
         protobufNS                = Module "HsProtobuf"

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -368,8 +368,7 @@ nestedTypeName (Dots (Path parents)) nm =
     (<> ("_" <> nm)) <$> (intercalate "_" <$> mapM typeLikeName parents)
 nestedTypeName (Qualified {})  _  = internalError "nestedTypeName: Qualified"
 
-aesonName, haskellName, jsonpbName, grpcName, protobufName :: String -> HsQName
-aesonName    name = Qual (Module "HsAeson") (HsIdent name)
+haskellName, jsonpbName, grpcName, protobufName :: String -> HsQName
 haskellName  name = Qual (Module "Hs") (HsIdent name)
 jsonpbName   name = Qual (Module "HsJSONPB") (HsIdent name)
 grpcName     name = Qual (Module "HsGRPC") (HsIdent name)
@@ -1268,7 +1267,7 @@ intP x = (if x < 0 then HsPParen else id) . HsPLit . HsInt . fromIntegral $ x
 
 toJSONInstDecl :: String -> HsDecl
 toJSONInstDecl typeName =
-  instDecl_ (aesonName "ToJSON")
+  instDecl_ (jsonpbName "ToJSON")
             [ type_ typeName ]
             [ HsFunBind [ match_ (HsIdent "toJSON") []
                                  (HsUnGuardedRhs (HsVar (jsonpbName "toAesonValue"))) []
@@ -1281,7 +1280,7 @@ toJSONInstDecl typeName =
 
 fromJSONInstDecl :: String -> HsDecl
 fromJSONInstDecl typeName =
-  instDecl_ (aesonName "FromJSON")
+  instDecl_ (jsonpbName "FromJSON")
             [ type_ typeName ]
             [ HsFunBind [match_ (HsIdent "parseJSON") [] (HsUnGuardedRhs (HsVar (jsonpbName "parseJSONPB"))) []
                         ]
@@ -1382,7 +1381,6 @@ defaultImports usesGrpc =
                               , importSym "Word64" ]))
   , importDecl_ ghcGenericsM              True (Just haskellNS) Nothing
   , importDecl_ ghcEnumM                  True (Just haskellNS) Nothing
-  , importDecl_ dataAesonM                True (Just aesonNS) Nothing
   ] <>
   if usesGrpc
     then [ importDecl_ networkGrpcHighLevelGeneratedM   False (Just grpcNS) Nothing
@@ -1403,7 +1401,6 @@ defaultImports usesGrpc =
         controlMonadM             = Module "Control.Monad"
         dataTextM                 = Module "Data.Text.Lazy"
         dataByteStringM           = Module "Data.ByteString"
-        dataAesonM                = Module "Data.Aeson"
         dataStringM               = Module "Data.String"
         dataIntM                  = Module "Data.Int"
         dataVectorM               = Module "Data.Vector"
@@ -1416,7 +1413,6 @@ defaultImports usesGrpc =
         networkGrpcHighLevelServerUnregM = Module "Network.GRPC.HighLevel.Server.Unregistered"
         networkGrpcLowLevelCallM         = Module "Network.GRPC.LowLevel.Call"
 
-        aesonNS                   = Module "HsAeson"
         grpcNS                    = Module "HsGRPC"
         jsonpbNS                  = Module "HsJSONPB"
         protobufNS                = Module "HsProtobuf"

--- a/src/Proto3/Suite/JSONPB.hs
+++ b/src/Proto3/Suite/JSONPB.hs
@@ -23,6 +23,8 @@ module Proto3.Suite.JSONPB
   , toAesonValue
     -- * Aeson re-exports
   , A.Value(..)
+  , A.ToJSON(..)
+  , A.FromJSON(..)
   , A.typeMismatch
   , A.withObject
   )

--- a/src/Proto3/Suite/JSONPB.hs
+++ b/src/Proto3/Suite/JSONPB.hs
@@ -19,6 +19,8 @@ module Proto3.Suite.JSONPB
   , pair
   , pairs
   , parseField
+  , toAesonEncoding
+  , toAesonValue
     -- * Aeson re-exports
   , A.Value(..)
   , A.typeMismatch

--- a/src/Proto3/Suite/JSONPB/Class.hs
+++ b/src/Proto3/Suite/JSONPB/Class.hs
@@ -105,12 +105,8 @@ class ToJSONPB a where
 
 -- | 'A.FromJSON' variant for JSONPB decoding from the 'A.Value' IR
 class FromJSONPB a where
-  -- | 'A.parseJSON' variant for JSONPB decoders. Equivalent to 'A.parseJSON' if
-  -- an implementation is not provided.
+  -- | 'A.parseJSON' variant for JSONPB decoders.
   parseJSONPB :: A.Value -> A.Parser a
-
-  default parseJSONPB :: (A.FromJSON a) => A.Value -> A.Parser a
-  parseJSONPB = A.parseJSON
 
 -- * JSONPB codec entry points
 
@@ -200,6 +196,15 @@ enumFieldString = A.String . T.pack . dropNamedPrefix (Proxy @a) . show
 enumFieldEncoding :: forall a. (Named a, Show a) => a -> A.Encoding
 enumFieldEncoding = E.string . dropNamedPrefix (Proxy @a) . show
 
+-- | A 'Data.Aeson' 'A.Value' encoder for values which can be
+-- JSONPB-encoded
+toAesonValue :: ToJSONPB a => a -> A.Value
+toAesonValue = flip toJSONPB defaultOptions
+
+-- | A direct 'A.Encoding' for values which can be JSONPB-encoded
+toAesonEncoding :: ToJSONPB a => a -> A.Encoding
+toAesonEncoding = flip toEncodingPB defaultOptions
+
 -- | Parse a JSONPB floating point value; first parameter provides context for
 -- type mismatches
 parseFP :: (A.FromJSON a, A.FromJSONKey a) => String -> A.Value -> A.Parser a
@@ -230,7 +235,8 @@ instance ToJSONPB Bool where
   toJSONPB     = const . A.toJSON
   toEncodingPB = const . A.toEncoding
 
-instance FromJSONPB Bool
+instance FromJSONPB Bool where
+  parseJSONPB = A.parseJSON
 
 --------------------------------------------------------------------------------
 -- Integer scalar types
@@ -329,7 +335,8 @@ instance FromJSONPB Double where
 instance ToJSONPB TL.Text where
   toJSONPB     = const . A.toJSON
   toEncodingPB = const . A.toEncoding
-instance FromJSONPB TL.Text
+instance FromJSONPB TL.Text where
+  parseJSONPB = A.parseJSON
 
 -- bytes
 

--- a/tests/TestProto.hs
+++ b/tests/TestProto.hs
@@ -24,6 +24,7 @@ import qualified Data.Int as Hs (Int16, Int32, Int64)
 import qualified Data.Word as Hs (Word16, Word32, Word64)
 import qualified GHC.Generics as Hs
 import qualified GHC.Enum as Hs
+import qualified Data.Aeson as HsAeson
 import qualified TestProtoImport
  
 data Trivial = Trivial{trivialTrivialField :: Hs.Int32}
@@ -56,6 +57,13 @@ instance HsJSONPB.FromJSONPB Trivial where
         parseJSONPB
           = (HsJSONPB.withObject "Trivial"
                (\ obj -> (Hs.pure Trivial) <*> obj .: "trivialField"))
+ 
+instance HsAeson.ToJSON Trivial where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON Trivial where
+        parseJSON = HsJSONPB.parseJSONPB
  
 data MultipleFields = MultipleFields{multipleFieldsMultiFieldDouble
                                      :: Hs.Double,
@@ -165,6 +173,13 @@ instance HsJSONPB.FromJSONPB MultipleFields where
                     <*> obj .: "multiFieldString"
                     <*> obj .: "multiFieldBool"))
  
+instance HsAeson.ToJSON MultipleFields where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON MultipleFields where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data SignedInts = SignedInts{signedIntsSigned32 :: Hs.Int32,
                              signedIntsSigned64 :: Hs.Int64}
                 deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -214,6 +229,13 @@ instance HsJSONPB.FromJSONPB SignedInts where
                (\ obj ->
                   (Hs.pure SignedInts) <*> obj .: "signed32" <*> obj .: "signed64"))
  
+instance HsAeson.ToJSON SignedInts where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON SignedInts where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data WithEnum = WithEnum{withEnumEnumField ::
                          HsProtobuf.Enumerated TestProto.WithEnum_TestEnum}
               deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -245,6 +267,13 @@ instance HsJSONPB.FromJSONPB WithEnum where
         parseJSONPB
           = (HsJSONPB.withObject "WithEnum"
                (\ obj -> (Hs.pure WithEnum) <*> obj .: "enumField"))
+ 
+instance HsAeson.ToJSON WithEnum where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithEnum where
+        parseJSON = HsJSONPB.parseJSONPB
  
 data WithEnum_TestEnum = WithEnum_TestEnumENUM1
                        | WithEnum_TestEnumENUM2
@@ -282,6 +311,13 @@ instance HsJSONPB.FromJSONPB WithEnum_TestEnum where
           = Hs.pure WithEnum_TestEnumENUM3
         parseJSONPB v = (HsJSONPB.typeMismatch "WithEnum_TestEnum" v)
  
+instance HsAeson.ToJSON WithEnum_TestEnum where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithEnum_TestEnum where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data WithNesting = WithNesting{withNestingNestedMessage ::
                                Hs.Maybe TestProto.WithNesting_Nested}
                  deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -317,6 +353,13 @@ instance HsJSONPB.FromJSONPB WithNesting where
         parseJSONPB
           = (HsJSONPB.withObject "WithNesting"
                (\ obj -> (Hs.pure WithNesting) <*> obj .: "nestedMessage"))
+ 
+instance HsAeson.ToJSON WithNesting where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithNesting where
+        parseJSON = HsJSONPB.parseJSONPB
  
 data WithNesting_Nested = WithNesting_Nested{withNesting_NestedNestedField1
                                              :: Hs.Text,
@@ -403,6 +446,13 @@ instance HsJSONPB.FromJSONPB WithNesting_Nested where
                     <*> obj .: "nestedPacked"
                     <*> obj .: "nestedUnpacked"))
  
+instance HsAeson.ToJSON WithNesting_Nested where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithNesting_Nested where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data WithNestingRepeated = WithNestingRepeated{withNestingRepeatedNestedMessages
                                                :: Hs.Vector TestProto.WithNestingRepeated_Nested}
                          deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -441,6 +491,13 @@ instance HsJSONPB.FromJSONPB WithNestingRepeated where
           = (HsJSONPB.withObject "WithNestingRepeated"
                (\ obj ->
                   (Hs.pure WithNestingRepeated) <*> obj .: "nestedMessages"))
+ 
+instance HsAeson.ToJSON WithNestingRepeated where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithNestingRepeated where
+        parseJSON = HsJSONPB.parseJSONPB
  
 data WithNestingRepeated_Nested = WithNestingRepeated_Nested{withNestingRepeated_NestedNestedField1
                                                              :: Hs.Text,
@@ -533,6 +590,13 @@ instance HsJSONPB.FromJSONPB WithNestingRepeated_Nested where
                     <*> obj .: "nestedPacked"
                     <*> obj .: "nestedUnpacked"))
  
+instance HsAeson.ToJSON WithNestingRepeated_Nested where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithNestingRepeated_Nested where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data NestedInts = NestedInts{nestedIntsNestedInt1 :: Hs.Int32,
                              nestedIntsNestedInt2 :: Hs.Int32}
                 deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -581,6 +645,13 @@ instance HsJSONPB.FromJSONPB NestedInts where
                   (Hs.pure NestedInts) <*> obj .: "nestedInt1" <*>
                     obj .: "nestedInt2"))
  
+instance HsAeson.ToJSON NestedInts where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON NestedInts where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data WithNestingRepeatedInts = WithNestingRepeatedInts{withNestingRepeatedIntsNestedInts
                                                        :: Hs.Vector TestProto.NestedInts}
                              deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -620,6 +691,13 @@ instance HsJSONPB.FromJSONPB WithNestingRepeatedInts where
                (\ obj ->
                   (Hs.pure WithNestingRepeatedInts) <*> obj .: "nestedInts"))
  
+instance HsAeson.ToJSON WithNestingRepeatedInts where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithNestingRepeatedInts where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data WithNestingInts = WithNestingInts{withNestingIntsNestedInts ::
                                        Hs.Maybe TestProto.NestedInts}
                      deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -658,6 +736,13 @@ instance HsJSONPB.FromJSONPB WithNestingInts where
           = (HsJSONPB.withObject "WithNestingInts"
                (\ obj -> (Hs.pure WithNestingInts) <*> obj .: "nestedInts"))
  
+instance HsAeson.ToJSON WithNestingInts where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithNestingInts where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data WithRepetition = WithRepetition{withRepetitionRepeatedField1
                                      :: Hs.Vector Hs.Int32}
                     deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -694,6 +779,13 @@ instance HsJSONPB.FromJSONPB WithRepetition where
         parseJSONPB
           = (HsJSONPB.withObject "WithRepetition"
                (\ obj -> (Hs.pure WithRepetition) <*> obj .: "repeatedField1"))
+ 
+instance HsAeson.ToJSON WithRepetition where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithRepetition where
+        parseJSON = HsJSONPB.parseJSONPB
  
 data WithFixed = WithFixed{withFixedFixed1 ::
                            HsProtobuf.Fixed Hs.Word32,
@@ -773,6 +865,13 @@ instance HsJSONPB.FromJSONPB WithFixed where
                     obj .: "fixed3"
                     <*> obj .: "fixed4"))
  
+instance HsAeson.ToJSON WithFixed where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithFixed where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data WithBytes = WithBytes{withBytesBytes1 :: Hs.ByteString,
                            withBytesBytes2 :: Hs.Vector Hs.ByteString}
                deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -820,6 +919,13 @@ instance HsJSONPB.FromJSONPB WithBytes where
           = (HsJSONPB.withObject "WithBytes"
                (\ obj ->
                   (Hs.pure WithBytes) <*> obj .: "bytes1" <*> obj .: "bytes2"))
+ 
+instance HsAeson.ToJSON WithBytes where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithBytes where
+        parseJSON = HsJSONPB.parseJSONPB
  
 data WithPacking = WithPacking{withPackingPacking1 ::
                                Hs.Vector Hs.Int32,
@@ -872,6 +978,13 @@ instance HsJSONPB.FromJSONPB WithPacking where
           = (HsJSONPB.withObject "WithPacking"
                (\ obj ->
                   (Hs.pure WithPacking) <*> obj .: "packing1" <*> obj .: "packing2"))
+ 
+instance HsAeson.ToJSON WithPacking where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithPacking where
+        parseJSON = HsJSONPB.parseJSONPB
  
 data AllPackedTypes = AllPackedTypes{allPackedTypesPackedWord32 ::
                                      Hs.Vector Hs.Word32,
@@ -1063,6 +1176,13 @@ instance HsJSONPB.FromJSONPB AllPackedTypes where
                     <*> obj .: "packedSFixed32"
                     <*> obj .: "packedSFixed64"))
  
+instance HsAeson.ToJSON AllPackedTypes where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON AllPackedTypes where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data OutOfOrderFields = OutOfOrderFields{outOfOrderFieldsField1 ::
                                          Hs.Vector Hs.Word32,
                                          outOfOrderFieldsField2 :: Hs.Text,
@@ -1144,6 +1264,13 @@ instance HsJSONPB.FromJSONPB OutOfOrderFields where
                     <*> obj .: "field3"
                     <*> obj .: "field4"))
  
+instance HsAeson.ToJSON OutOfOrderFields where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON OutOfOrderFields where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data ShadowedMessage = ShadowedMessage{shadowedMessageName ::
                                        Hs.Text,
                                        shadowedMessageValue :: Hs.Int32}
@@ -1191,6 +1318,13 @@ instance HsJSONPB.FromJSONPB ShadowedMessage where
           = (HsJSONPB.withObject "ShadowedMessage"
                (\ obj ->
                   (Hs.pure ShadowedMessage) <*> obj .: "name" <*> obj .: "value"))
+ 
+instance HsAeson.ToJSON ShadowedMessage where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON ShadowedMessage where
+        parseJSON = HsJSONPB.parseJSONPB
  
 data MessageShadower = MessageShadower{messageShadowerShadowedMessage
                                        :: Hs.Maybe TestProto.MessageShadower_ShadowedMessage,
@@ -1244,6 +1378,13 @@ instance HsJSONPB.FromJSONPB MessageShadower where
                   (Hs.pure MessageShadower) <*> obj .: "shadowed_message" <*>
                     obj .: "name"))
  
+instance HsAeson.ToJSON MessageShadower where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON MessageShadower where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data MessageShadower_ShadowedMessage = MessageShadower_ShadowedMessage{messageShadower_ShadowedMessageName
                                                                        :: Hs.Text,
                                                                        messageShadower_ShadowedMessageValue
@@ -1295,6 +1436,13 @@ instance HsJSONPB.FromJSONPB MessageShadower_ShadowedMessage where
                (\ obj ->
                   (Hs.pure MessageShadower_ShadowedMessage) <*> obj .: "name" <*>
                     obj .: "value"))
+ 
+instance HsAeson.ToJSON MessageShadower_ShadowedMessage where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON MessageShadower_ShadowedMessage where
+        parseJSON = HsJSONPB.parseJSONPB
  
 data WithQualifiedName = WithQualifiedName{withQualifiedNameQname1
                                            :: Hs.Maybe TestProto.ShadowedMessage,
@@ -1352,6 +1500,13 @@ instance HsJSONPB.FromJSONPB WithQualifiedName where
                (\ obj ->
                   (Hs.pure WithQualifiedName) <*> obj .: "qname1" <*>
                     obj .: "qname2"))
+ 
+instance HsAeson.ToJSON WithQualifiedName where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithQualifiedName where
+        parseJSON = HsJSONPB.parseJSONPB
  
 data UsingImported = UsingImported{usingImportedImportedNesting ::
                                    Hs.Maybe TestProtoImport.WithNesting,
@@ -1411,6 +1566,13 @@ instance HsJSONPB.FromJSONPB UsingImported where
                   (Hs.pure UsingImported) <*> obj .: "importedNesting" <*>
                     obj .: "localNesting"))
  
+instance HsAeson.ToJSON UsingImported where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON UsingImported where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data Wrapped = Wrapped{wrappedWrapped ::
                        Hs.Maybe TestProto.Wrapped}
              deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -1443,3 +1605,10 @@ instance HsJSONPB.FromJSONPB Wrapped where
         parseJSONPB
           = (HsJSONPB.withObject "Wrapped"
                (\ obj -> (Hs.pure Wrapped) <*> obj .: "wrapped"))
+ 
+instance HsAeson.ToJSON Wrapped where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON Wrapped where
+        parseJSON = HsJSONPB.parseJSONPB

--- a/tests/TestProto.hs
+++ b/tests/TestProto.hs
@@ -24,7 +24,6 @@ import qualified Data.Int as Hs (Int16, Int32, Int64)
 import qualified Data.Word as Hs (Word16, Word32, Word64)
 import qualified GHC.Generics as Hs
 import qualified GHC.Enum as Hs
-import qualified Data.Aeson as HsAeson
 import qualified TestProtoImport
  
 data Trivial = Trivial{trivialTrivialField :: Hs.Int32}
@@ -58,11 +57,11 @@ instance HsJSONPB.FromJSONPB Trivial where
           = (HsJSONPB.withObject "Trivial"
                (\ obj -> (Hs.pure Trivial) <*> obj .: "trivialField"))
  
-instance HsAeson.ToJSON Trivial where
+instance HsJSONPB.ToJSON Trivial where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON Trivial where
+instance HsJSONPB.FromJSON Trivial where
         parseJSON = HsJSONPB.parseJSONPB
  
 data MultipleFields = MultipleFields{multipleFieldsMultiFieldDouble
@@ -173,11 +172,11 @@ instance HsJSONPB.FromJSONPB MultipleFields where
                     <*> obj .: "multiFieldString"
                     <*> obj .: "multiFieldBool"))
  
-instance HsAeson.ToJSON MultipleFields where
+instance HsJSONPB.ToJSON MultipleFields where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON MultipleFields where
+instance HsJSONPB.FromJSON MultipleFields where
         parseJSON = HsJSONPB.parseJSONPB
  
 data SignedInts = SignedInts{signedIntsSigned32 :: Hs.Int32,
@@ -229,11 +228,11 @@ instance HsJSONPB.FromJSONPB SignedInts where
                (\ obj ->
                   (Hs.pure SignedInts) <*> obj .: "signed32" <*> obj .: "signed64"))
  
-instance HsAeson.ToJSON SignedInts where
+instance HsJSONPB.ToJSON SignedInts where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON SignedInts where
+instance HsJSONPB.FromJSON SignedInts where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithEnum = WithEnum{withEnumEnumField ::
@@ -268,11 +267,11 @@ instance HsJSONPB.FromJSONPB WithEnum where
           = (HsJSONPB.withObject "WithEnum"
                (\ obj -> (Hs.pure WithEnum) <*> obj .: "enumField"))
  
-instance HsAeson.ToJSON WithEnum where
+instance HsJSONPB.ToJSON WithEnum where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithEnum where
+instance HsJSONPB.FromJSON WithEnum where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithEnum_TestEnum = WithEnum_TestEnumENUM1
@@ -311,11 +310,11 @@ instance HsJSONPB.FromJSONPB WithEnum_TestEnum where
           = Hs.pure WithEnum_TestEnumENUM3
         parseJSONPB v = (HsJSONPB.typeMismatch "WithEnum_TestEnum" v)
  
-instance HsAeson.ToJSON WithEnum_TestEnum where
+instance HsJSONPB.ToJSON WithEnum_TestEnum where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithEnum_TestEnum where
+instance HsJSONPB.FromJSON WithEnum_TestEnum where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithNesting = WithNesting{withNestingNestedMessage ::
@@ -354,11 +353,11 @@ instance HsJSONPB.FromJSONPB WithNesting where
           = (HsJSONPB.withObject "WithNesting"
                (\ obj -> (Hs.pure WithNesting) <*> obj .: "nestedMessage"))
  
-instance HsAeson.ToJSON WithNesting where
+instance HsJSONPB.ToJSON WithNesting where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithNesting where
+instance HsJSONPB.FromJSON WithNesting where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithNesting_Nested = WithNesting_Nested{withNesting_NestedNestedField1
@@ -446,11 +445,11 @@ instance HsJSONPB.FromJSONPB WithNesting_Nested where
                     <*> obj .: "nestedPacked"
                     <*> obj .: "nestedUnpacked"))
  
-instance HsAeson.ToJSON WithNesting_Nested where
+instance HsJSONPB.ToJSON WithNesting_Nested where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithNesting_Nested where
+instance HsJSONPB.FromJSON WithNesting_Nested where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithNestingRepeated = WithNestingRepeated{withNestingRepeatedNestedMessages
@@ -492,11 +491,11 @@ instance HsJSONPB.FromJSONPB WithNestingRepeated where
                (\ obj ->
                   (Hs.pure WithNestingRepeated) <*> obj .: "nestedMessages"))
  
-instance HsAeson.ToJSON WithNestingRepeated where
+instance HsJSONPB.ToJSON WithNestingRepeated where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithNestingRepeated where
+instance HsJSONPB.FromJSON WithNestingRepeated where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithNestingRepeated_Nested = WithNestingRepeated_Nested{withNestingRepeated_NestedNestedField1
@@ -590,11 +589,11 @@ instance HsJSONPB.FromJSONPB WithNestingRepeated_Nested where
                     <*> obj .: "nestedPacked"
                     <*> obj .: "nestedUnpacked"))
  
-instance HsAeson.ToJSON WithNestingRepeated_Nested where
+instance HsJSONPB.ToJSON WithNestingRepeated_Nested where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithNestingRepeated_Nested where
+instance HsJSONPB.FromJSON WithNestingRepeated_Nested where
         parseJSON = HsJSONPB.parseJSONPB
  
 data NestedInts = NestedInts{nestedIntsNestedInt1 :: Hs.Int32,
@@ -645,11 +644,11 @@ instance HsJSONPB.FromJSONPB NestedInts where
                   (Hs.pure NestedInts) <*> obj .: "nestedInt1" <*>
                     obj .: "nestedInt2"))
  
-instance HsAeson.ToJSON NestedInts where
+instance HsJSONPB.ToJSON NestedInts where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON NestedInts where
+instance HsJSONPB.FromJSON NestedInts where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithNestingRepeatedInts = WithNestingRepeatedInts{withNestingRepeatedIntsNestedInts
@@ -691,11 +690,11 @@ instance HsJSONPB.FromJSONPB WithNestingRepeatedInts where
                (\ obj ->
                   (Hs.pure WithNestingRepeatedInts) <*> obj .: "nestedInts"))
  
-instance HsAeson.ToJSON WithNestingRepeatedInts where
+instance HsJSONPB.ToJSON WithNestingRepeatedInts where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithNestingRepeatedInts where
+instance HsJSONPB.FromJSON WithNestingRepeatedInts where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithNestingInts = WithNestingInts{withNestingIntsNestedInts ::
@@ -736,11 +735,11 @@ instance HsJSONPB.FromJSONPB WithNestingInts where
           = (HsJSONPB.withObject "WithNestingInts"
                (\ obj -> (Hs.pure WithNestingInts) <*> obj .: "nestedInts"))
  
-instance HsAeson.ToJSON WithNestingInts where
+instance HsJSONPB.ToJSON WithNestingInts where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithNestingInts where
+instance HsJSONPB.FromJSON WithNestingInts where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithRepetition = WithRepetition{withRepetitionRepeatedField1
@@ -780,11 +779,11 @@ instance HsJSONPB.FromJSONPB WithRepetition where
           = (HsJSONPB.withObject "WithRepetition"
                (\ obj -> (Hs.pure WithRepetition) <*> obj .: "repeatedField1"))
  
-instance HsAeson.ToJSON WithRepetition where
+instance HsJSONPB.ToJSON WithRepetition where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithRepetition where
+instance HsJSONPB.FromJSON WithRepetition where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithFixed = WithFixed{withFixedFixed1 ::
@@ -865,11 +864,11 @@ instance HsJSONPB.FromJSONPB WithFixed where
                     obj .: "fixed3"
                     <*> obj .: "fixed4"))
  
-instance HsAeson.ToJSON WithFixed where
+instance HsJSONPB.ToJSON WithFixed where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithFixed where
+instance HsJSONPB.FromJSON WithFixed where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithBytes = WithBytes{withBytesBytes1 :: Hs.ByteString,
@@ -920,11 +919,11 @@ instance HsJSONPB.FromJSONPB WithBytes where
                (\ obj ->
                   (Hs.pure WithBytes) <*> obj .: "bytes1" <*> obj .: "bytes2"))
  
-instance HsAeson.ToJSON WithBytes where
+instance HsJSONPB.ToJSON WithBytes where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithBytes where
+instance HsJSONPB.FromJSON WithBytes where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithPacking = WithPacking{withPackingPacking1 ::
@@ -979,11 +978,11 @@ instance HsJSONPB.FromJSONPB WithPacking where
                (\ obj ->
                   (Hs.pure WithPacking) <*> obj .: "packing1" <*> obj .: "packing2"))
  
-instance HsAeson.ToJSON WithPacking where
+instance HsJSONPB.ToJSON WithPacking where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithPacking where
+instance HsJSONPB.FromJSON WithPacking where
         parseJSON = HsJSONPB.parseJSONPB
  
 data AllPackedTypes = AllPackedTypes{allPackedTypesPackedWord32 ::
@@ -1176,11 +1175,11 @@ instance HsJSONPB.FromJSONPB AllPackedTypes where
                     <*> obj .: "packedSFixed32"
                     <*> obj .: "packedSFixed64"))
  
-instance HsAeson.ToJSON AllPackedTypes where
+instance HsJSONPB.ToJSON AllPackedTypes where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON AllPackedTypes where
+instance HsJSONPB.FromJSON AllPackedTypes where
         parseJSON = HsJSONPB.parseJSONPB
  
 data OutOfOrderFields = OutOfOrderFields{outOfOrderFieldsField1 ::
@@ -1264,11 +1263,11 @@ instance HsJSONPB.FromJSONPB OutOfOrderFields where
                     <*> obj .: "field3"
                     <*> obj .: "field4"))
  
-instance HsAeson.ToJSON OutOfOrderFields where
+instance HsJSONPB.ToJSON OutOfOrderFields where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON OutOfOrderFields where
+instance HsJSONPB.FromJSON OutOfOrderFields where
         parseJSON = HsJSONPB.parseJSONPB
  
 data ShadowedMessage = ShadowedMessage{shadowedMessageName ::
@@ -1319,11 +1318,11 @@ instance HsJSONPB.FromJSONPB ShadowedMessage where
                (\ obj ->
                   (Hs.pure ShadowedMessage) <*> obj .: "name" <*> obj .: "value"))
  
-instance HsAeson.ToJSON ShadowedMessage where
+instance HsJSONPB.ToJSON ShadowedMessage where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON ShadowedMessage where
+instance HsJSONPB.FromJSON ShadowedMessage where
         parseJSON = HsJSONPB.parseJSONPB
  
 data MessageShadower = MessageShadower{messageShadowerShadowedMessage
@@ -1378,11 +1377,11 @@ instance HsJSONPB.FromJSONPB MessageShadower where
                   (Hs.pure MessageShadower) <*> obj .: "shadowed_message" <*>
                     obj .: "name"))
  
-instance HsAeson.ToJSON MessageShadower where
+instance HsJSONPB.ToJSON MessageShadower where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON MessageShadower where
+instance HsJSONPB.FromJSON MessageShadower where
         parseJSON = HsJSONPB.parseJSONPB
  
 data MessageShadower_ShadowedMessage = MessageShadower_ShadowedMessage{messageShadower_ShadowedMessageName
@@ -1437,11 +1436,11 @@ instance HsJSONPB.FromJSONPB MessageShadower_ShadowedMessage where
                   (Hs.pure MessageShadower_ShadowedMessage) <*> obj .: "name" <*>
                     obj .: "value"))
  
-instance HsAeson.ToJSON MessageShadower_ShadowedMessage where
+instance HsJSONPB.ToJSON MessageShadower_ShadowedMessage where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON MessageShadower_ShadowedMessage where
+instance HsJSONPB.FromJSON MessageShadower_ShadowedMessage where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithQualifiedName = WithQualifiedName{withQualifiedNameQname1
@@ -1501,11 +1500,11 @@ instance HsJSONPB.FromJSONPB WithQualifiedName where
                   (Hs.pure WithQualifiedName) <*> obj .: "qname1" <*>
                     obj .: "qname2"))
  
-instance HsAeson.ToJSON WithQualifiedName where
+instance HsJSONPB.ToJSON WithQualifiedName where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithQualifiedName where
+instance HsJSONPB.FromJSON WithQualifiedName where
         parseJSON = HsJSONPB.parseJSONPB
  
 data UsingImported = UsingImported{usingImportedImportedNesting ::
@@ -1566,11 +1565,11 @@ instance HsJSONPB.FromJSONPB UsingImported where
                   (Hs.pure UsingImported) <*> obj .: "importedNesting" <*>
                     obj .: "localNesting"))
  
-instance HsAeson.ToJSON UsingImported where
+instance HsJSONPB.ToJSON UsingImported where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON UsingImported where
+instance HsJSONPB.FromJSON UsingImported where
         parseJSON = HsJSONPB.parseJSONPB
  
 data Wrapped = Wrapped{wrappedWrapped ::
@@ -1606,9 +1605,9 @@ instance HsJSONPB.FromJSONPB Wrapped where
           = (HsJSONPB.withObject "Wrapped"
                (\ obj -> (Hs.pure Wrapped) <*> obj .: "wrapped"))
  
-instance HsAeson.ToJSON Wrapped where
+instance HsJSONPB.ToJSON Wrapped where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON Wrapped where
+instance HsJSONPB.FromJSON Wrapped where
         parseJSON = HsJSONPB.parseJSONPB

--- a/tests/TestProtoImport.hs
+++ b/tests/TestProtoImport.hs
@@ -24,7 +24,6 @@ import qualified Data.Int as Hs (Int16, Int32, Int64)
 import qualified Data.Word as Hs (Word16, Word32, Word64)
 import qualified GHC.Generics as Hs
 import qualified GHC.Enum as Hs
-import qualified Data.Aeson as HsAeson
  
 data WithNesting = WithNesting{withNestingNestedMessage1 ::
                                Hs.Maybe TestProtoImport.WithNesting_Nested,
@@ -80,11 +79,11 @@ instance HsJSONPB.FromJSONPB WithNesting where
                   (Hs.pure WithNesting) <*> obj .: "nestedMessage1" <*>
                     obj .: "nestedMessage2"))
  
-instance HsAeson.ToJSON WithNesting where
+instance HsJSONPB.ToJSON WithNesting where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithNesting where
+instance HsJSONPB.FromJSON WithNesting where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithNesting_Nested = WithNesting_Nested{withNesting_NestedNestedField1
@@ -137,9 +136,9 @@ instance HsJSONPB.FromJSONPB WithNesting_Nested where
                   (Hs.pure WithNesting_Nested) <*> obj .: "nestedField1" <*>
                     obj .: "nestedField2"))
  
-instance HsAeson.ToJSON WithNesting_Nested where
+instance HsJSONPB.ToJSON WithNesting_Nested where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithNesting_Nested where
+instance HsJSONPB.FromJSON WithNesting_Nested where
         parseJSON = HsJSONPB.parseJSONPB

--- a/tests/TestProtoImport.hs
+++ b/tests/TestProtoImport.hs
@@ -24,6 +24,7 @@ import qualified Data.Int as Hs (Int16, Int32, Int64)
 import qualified Data.Word as Hs (Word16, Word32, Word64)
 import qualified GHC.Generics as Hs
 import qualified GHC.Enum as Hs
+import qualified Data.Aeson as HsAeson
  
 data WithNesting = WithNesting{withNestingNestedMessage1 ::
                                Hs.Maybe TestProtoImport.WithNesting_Nested,
@@ -79,6 +80,13 @@ instance HsJSONPB.FromJSONPB WithNesting where
                   (Hs.pure WithNesting) <*> obj .: "nestedMessage1" <*>
                     obj .: "nestedMessage2"))
  
+instance HsAeson.ToJSON WithNesting where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithNesting where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data WithNesting_Nested = WithNesting_Nested{withNesting_NestedNestedField1
                                              :: Hs.Int32,
                                              withNesting_NestedNestedField2 :: Hs.Int32}
@@ -128,3 +136,10 @@ instance HsJSONPB.FromJSONPB WithNesting_Nested where
                (\ obj ->
                   (Hs.pure WithNesting_Nested) <*> obj .: "nestedField1" <*>
                     obj .: "nestedField2"))
+ 
+instance HsAeson.ToJSON WithNesting_Nested where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithNesting_Nested where
+        parseJSON = HsJSONPB.parseJSONPB

--- a/tests/TestProtoOneof.hs
+++ b/tests/TestProtoOneof.hs
@@ -24,6 +24,7 @@ import qualified Data.Int as Hs (Int16, Int32, Int64)
 import qualified Data.Word as Hs (Word16, Word32, Word64)
 import qualified GHC.Generics as Hs
 import qualified GHC.Enum as Hs
+import qualified Data.Aeson as HsAeson
 import qualified TestProtoOneofImport
  
 data DummyMsg = DummyMsg{dummyMsgDummy :: Hs.Int32}
@@ -57,6 +58,13 @@ instance HsJSONPB.FromJSONPB DummyMsg where
           = (HsJSONPB.withObject "DummyMsg"
                (\ obj -> (Hs.pure DummyMsg) <*> obj .: "dummy"))
  
+instance HsAeson.ToJSON DummyMsg where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON DummyMsg where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data DummyEnum = DummyEnumDUMMY0
                | DummyEnumDUMMY1
                deriving (Hs.Show, Hs.Bounded, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -83,6 +91,13 @@ instance HsJSONPB.FromJSONPB DummyEnum where
         parseJSONPB (HsJSONPB.String "DUMMY0") = Hs.pure DummyEnumDUMMY0
         parseJSONPB (HsJSONPB.String "DUMMY1") = Hs.pure DummyEnumDUMMY1
         parseJSONPB v = (HsJSONPB.typeMismatch "DummyEnum" v)
+ 
+instance HsAeson.ToJSON DummyEnum where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON DummyEnum where
+        parseJSON = HsJSONPB.parseJSONPB
  
 data Something = Something{somethingValue :: Hs.Int64,
                            somethingAnother :: Hs.Int32,
@@ -205,6 +220,13 @@ instance HsJSONPB.FromJSONPB Something where
                          (HsJSONPB.parseField obj "dummyEnum"),
                        Hs.pure Hs.Nothing]))
  
+instance HsAeson.ToJSON Something where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON Something where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data SomethingPickOne = SomethingPickOneName Hs.Text
                       | SomethingPickOneSomeid Hs.Int32
                       | SomethingPickOneDummyMsg1 TestProtoOneof.DummyMsg
@@ -285,6 +307,13 @@ instance HsJSONPB.FromJSONPB OneofFirst where
                          (HsJSONPB.parseField obj "choice2"),
                        Hs.pure Hs.Nothing]
                     <*> obj .: "last"))
+ 
+instance HsAeson.ToJSON OneofFirst where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON OneofFirst where
+        parseJSON = HsJSONPB.parseJSONPB
  
 data OneofFirstFirst = OneofFirstFirstChoice1 Hs.Text
                      | OneofFirstFirstChoice2 Hs.Text
@@ -380,6 +409,13 @@ instance HsJSONPB.FromJSONPB OneofMiddle where
                        Hs.pure Hs.Nothing]
                     <*> obj .: "last"))
  
+instance HsAeson.ToJSON OneofMiddle where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON OneofMiddle where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
 data OneofMiddleMiddle = OneofMiddleMiddleChoice1 Hs.Text
                        | OneofMiddleMiddleChoice2 Hs.Text
                        deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -445,6 +481,13 @@ instance HsJSONPB.FromJSONPB WithImported where
                        Hs.Just Hs.. WithImportedPickOneWithOneof <$>
                          (HsJSONPB.parseField obj "withOneof"),
                        Hs.pure Hs.Nothing]))
+ 
+instance HsAeson.ToJSON WithImported where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithImported where
+        parseJSON = HsJSONPB.parseJSONPB
  
 data WithImportedPickOne = WithImportedPickOneDummyMsg1 TestProtoOneof.DummyMsg
                          | WithImportedPickOneWithOneof TestProtoOneofImport.WithOneof

--- a/tests/TestProtoOneof.hs
+++ b/tests/TestProtoOneof.hs
@@ -24,7 +24,6 @@ import qualified Data.Int as Hs (Int16, Int32, Int64)
 import qualified Data.Word as Hs (Word16, Word32, Word64)
 import qualified GHC.Generics as Hs
 import qualified GHC.Enum as Hs
-import qualified Data.Aeson as HsAeson
 import qualified TestProtoOneofImport
  
 data DummyMsg = DummyMsg{dummyMsgDummy :: Hs.Int32}
@@ -58,11 +57,11 @@ instance HsJSONPB.FromJSONPB DummyMsg where
           = (HsJSONPB.withObject "DummyMsg"
                (\ obj -> (Hs.pure DummyMsg) <*> obj .: "dummy"))
  
-instance HsAeson.ToJSON DummyMsg where
+instance HsJSONPB.ToJSON DummyMsg where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON DummyMsg where
+instance HsJSONPB.FromJSON DummyMsg where
         parseJSON = HsJSONPB.parseJSONPB
  
 data DummyEnum = DummyEnumDUMMY0
@@ -92,11 +91,11 @@ instance HsJSONPB.FromJSONPB DummyEnum where
         parseJSONPB (HsJSONPB.String "DUMMY1") = Hs.pure DummyEnumDUMMY1
         parseJSONPB v = (HsJSONPB.typeMismatch "DummyEnum" v)
  
-instance HsAeson.ToJSON DummyEnum where
+instance HsJSONPB.ToJSON DummyEnum where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON DummyEnum where
+instance HsJSONPB.FromJSON DummyEnum where
         parseJSON = HsJSONPB.parseJSONPB
  
 data Something = Something{somethingValue :: Hs.Int64,
@@ -220,11 +219,11 @@ instance HsJSONPB.FromJSONPB Something where
                          (HsJSONPB.parseField obj "dummyEnum"),
                        Hs.pure Hs.Nothing]))
  
-instance HsAeson.ToJSON Something where
+instance HsJSONPB.ToJSON Something where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON Something where
+instance HsJSONPB.FromJSON Something where
         parseJSON = HsJSONPB.parseJSONPB
  
 data SomethingPickOne = SomethingPickOneName Hs.Text
@@ -308,11 +307,11 @@ instance HsJSONPB.FromJSONPB OneofFirst where
                        Hs.pure Hs.Nothing]
                     <*> obj .: "last"))
  
-instance HsAeson.ToJSON OneofFirst where
+instance HsJSONPB.ToJSON OneofFirst where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON OneofFirst where
+instance HsJSONPB.FromJSON OneofFirst where
         parseJSON = HsJSONPB.parseJSONPB
  
 data OneofFirstFirst = OneofFirstFirstChoice1 Hs.Text
@@ -409,11 +408,11 @@ instance HsJSONPB.FromJSONPB OneofMiddle where
                        Hs.pure Hs.Nothing]
                     <*> obj .: "last"))
  
-instance HsAeson.ToJSON OneofMiddle where
+instance HsJSONPB.ToJSON OneofMiddle where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON OneofMiddle where
+instance HsJSONPB.FromJSON OneofMiddle where
         parseJSON = HsJSONPB.parseJSONPB
  
 data OneofMiddleMiddle = OneofMiddleMiddleChoice1 Hs.Text
@@ -482,11 +481,11 @@ instance HsJSONPB.FromJSONPB WithImported where
                          (HsJSONPB.parseField obj "withOneof"),
                        Hs.pure Hs.Nothing]))
  
-instance HsAeson.ToJSON WithImported where
+instance HsJSONPB.ToJSON WithImported where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithImported where
+instance HsJSONPB.FromJSON WithImported where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithImportedPickOne = WithImportedPickOneDummyMsg1 TestProtoOneof.DummyMsg

--- a/tests/TestProtoOneofImport.hs
+++ b/tests/TestProtoOneofImport.hs
@@ -24,7 +24,6 @@ import qualified Data.Int as Hs (Int16, Int32, Int64)
 import qualified Data.Word as Hs (Word16, Word32, Word64)
 import qualified GHC.Generics as Hs
 import qualified GHC.Enum as Hs
-import qualified Data.Aeson as HsAeson
  
 data WithOneof = WithOneof{withOneofPickOne ::
                            Hs.Maybe WithOneofPickOne}
@@ -81,11 +80,11 @@ instance HsJSONPB.FromJSONPB WithOneof where
                        Hs.Just Hs.. WithOneofPickOneB <$> (HsJSONPB.parseField obj "b"),
                        Hs.pure Hs.Nothing]))
  
-instance HsAeson.ToJSON WithOneof where
+instance HsJSONPB.ToJSON WithOneof where
         toJSON = HsJSONPB.toAesonValue
         toEncoding = HsJSONPB.toAesonEncoding
  
-instance HsAeson.FromJSON WithOneof where
+instance HsJSONPB.FromJSON WithOneof where
         parseJSON = HsJSONPB.parseJSONPB
  
 data WithOneofPickOne = WithOneofPickOneA Hs.Text

--- a/tests/TestProtoOneofImport.hs
+++ b/tests/TestProtoOneofImport.hs
@@ -24,6 +24,7 @@ import qualified Data.Int as Hs (Int16, Int32, Int64)
 import qualified Data.Word as Hs (Word16, Word32, Word64)
 import qualified GHC.Generics as Hs
 import qualified GHC.Enum as Hs
+import qualified Data.Aeson as HsAeson
  
 data WithOneof = WithOneof{withOneofPickOne ::
                            Hs.Maybe WithOneofPickOne}
@@ -79,6 +80,13 @@ instance HsJSONPB.FromJSONPB WithOneof where
                       [Hs.Just Hs.. WithOneofPickOneA <$> (HsJSONPB.parseField obj "a"),
                        Hs.Just Hs.. WithOneofPickOneB <$> (HsJSONPB.parseField obj "b"),
                        Hs.pure Hs.Nothing]))
+ 
+instance HsAeson.ToJSON WithOneof where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsAeson.FromJSON WithOneof where
+        parseJSON = HsJSONPB.parseJSONPB
  
 data WithOneofPickOne = WithOneofPickOneA Hs.Text
                       | WithOneofPickOneB Hs.Int32


### PR DESCRIPTION
This PR extends the code generator to define `aeson` instances for protobuf types, in terms of their generated JSONPB instances. 

This change allows use of generated Haskell types in `aeson` contexts without additional boilerplate.
