### PR TITLE
Generate preliminary `swagger2` schemas for JSONPB encodings

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,10 @@
-{ mkDerivation, aeson, attoparsec, base, base64-bytestring
-, bytestring, cereal, containers, deepseq, doctest, foldl
-, haskell-src, lens, mtl, neat-interpolation, optparse-generic
-, parsec, parsers, pretty, pretty-show, proto3-wire, QuickCheck
-, range-set-list, safe, semigroups, stdenv, system-filepath, tasty
-, tasty-hunit, tasty-quickcheck, text, transformers, turtle, vector
+{ mkDerivation, aeson, aeson-pretty, attoparsec, base
+, base64-bytestring, bytestring, cereal, containers, deepseq
+, doctest, foldl, haskell-src, lens, mtl, neat-interpolation
+, optparse-generic, parsec, parsers, pretty, pretty-show
+, proto3-wire, QuickCheck, range-set-list, safe, semigroups, stdenv
+, swagger2, system-filepath, tasty, tasty-hunit, tasty-quickcheck
+, text, transformers, turtle, vector
 }:
 mkDerivation {
   pname = "proto3-suite";
@@ -12,10 +13,11 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson attoparsec base base64-bytestring bytestring cereal
-    containers deepseq foldl haskell-src lens mtl neat-interpolation
-    parsec parsers pretty pretty-show proto3-wire QuickCheck safe
-    semigroups system-filepath text transformers turtle vector
+    aeson aeson-pretty attoparsec base base64-bytestring bytestring
+    cereal containers deepseq foldl haskell-src lens mtl
+    neat-interpolation parsec parsers pretty pretty-show proto3-wire
+    QuickCheck safe semigroups swagger2 system-filepath text
+    transformers turtle vector
   ];
   executableHaskellDepends = [
     base containers optparse-generic proto3-wire range-set-list

--- a/nix/aeson-pretty.nix
+++ b/nix/aeson-pretty.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, aeson, attoparsec, base, base-compat, bytestring
+, cmdargs, scientific, stdenv, text, unordered-containers, vector
+}:
+mkDerivation {
+  pname = "aeson-pretty";
+  version = "0.8.2";
+  sha256 = "1c5r1w1hcv297pmj9yjpz9al22k3mh61gimi37wddga02212kd3c";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson base base-compat bytestring scientific text
+    unordered-containers vector
+  ];
+  executableHaskellDepends = [
+    aeson attoparsec base bytestring cmdargs
+  ];
+  homepage = "http://github.com/informatikr/aeson-pretty";
+  description = "JSON pretty-printing library and command-line tool";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/cabal-doctest.nix
+++ b/nix/cabal-doctest.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, base, Cabal, directory, filepath, stdenv }:
+mkDerivation {
+  pname = "cabal-doctest";
+  version = "1.0.2";
+  sha256 = "0h3wsjf2mg8kw1zvxc0f9nzchj5kzvza9z0arcyixkd9rkgqq6sa";
+  libraryHaskellDepends = [ base Cabal directory filepath ];
+  homepage = "https://github.com/phadej/cabal-doctest";
+  description = "A Setup.hs helper for doctests running";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/insert-ordered-containers.nix
+++ b/nix/insert-ordered-containers.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, aeson, base, base-compat, hashable, lens
+, QuickCheck, semigroupoids, semigroups, stdenv, tasty
+, tasty-quickcheck, text, transformers, unordered-containers
+}:
+mkDerivation {
+  pname = "insert-ordered-containers";
+  version = "0.2.1.0";
+  sha256 = "1612f455dw37da9g7bsd1s5kyi84mnr1ifnjw69892amyimi47fp";
+  revision = "3";
+  editedCabalFile = "6fdce987672b006226243aa17522b57ec7a9e1cab247802eddbdaa9dc5b06446";
+  libraryHaskellDepends = [
+    aeson base base-compat hashable lens semigroupoids semigroups text
+    transformers unordered-containers
+  ];
+  testHaskellDepends = [
+    aeson base base-compat hashable lens QuickCheck semigroupoids
+    semigroups tasty tasty-quickcheck text transformers
+    unordered-containers
+  ];
+  homepage = "https://github.com/phadej/insert-ordered-containers#readme";
+  description = "Associative containers retating insertion order for traversals";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/swagger2.nix
+++ b/nix/swagger2.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, aeson, aeson-qq, base, base-compat, bytestring
+, Cabal, cabal-doctest, containers, doctest, generics-sop, Glob
+, hashable, hspec, http-media, HUnit, insert-ordered-containers
+, lens, mtl, network, QuickCheck, scientific, stdenv
+, template-haskell, text, time, transformers, transformers-compat
+, unordered-containers, uuid-types, vector
+}:
+mkDerivation {
+  pname = "swagger2";
+  version = "2.1.6";
+  sha256 = "01a29h56vfyw0ilij1pn6qwy50ca90kyj884vs1q52vvh572758j";
+  setupHaskellDepends = [ base Cabal cabal-doctest ];
+  libraryHaskellDepends = [
+    aeson base base-compat bytestring containers generics-sop hashable
+    http-media insert-ordered-containers lens mtl network scientific
+    template-haskell text time transformers transformers-compat
+    unordered-containers uuid-types vector
+  ];
+  testHaskellDepends = [
+    aeson aeson-qq base base-compat bytestring containers doctest Glob
+    hashable hspec HUnit insert-ordered-containers lens mtl QuickCheck
+    text time unordered-containers vector
+  ];
+  homepage = "https://github.com/GetShopTV/swagger2";
+  description = "Swagger 2.0 data model";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -22,8 +22,10 @@ library
                        Proto3.Suite.Tutorial
                        Proto3.Suite.Types
   other-modules:       Proto3.Suite.DotProto.Internal
+                       Proto3.Suite.DotProto.Generate.Swagger
                        Proto3.Suite.JSONPB.Class
   build-depends:       aeson == 1.1.1.0,
+                       aeson-pretty,
                        attoparsec >= 0.13.0.1,
                        base >=4.8 && <5.0,
                        base64-bytestring >= 1.0.0.1 && < 1.1,
@@ -42,8 +44,9 @@ library
                        pretty-show >= 1.6.12 && < 1.7,
                        proto3-wire == 1.0.*,
                        QuickCheck >=2.8 && <2.10,
-                       semigroups ==0.18.*,
                        safe ==0.3.*,
+                       semigroups ==0.18.*,
+                       swagger2,
                        system-filepath,
                        text >= 0.2 && <1.3,
                        transformers >=0.4 && <0.6,

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -46,7 +46,7 @@ library
                        QuickCheck >=2.8 && <2.10,
                        safe ==0.3.*,
                        semigroups ==0.18.*,
-                       swagger2,
+                       swagger2 == 2.1.6,
                        system-filepath,
                        text >= 0.2 && <1.3,
                        transformers >=0.4 && <0.6,

--- a/release.nix
+++ b/release.nix
@@ -23,6 +23,15 @@ let
               aeson =
                 pkgs.haskell.lib.dontCheck (haskellPackagesNew.callPackage ./nix/aeson.nix { });
 
+              aeson-pretty =
+                haskellPackagesNew.callPackage ./nix/aeson-pretty.nix { };
+
+              cabal-doctest =
+                haskellPackagesNew.callPackage ./nix/cabal-doctest.nix { };
+
+              insert-ordered-containers =
+                haskellPackagesNew.callPackage ./nix/insert-ordered-containers.nix { };
+
               neat-interpolation =
                 haskellPackagesNew.callPackage ./nix/neat-interpolation.nix { };
 
@@ -62,6 +71,9 @@ let
 
               scientific =
                 pkgs.haskell.lib.dontCheck haskellPackagesOld.scientific;
+
+              swagger2 =
+                pkgs.haskell.lib.dontHaddock (haskellPackagesNew.callPackage ./nix/swagger2.nix { });
 
               turtle =
                 haskellPackagesNew.callPackage ./nix/turtle.nix { } ;

--- a/src/Proto3/Suite/DotProto/Generate/Swagger.hs
+++ b/src/Proto3/Suite/DotProto/Generate/Swagger.hs
@@ -1,0 +1,21 @@
+-- | This module provides helper functions to generate Swagger schemas which
+-- describe JSONPB encodings for protobuf types.
+
+module Proto3.Suite.DotProto.Generate.Swagger
+  ( ppSchema
+  )
+where
+
+import           Data.Aeson.Encode.Pretty        (encodePretty)
+import qualified Data.ByteString.Lazy.Char8      as LC8
+import           Data.Swagger
+-- import qualified Data.Swagger.Declare            as Swagger
+-- import qualified Data.Swagger.Internal.Schema    as Swagger.Internal
+-- import qualified Data.Swagger.Internal.TypeShape as Swagger.Internal
+
+-- | Pretty-prints a schema. Useful when playing around with schemas in the
+-- REPL.
+--
+-- >>> ppSchema (Proxy @Enumerated MyEnum))
+ppSchema :: ToSchema a => proxy a -> IO ()
+ppSchema = LC8.putStrLn . encodePretty . toSchema

