### PR TITLE
Parse options for enum types

### DIFF
--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -261,7 +261,7 @@ class Enum a => Finite a where
 enum :: (Finite e, Named e) => Proxy e -> DotProtoDefinition
 enum pr = DotProtoEnum (Single $ nameOf pr) (map enumField $ enumerate pr)
   where
-    enumField (name, value) = DotProtoEnumField (Single name) value
+    enumField (name, value) = DotProtoEnumField (Single name) value []
 
 class GenericFinite (f :: * -> *) where
   genericEnumerate :: IsString string => Proxy f -> Int -> (Int, [(string, Int)])

--- a/src/Proto3/Suite/DotProto/AST.hs
+++ b/src/Proto3/Suite/DotProto/AST.hs
@@ -263,7 +263,7 @@ instance Arbitrary DotProtoType where
 type DotProtoEnumValue = Int
 
 data DotProtoEnumPart
-  = DotProtoEnumField DotProtoIdentifier DotProtoEnumValue -- [DotProtoOption]
+  = DotProtoEnumField DotProtoIdentifier DotProtoEnumValue [DotProtoOption]
   | DotProtoEnumOption DotProtoOption
   | DotProtoEnumEmpty
   deriving (Show, Eq)
@@ -274,7 +274,8 @@ instance Arbitrary DotProtoEnumPart where
       arbitraryField = do
         identifier <- arbitraryIdentifier
         enumValue  <- arbitrary
-        return (DotProtoEnumField identifier enumValue)
+        opts       <- arbitrary
+        return (DotProtoEnumField identifier enumValue opts)
 
       arbitraryOption = do
         option <- arbitrary

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -1005,6 +1005,7 @@ dotProtoEnumD parentIdent enumIdent enumParts =
                           | DotProtoEnumField conIdent i _options <- enumParts ]
 
      let enumNameE = HsLit (HsString enumName)
+         -- TODO assert that there is more than one enumeration constructor
          ((minEnumVal, maxEnumVal), enumConNames) = first (minimum &&& maximum) $ unzip enumCons
 
          boundsE = HsTuple
