### PR TITLE
Generated code no longer depends on `grpc-haskell-core`

### DIFF
--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -1628,7 +1628,7 @@ defaultImports usesGrpc =
                (Just (True, [ importSym "serverLoop" ]))
          , importDecl_ networkGrpcHighLevelServerUnregM False (Just grpcNS)
                (Just (False, [ importSym "serverLoop" ]))
-         , importDecl_ networkGrpcLowLevelCallM         False (Just grpcNS) Nothing  ]
+         ]
     else []
   where preludeM                  = Module "Prelude"
         dataProtobufWireDotProtoM = Module "Proto3.Suite.DotProto"
@@ -1650,7 +1650,6 @@ defaultImports usesGrpc =
         networkGrpcHighLevelServerM      = Module "Network.GRPC.HighLevel.Server"
         networkGrpcHighLevelClientM      = Module "Network.GRPC.HighLevel.Client"
         networkGrpcHighLevelServerUnregM = Module "Network.GRPC.HighLevel.Server.Unregistered"
-        networkGrpcLowLevelCallM         = Module "Network.GRPC.LowLevel.Call"
 
         grpcNS                    = Module "HsGRPC"
         jsonpbNS                  = Module "HsJSONPB"


### PR DESCRIPTION
Fixes https://github.com/awakesecurity/gRPC-haskell/issues/53

The motivation for this change is so that generated code does not need to
depend on the `grpc-haskell-core` package

This removes the unnecessary `Network.GRPC.HighLevel.Server.Unregistered`
import from the generated code since everything provided by the low-level
library is already re-exported by the high-level library

I tested this against the `gRPC-haskell` test suite, which still passed after this
change