--- a/src/Proto3/Suite/DotProto/Generate/Swagger.hs
+++ b/src/Proto3/Suite/DotProto/Generate/Swagger.hs
@@ -1,21 +1,103 @@
--- | This module provides helper functions to generate Swagger schemas which
--- describe JSONPB encodings for protobuf types.
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- | This module provides helper functions to generate Swagger schemas that
+-- describe JSONPB encodings for protobuf types.
 module Proto3.Suite.DotProto.Generate.Swagger
-  ( ppSchema
+  ( ToSchema(..)
+  , genericDeclareNamedSchemaJSONPB
+  , ppSchema
   )
 where
 
+import           Control.Lens                    (over, set, (&), (.~), (?~))
+import           Control.Lens.Cons               (_head)
+import           Data.Aeson                      (Value (String))
 import           Data.Aeson.Encode.Pretty        (encodePretty)
+import qualified Data.ByteString                 as BS
 import qualified Data.ByteString.Lazy.Char8      as LC8
+import           Data.Char                       (toLower)
+import           Data.Functor.Identity           (Identity)
 import           Data.Swagger
--- import qualified Data.Swagger.Declare            as Swagger
--- import qualified Data.Swagger.Internal.Schema    as Swagger.Internal
--- import qualified Data.Swagger.Internal.TypeShape as Swagger.Internal
+import qualified Data.Swagger.Declare            as Swagger
+import qualified Data.Swagger.Internal.Schema    as Swagger.Internal
+import qualified Data.Swagger.Internal.TypeShape as Swagger.Internal
+import qualified Data.Text                       as T
+import           Data.Proxy
+import qualified Data.Vector                     as V
+import           GHC.Generics
+import           GHC.Int
+import           GHC.Word
+import           Proto3.Suite                    (Enumerated (..), Finite (..),
+                                                  Fixed (..), Named (..), enumerate)
+
+genericDeclareNamedSchemaJSONPB :: forall a proxy.
+                                   ( Generic a
+                                   , Named a
+                                   , Swagger.Internal.GenericHasSimpleShape a
+                                       "genericDeclareNamedSchemaUnrestricted"
+                                       (Swagger.Internal.GenericShape (Rep a))
+                                   , Swagger.Internal.GToSchema (Rep a)
+                                   )
+                                => proxy a
+                                -> Swagger.DeclareT (Definitions Schema) Identity NamedSchema
+genericDeclareNamedSchemaJSONPB proxy =
+  over schema (set required []) <$> genericDeclareNamedSchema opts proxy
+  where
+    opts = defaultSchemaOptions{
+             fieldLabelModifier = over _head toLower
+                                . drop (T.length (nameOf (Proxy @a)))
+           }
 
 -- | Pretty-prints a schema. Useful when playing around with schemas in the
 -- REPL.
---
--- >>> ppSchema (Proxy @Enumerated MyEnum))
 ppSchema :: ToSchema a => proxy a -> IO ()
 ppSchema = LC8.putStrLn . encodePretty . toSchema