@@ -1047,10 +1048,7 @@ dotProtoEnumD parentIdent enumIdent enumParts =
          parseJSONPBDecls =
            [ let pat nm =
                    HsPApp (jsonpbName "String")
-                     [ HsPLit (HsString (case stripPrefix enumName nm of
-                                           Just s  -> s
-                                           Nothing -> nm))
-                     ]
+                     [ HsPLit (HsString (fromMaybe <*> stripPrefix enumName $ nm)) ]
              in
              match_ (HsIdent "parseJSONPB") [pat conName]
                     (HsUnGuardedRhs

--- a/src/Proto3/Suite/DotProto/Parsing.hs
+++ b/src/Proto3/Suite/DotProto/Parsing.hs
@@ -382,8 +382,10 @@ enumField = do fname <- identifier
                whiteSpace
                fpos <- fromInteger <$> integer
                whiteSpace
+               opts <- optionAnnotation
+               whiteSpace
                string ";"
-               return $ DotProtoEnumField fname fpos
+               return $ DotProtoEnumField fname fpos opts
 
 
 enumStatement :: Parser DotProtoEnumPart

--- a/src/Proto3/Suite/DotProto/Rendering.hs
+++ b/src/Proto3/Suite/DotProto/Rendering.hs
@@ -127,9 +127,16 @@ prettyPrintProtoDefinition opts = defn where
   field _ DotProtoEmptyField = PP.empty
 
   enumPart :: DotProtoIdentifier -> DotProtoEnumPart -> PP.Doc
-  enumPart msgName (DotProtoEnumField name value) = roEnumMemberName opts msgName name <+> PP.text "=" <+> pPrint value <> PP.text ";"
-  enumPart _       (DotProtoEnumOption opt)       = PP.text "option" <+> pPrint opt <> PP.text ";"
-  enumPart _       DotProtoEnumEmpty              = PP.empty
+  enumPart msgName (DotProtoEnumField name value options)
+    = roEnumMemberName opts msgName name
+    <+> PP.text "="
+    <+> pPrint value
+    <+> optionAnnotation options
+    <> PP.text ";"
+  enumPart _       (DotProtoEnumOption opt)
+    = PP.text "option" <+> pPrint opt <> PP.text ";"
+  enumPart _       DotProtoEnumEmpty
+    = PP.empty
 
 instance Pretty DotProtoServicePart where
   pPrint (DotProtoServiceRPC name (callname, callstrm) (retname, retstrm) options)

--- a/test-files/test_proto.proto
+++ b/test-files/test_proto.proto
@@ -136,6 +136,7 @@ message Wrapped {
   Wrapped wrapped = 1;
 }
 
-message Deprecated {
-  string randomField = 1 [deprecated=true];
+enum EnumAnnots {
+  FOO = 1337 [myOption = "hello world"];
+  BAR = 1701 [deprecated=true];
 }

--- a/test-files/test_proto.proto
+++ b/test-files/test_proto.proto
@@ -137,6 +137,6 @@ message Wrapped {
 }
 
 enum EnumAnnots {
-  FOO = 1337 [myOption = "hello world"];
-  BAR = 1701 [deprecated=true];
+  FOO = 0;
+  BAR = 1 [deprecated=true];
 }

--- a/test-files/test_proto.proto
+++ b/test-files/test_proto.proto
@@ -135,3 +135,7 @@ message UsingImported {
 message Wrapped {
   Wrapped wrapped = 1;
 }
+
+message Deprecated {
+  string randomField = 1 [deprecated=true];
+}

--- a/tests/TestCodeGen.hs
+++ b/tests/TestCodeGen.hs
@@ -113,7 +113,7 @@ simpleDecodeDotProto =
 dumpAST :: [FilePath] -> FilePath -> IO ()
 dumpAST incs fp = do
   Right (dp, tc) <- readDotProtoWithContext incs fp
-  let Right src = renderHsModuleForDotProto dp tc
+  let Right src = renderHsModuleForDotProto mempty dp tc
   putStrLn src
 
 hsTmpDir, pyTmpDir :: IsString a => a
@@ -125,7 +125,7 @@ compileTestDotProtos = do
   Turtle.mktree hsTmpDir
   Turtle.mktree pyTmpDir
   forM_ protoFiles $ \protoFile -> do
-    compileDotProtoFileOrDie hsTmpDir ["test-files"] protoFile
+    compileDotProtoFileOrDie [] hsTmpDir ["test-files"] protoFile
     (@?= ExitSuccess) =<< Turtle.shell (T.concat [ "protoc --python_out="
                                                  , pyTmpDir
                                                  , " --proto_path=test-files"

--- a/tests/TestProto.hs
+++ b/tests/TestProto.hs
@@ -1769,3 +1769,47 @@ instance HsJSONPB.FromJSON Wrapped where
  
 instance HsJSONPB.ToSchema Wrapped where
         declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB
+ 
+data Deprecated = Deprecated{deprecatedRandomField :: Hs.Text}
+                deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+ 
+instance HsProtobuf.Named Deprecated where
+        nameOf _ = (Hs.fromString "Deprecated")
+ 
+instance HsProtobuf.Message Deprecated where
+        encodeMessage _
+          Deprecated{deprecatedRandomField = deprecatedRandomField}
+          = (Hs.mconcat
+               [(HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 1)
+                   deprecatedRandomField)])
+        decodeMessage _
+          = (Hs.pure Deprecated) <*>
+              (HsProtobuf.at HsProtobuf.decodeMessageField
+                 (HsProtobuf.FieldNumber 1))
+        dotProto _
+          = [(HsProtobuf.DotProtoField (HsProtobuf.FieldNumber 1)
+                (HsProtobuf.Prim HsProtobuf.String)
+                (HsProtobuf.Single "randomField")
+                [(HsProtobuf.DotProtoOption (HsProtobuf.Single "deprecated")
+                    (HsProtobuf.BoolLit Hs.True))]
+                Hs.Nothing)]
+ 
+instance HsJSONPB.ToJSONPB Deprecated where
+        toJSONPB (Deprecated f1) = (HsJSONPB.object ["randomField" .= f1])
+        toEncodingPB (Deprecated f1)
+          = (HsJSONPB.pairs ["randomField" .= f1])
+ 
+instance HsJSONPB.FromJSONPB Deprecated where
+        parseJSONPB
+          = (HsJSONPB.withObject "Deprecated"
+               (\ obj -> (Hs.pure Deprecated) <*> obj .: "randomField"))
+ 
+instance HsJSONPB.ToJSON Deprecated where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsJSONPB.FromJSON Deprecated where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
+instance HsJSONPB.ToSchema Deprecated where
+        declareNamedSchema = HsJSONPB.genericDeclareNamedSchemaJSONPB


### PR DESCRIPTION
Currently only parses the options but does not use them in the generated code.

Additionally, this PR fixes type errors in the test suite introduced by #42 