### PR TITLE
Fix ToSchema field names for oneof types

### DIFF
--- a/src/Proto3/Suite/DotProto/Generate/Swagger.hs
+++ b/src/Proto3/Suite/DotProto/Generate/Swagger.hs
@@ -49,10 +49,11 @@ genericDeclareNamedSchemaJSONPB :: forall a proxy.
 genericDeclareNamedSchemaJSONPB proxy =
   over schema (set required []) <$> genericDeclareNamedSchema opts proxy
   where
-    opts = defaultSchemaOptions{
-             fieldLabelModifier = over _head toLower
-                                . drop (T.length (nameOf (Proxy @a)))
-           }
+    dropTypeName = over _head toLower . drop (T.length (nameOf (Proxy @a)))
+    opts = defaultSchemaOptions
+             { fieldLabelModifier = dropTypeName
+             , constructorTagModifier = dropTypeName
+             }
 
 -- | Pretty-prints a schema. Useful when playing around with schemas in the
 -- REPL.


### PR DESCRIPTION
This fixes the generated field labels for sum types. Given the following message,

```
message MyMessage {
  oneof FooOrBar {
    Foo x = 1;
    Bar y = 2;
  }
}
```

The current `ToSchema` instance will generate a swagger schema like this:

```
{  "FooOrBar": {
      "FooOrBarX": {...},
      "FooOrBarY": {...}
  }
}
```

The corrected schema looks like this:

```
{  "FooOrBar": {
      "x": {...},
      "y": {...}
  }
}
```