+
+-- | This orphan instance prevents Generic-based deriving mechanism from
+-- throwing error on 'ToSchema' for 'ByteString' and instead defaults to
+-- 'byteSchema'. It is a damn dirty hack, but very handy, as per:
+-- https://github.com/GetShopTV/swagger2/issues/51
+instance Swagger.Internal.GToSchema (K1 i BS.ByteString) where
+  gdeclareNamedSchema _ _ _ = pure
+                            $ NamedSchema Nothing
+                            $ byteSchema
+
+-- | This orphan instance prevents Generic-based deriving mechanism from
+-- throwing error on 'ToSchema' for 'V.Vector ByteString' and instead defaults
+-- to (an array of) 'byteSchema'. It is a damn dirty hack, but very handy, as
+-- per: https://github.com/GetShopTV/swagger2/issues/51
+instance Swagger.Internal.GToSchema (K1 i (V.Vector BS.ByteString)) where
+  gdeclareNamedSchema _ _ _ = pure
+                            $ NamedSchema Nothing
+                            $ mempty
+                                & type_ .~ SwaggerArray
+                                & items ?~ SwaggerItemsObject (Inline byteSchema)
+
+-- | JSONPB schemas for protobuf enumerations
+instance (Finite e, Named e) => ToSchema (Enumerated e) where
+  declareNamedSchema _ = do
+    let enumName        = nameOf (Proxy @e)
+    let dropPrefix      = T.drop (T.length enumName)
+    let enumMemberNames = dropPrefix . fst <$> enumerate (Proxy @e)
+    return $ NamedSchema (Just enumName)
+           $ mempty
+             & type_ .~ SwaggerString
+             & enum_ ?~ fmap String enumMemberNames
+
+instance ToSchema (Fixed Int32) where
+  declareNamedSchema _ = declareNamedSchema (Proxy @Int32)
+
+instance ToSchema (Fixed Int64) where
+  declareNamedSchema _ = declareNamedSchema (Proxy @Int64)
+
+instance ToSchema (Fixed Word32) where
+  declareNamedSchema _ = declareNamedSchema (Proxy @Word32)
+
+instance ToSchema (Fixed Word64) where
+  declareNamedSchema _ = declareNamedSchema (Proxy @Word64)

