### PR TITLE
Add `shell.nix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Alternately, the `nix-shell` environment provides an incremental build
 environment (but see below for testing). From the root of this repository:
 
 ```bash
-$ nix-shell release.nix -A proto3-suite-no-tests.env
+$ nix-shell
 [nix-shell]$ cabal configure
 [nix-shell]$ cabal build
 ```
@@ -41,7 +41,7 @@ $ nix-shell release.nix -A proto3-suite-no-tests.env
 Once your source code compiles and you want to test, do this instead:
 
 ```bash
-$ nix-shell release.nix -A proto3-suite.env
+$ nix-shell
 [nix-shell]$ cabal configure --enable-tests
 [nix-shell]$ cabal build
 [nix-shell]$ cabal test

--- a/release.nix
+++ b/release.nix
@@ -86,8 +86,8 @@ let
   darwinPkgs = import nixpkgs { inherit config; system = "x86_64-darwin"; };
         pkgs = import nixpkgs { inherit config; };
 in
-  { proto3-suite-linux    =     linuxPkgs.haskellPackages.proto3-suite;
-    proto3-suite-darwin   =    darwinPkgs.haskellPackages.proto3-suite;
-    proto3-suite          =          pkgs.haskellPackages.proto3-suite;
-    proto3-suite-no-tests = pkgs.haskellPackages.proto3-suite-no-tests;
+  { proto3-suite-linux  =  linuxPkgs.haskellPackages.proto3-suite;
+    proto3-suite-darwin = darwinPkgs.haskellPackages.proto3-suite;
+    proto3-suite        =       pkgs.haskellPackages.proto3-suite;
+    proto3-suite-boot   =       pkgs.haskellPackages.proto3-suite-boot;
   }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./release.nix).proto3-suite-boot.env

--- a/tests/generate-test-types.sh
+++ b/tests/generate-test-types.sh
@@ -1,4 +1,4 @@
-PROTO3_SUITE_NO_TESTS=$(nix-build --no-out-link ../release.nix -A proto3-suite-no-tests)
+PROTO3_SUITE_NO_TESTS=$(nix-build --no-out-link ../release.nix -A proto3-suite-boot)
 "${PROTO3_SUITE_NO_TESTS}"/bin/compile-proto-file --out . --includeDir ../test-files --proto test_proto.proto
 "${PROTO3_SUITE_NO_TESTS}"/bin/compile-proto-file --out . --includeDir ../test-files --proto test_proto_import.proto
 "${PROTO3_SUITE_NO_TESTS}"/bin/compile-proto-file --out . --includeDir ../test-files --proto test_proto_oneof.proto


### PR DESCRIPTION
This allows `nix-shell` to work without any arguments (and `cabal`'s
`nix: True` mode)