--- a/src/Proto3/Suite/JSONPB.hs
+++ b/src/Proto3/Suite/JSONPB.hs
@@ -27,9 +27,14 @@ module Proto3.Suite.JSONPB
   , A.FromJSON(..)
   , A.typeMismatch
   , A.withObject
+    -- * Swagger schema helpers
+  , Swagger.ToSchema(..)
+  , Swagger.genericDeclareNamedSchemaJSONPB
+  ,
   )
 where
 
-import qualified Data.Aeson                    as A
-import qualified Data.Aeson.Types              as A
+import qualified Data.Aeson                             as A
+import qualified Data.Aeson.Types                       as A
+import qualified Proto3.Suite.DotProto.Generate.Swagger as Swagger
 import           Proto3.Suite.JSONPB.Class

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,8 +8,12 @@ packages:
   extra-dep: true
 
 extra-deps: [ aeson-1.1.1.0
+            , aeson-pretty-0.8.2
+            , cabal-doctest-1.0.2
+            , insert-ordered-containers-0.2.1.0
             , neat-interpolation-0.3.2.1
             , optparse-applicative-0.13.2.0
             , optparse-generic-1.2.1
+            , swagger2-2.1.6
             , turtle-1.3.6
             ]

--- a/tests/TestProto.hs
+++ b/tests/TestProto.hs
@@ -64,6 +64,9 @@ instance HsJSONPB.ToJSON Trivial where
 instance HsJSONPB.FromJSON Trivial where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema Trivial where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data MultipleFields = MultipleFields{multipleFieldsMultiFieldDouble
                                      :: Hs.Double,
                                      multipleFieldsMultiFieldFloat :: Hs.Float,
@@ -179,6 +182,9 @@ instance HsJSONPB.ToJSON MultipleFields where
 instance HsJSONPB.FromJSON MultipleFields where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema MultipleFields where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data SignedInts = SignedInts{signedIntsSigned32 :: Hs.Int32,
                              signedIntsSigned64 :: Hs.Int64}
                 deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -235,6 +241,9 @@ instance HsJSONPB.ToJSON SignedInts where
 instance HsJSONPB.FromJSON SignedInts where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema SignedInts where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data WithEnum = WithEnum{withEnumEnumField ::
                          HsProtobuf.Enumerated TestProto.WithEnum_TestEnum}
               deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -273,6 +282,9 @@ instance HsJSONPB.ToJSON WithEnum where
  
 instance HsJSONPB.FromJSON WithEnum where
         parseJSON = HsJSONPB.parseJSONPB
+ 
+instance HsJSONPB.ToSchema WithEnum where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
  
 data WithEnum_TestEnum = WithEnum_TestEnumENUM1
                        | WithEnum_TestEnumENUM2
@@ -317,6 +329,8 @@ instance HsJSONPB.ToJSON WithEnum_TestEnum where
 instance HsJSONPB.FromJSON WithEnum_TestEnum where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsProtobuf.Finite WithEnum_TestEnum
+ 
 data WithNesting = WithNesting{withNestingNestedMessage ::
                                Hs.Maybe TestProto.WithNesting_Nested}
                  deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -359,6 +373,9 @@ instance HsJSONPB.ToJSON WithNesting where
  
 instance HsJSONPB.FromJSON WithNesting where
         parseJSON = HsJSONPB.parseJSONPB
+ 
+instance HsJSONPB.ToSchema WithNesting where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
  
 data WithNesting_Nested = WithNesting_Nested{withNesting_NestedNestedField1
                                              :: Hs.Text,
@@ -452,6 +469,9 @@ instance HsJSONPB.ToJSON WithNesting_Nested where
 instance HsJSONPB.FromJSON WithNesting_Nested where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema WithNesting_Nested where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data WithNestingRepeated = WithNestingRepeated{withNestingRepeatedNestedMessages
                                                :: Hs.Vector TestProto.WithNestingRepeated_Nested}
                          deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -497,6 +517,9 @@ instance HsJSONPB.ToJSON WithNestingRepeated where
  
 instance HsJSONPB.FromJSON WithNestingRepeated where
         parseJSON = HsJSONPB.parseJSONPB
+ 
+instance HsJSONPB.ToSchema WithNestingRepeated where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
  
 data WithNestingRepeated_Nested = WithNestingRepeated_Nested{withNestingRepeated_NestedNestedField1
                                                              :: Hs.Text,
@@ -596,6 +619,9 @@ instance HsJSONPB.ToJSON WithNestingRepeated_Nested where
 instance HsJSONPB.FromJSON WithNestingRepeated_Nested where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema WithNestingRepeated_Nested where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data NestedInts = NestedInts{nestedIntsNestedInt1 :: Hs.Int32,
                              nestedIntsNestedInt2 :: Hs.Int32}
                 deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -651,6 +677,9 @@ instance HsJSONPB.ToJSON NestedInts where
 instance HsJSONPB.FromJSON NestedInts where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema NestedInts where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data WithNestingRepeatedInts = WithNestingRepeatedInts{withNestingRepeatedIntsNestedInts
                                                        :: Hs.Vector TestProto.NestedInts}
                              deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -697,6 +726,9 @@ instance HsJSONPB.ToJSON WithNestingRepeatedInts where
 instance HsJSONPB.FromJSON WithNestingRepeatedInts where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema WithNestingRepeatedInts where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data WithNestingInts = WithNestingInts{withNestingIntsNestedInts ::
                                        Hs.Maybe TestProto.NestedInts}
                      deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -742,6 +774,9 @@ instance HsJSONPB.ToJSON WithNestingInts where
 instance HsJSONPB.FromJSON WithNestingInts where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema WithNestingInts where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data WithRepetition = WithRepetition{withRepetitionRepeatedField1
                                      :: Hs.Vector Hs.Int32}
                     deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -785,6 +820,9 @@ instance HsJSONPB.ToJSON WithRepetition where
  
 instance HsJSONPB.FromJSON WithRepetition where
         parseJSON = HsJSONPB.parseJSONPB
+ 
+instance HsJSONPB.ToSchema WithRepetition where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
  
 data WithFixed = WithFixed{withFixedFixed1 ::
                            HsProtobuf.Fixed Hs.Word32,
@@ -871,6 +909,9 @@ instance HsJSONPB.ToJSON WithFixed where
 instance HsJSONPB.FromJSON WithFixed where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema WithFixed where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data WithBytes = WithBytes{withBytesBytes1 :: Hs.ByteString,
                            withBytesBytes2 :: Hs.Vector Hs.ByteString}
                deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -925,6 +966,9 @@ instance HsJSONPB.ToJSON WithBytes where
  
 instance HsJSONPB.FromJSON WithBytes where
         parseJSON = HsJSONPB.parseJSONPB
+ 
+instance HsJSONPB.ToSchema WithBytes where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
  
 data WithPacking = WithPacking{withPackingPacking1 ::
                                Hs.Vector Hs.Int32,
@@ -984,6 +1028,9 @@ instance HsJSONPB.ToJSON WithPacking where
  
 instance HsJSONPB.FromJSON WithPacking where
         parseJSON = HsJSONPB.parseJSONPB
+ 
+instance HsJSONPB.ToSchema WithPacking where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
  
 data AllPackedTypes = AllPackedTypes{allPackedTypesPackedWord32 ::
                                      Hs.Vector Hs.Word32,
@@ -1182,6 +1229,9 @@ instance HsJSONPB.ToJSON AllPackedTypes where
 instance HsJSONPB.FromJSON AllPackedTypes where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema AllPackedTypes where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data OutOfOrderFields = OutOfOrderFields{outOfOrderFieldsField1 ::
                                          Hs.Vector Hs.Word32,
                                          outOfOrderFieldsField2 :: Hs.Text,
@@ -1270,6 +1320,9 @@ instance HsJSONPB.ToJSON OutOfOrderFields where
 instance HsJSONPB.FromJSON OutOfOrderFields where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema OutOfOrderFields where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data ShadowedMessage = ShadowedMessage{shadowedMessageName ::
                                        Hs.Text,
                                        shadowedMessageValue :: Hs.Int32}
@@ -1324,6 +1377,9 @@ instance HsJSONPB.ToJSON ShadowedMessage where
  
 instance HsJSONPB.FromJSON ShadowedMessage where
         parseJSON = HsJSONPB.parseJSONPB
+ 
+instance HsJSONPB.ToSchema ShadowedMessage where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
  
 data MessageShadower = MessageShadower{messageShadowerShadowedMessage
                                        :: Hs.Maybe TestProto.MessageShadower_ShadowedMessage,
@@ -1384,6 +1440,9 @@ instance HsJSONPB.ToJSON MessageShadower where
 instance HsJSONPB.FromJSON MessageShadower where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema MessageShadower where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data MessageShadower_ShadowedMessage = MessageShadower_ShadowedMessage{messageShadower_ShadowedMessageName
                                                                        :: Hs.Text,
                                                                        messageShadower_ShadowedMessageValue
@@ -1442,6 +1501,9 @@ instance HsJSONPB.ToJSON MessageShadower_ShadowedMessage where
  
 instance HsJSONPB.FromJSON MessageShadower_ShadowedMessage where
         parseJSON = HsJSONPB.parseJSONPB
+ 
+instance HsJSONPB.ToSchema MessageShadower_ShadowedMessage where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
  
 data WithQualifiedName = WithQualifiedName{withQualifiedNameQname1
                                            :: Hs.Maybe TestProto.ShadowedMessage,
@@ -1506,6 +1568,9 @@ instance HsJSONPB.ToJSON WithQualifiedName where
  
 instance HsJSONPB.FromJSON WithQualifiedName where
         parseJSON = HsJSONPB.parseJSONPB
+ 
+instance HsJSONPB.ToSchema WithQualifiedName where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
  
 data UsingImported = UsingImported{usingImportedImportedNesting ::
                                    Hs.Maybe TestProtoImport.WithNesting,
@@ -1572,6 +1637,9 @@ instance HsJSONPB.ToJSON UsingImported where
 instance HsJSONPB.FromJSON UsingImported where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema UsingImported where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data Wrapped = Wrapped{wrappedWrapped ::
                        Hs.Maybe TestProto.Wrapped}
              deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -1611,3 +1679,6 @@ instance HsJSONPB.ToJSON Wrapped where
  
 instance HsJSONPB.FromJSON Wrapped where
         parseJSON = HsJSONPB.parseJSONPB
+ 
+instance HsJSONPB.ToSchema Wrapped where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB

--- a/tests/TestProtoImport.hs
+++ b/tests/TestProtoImport.hs
@@ -86,6 +86,9 @@ instance HsJSONPB.ToJSON WithNesting where
 instance HsJSONPB.FromJSON WithNesting where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema WithNesting where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data WithNesting_Nested = WithNesting_Nested{withNesting_NestedNestedField1
                                              :: Hs.Int32,
                                              withNesting_NestedNestedField2 :: Hs.Int32}
@@ -142,3 +145,6 @@ instance HsJSONPB.ToJSON WithNesting_Nested where
  
 instance HsJSONPB.FromJSON WithNesting_Nested where
         parseJSON = HsJSONPB.parseJSONPB
+ 
+instance HsJSONPB.ToSchema WithNesting_Nested where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB

--- a/tests/TestProtoOneof.hs
+++ b/tests/TestProtoOneof.hs
@@ -64,6 +64,9 @@ instance HsJSONPB.ToJSON DummyMsg where
 instance HsJSONPB.FromJSON DummyMsg where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema DummyMsg where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data DummyEnum = DummyEnumDUMMY0
                | DummyEnumDUMMY1
                deriving (Hs.Show, Hs.Bounded, Hs.Eq, Hs.Ord, Hs.Generic)
@@ -97,6 +100,8 @@ instance HsJSONPB.ToJSON DummyEnum where
  
 instance HsJSONPB.FromJSON DummyEnum where
         parseJSON = HsJSONPB.parseJSONPB
+ 
+instance HsProtobuf.Finite DummyEnum
  
 data Something = Something{somethingValue :: Hs.Int64,
                            somethingAnother :: Hs.Int32,
@@ -226,6 +231,9 @@ instance HsJSONPB.ToJSON Something where
 instance HsJSONPB.FromJSON Something where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema Something where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data SomethingPickOne = SomethingPickOneName Hs.Text
                       | SomethingPickOneSomeid Hs.Int32
                       | SomethingPickOneDummyMsg1 TestProtoOneof.DummyMsg
@@ -233,6 +241,12 @@ data SomethingPickOne = SomethingPickOneName Hs.Text
                       | SomethingPickOneDummyEnum (HsProtobuf.Enumerated
                                                      TestProtoOneof.DummyEnum)
                       deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+ 
+instance HsProtobuf.Named SomethingPickOne where
+        nameOf _ = (Hs.fromString "SomethingPickOne")
+ 
+instance HsJSONPB.ToSchema SomethingPickOne where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
  
 data OneofFirst = OneofFirst{oneofFirstFirst ::
                              Hs.Maybe OneofFirstFirst,
@@ -314,9 +328,18 @@ instance HsJSONPB.ToJSON OneofFirst where
 instance HsJSONPB.FromJSON OneofFirst where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema OneofFirst where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data OneofFirstFirst = OneofFirstFirstChoice1 Hs.Text
                      | OneofFirstFirstChoice2 Hs.Text
                      deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+ 
+instance HsProtobuf.Named OneofFirstFirst where
+        nameOf _ = (Hs.fromString "OneofFirstFirst")
+ 
+instance HsJSONPB.ToSchema OneofFirstFirst where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
  
 data OneofMiddle = OneofMiddle{oneofMiddleFirst :: Hs.Int32,
                                oneofMiddleMiddle :: Hs.Maybe OneofMiddleMiddle,
@@ -415,9 +438,18 @@ instance HsJSONPB.ToJSON OneofMiddle where
 instance HsJSONPB.FromJSON OneofMiddle where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema OneofMiddle where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data OneofMiddleMiddle = OneofMiddleMiddleChoice1 Hs.Text
                        | OneofMiddleMiddleChoice2 Hs.Text
                        deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+ 
+instance HsProtobuf.Named OneofMiddleMiddle where
+        nameOf _ = (Hs.fromString "OneofMiddleMiddle")
+ 
+instance HsJSONPB.ToSchema OneofMiddleMiddle where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
  
 data WithImported = WithImported{withImportedPickOne ::
                                  Hs.Maybe WithImportedPickOne}
@@ -488,6 +520,15 @@ instance HsJSONPB.ToJSON WithImported where
 instance HsJSONPB.FromJSON WithImported where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema WithImported where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data WithImportedPickOne = WithImportedPickOneDummyMsg1 TestProtoOneof.DummyMsg
                          | WithImportedPickOneWithOneof TestProtoOneofImport.WithOneof
                          deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+ 
+instance HsProtobuf.Named WithImportedPickOne where
+        nameOf _ = (Hs.fromString "WithImportedPickOne")
+ 
+instance HsJSONPB.ToSchema WithImportedPickOne where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB

--- a/tests/TestProtoOneofImport.hs
+++ b/tests/TestProtoOneofImport.hs
@@ -87,6 +87,15 @@ instance HsJSONPB.ToJSON WithOneof where
 instance HsJSONPB.FromJSON WithOneof where
         parseJSON = HsJSONPB.parseJSONPB
  
+instance HsJSONPB.ToSchema WithOneof where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
 data WithOneofPickOne = WithOneofPickOneA Hs.Text
                       | WithOneofPickOneB Hs.Int32
                       deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+ 
+instance HsProtobuf.Named WithOneofPickOne where
+        nameOf _ = (Hs.fromString "WithOneofPickOne")
+ 
+instance HsJSONPB.ToSchema WithOneofPickOne where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB


### PR DESCRIPTION
This PR implements preliminary [`swagger2`](https://hackage.haskell.org/package/swagger2-2.1.6) schema generation for JSONPB encodings of protobuf types.

E.g., given:

```
message MultipleFields {
  double multiFieldDouble = 1;
  float  multiFieldFloat  = 2;
  int32  multiFieldInt32  = 3;
  int64  multiFieldInt64  = 4;
  string multiFieldString = 5;
  bool   multiFieldBool   = 6;
}
```

We'll generate:

```
λ> ppSchema (Proxy @MultipleFields)
{
    "type": "object",
    "properties": {
        "multiFieldInt64": {
            "maximum": 9223372036854775807,
            "format": "int64",
            "minimum": -9223372036854775808,
            "type": "integer"
        },
        "multiFieldString": {
            "type": "string"
        },
        "multiFieldDouble": {
            "format": "double",
            "type": "number"
        },
        "multiFieldInt32": {
            "maximum": 2147483647,
            "format": "int32",
            "minimum": -2147483648,
            "type": "integer"
        },
        "multiFieldBool": {
            "type": "boolean"
        },
        "multiFieldFloat": {
            "format": "float",
            "type": "number"
        }
    }
}
```
