### PR TITLE
Reexport Dhall.Interpret and Dhall.Inject so that projects do not need to explicitly depend on Dhall unless they have to

### DIFF
--- a/nixpkgs/17_09.nix
+++ b/nixpkgs/17_09.nix
@@ -7,6 +7,7 @@
 # The SHA256 will be printed as the last line of stdout.
 
 import ./fetch-nixpkgs.nix {
-   rev    = "74286ec9e76be7cd00c4247b9acb430c4bd9f1ce";
-   sha256 = "0njb3qd2wxj7gil8y61lwh7zacmvr6zklv67w5zmvifi1fvalvdg";
+     rev          = "74286ec9e76be7cd00c4247b9acb430c4bd9f1ce";
+     sha256       = "0njb3qd2wxj7gil8y61lwh7zacmvr6zklv67w5zmvifi1fvalvdg";
+     outputSha256 = "13ydgpzl5nix4gc358iy9zjd5nrrpbpwpxmfhis4aai2zmkja3ak";
 }

--- a/src/Proto3/Suite/DhallPB.hs
+++ b/src/Proto3/Suite/DhallPB.hs
@@ -3,17 +3,21 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Proto3.Suite.DhallPB where
+module Proto3.Suite.DhallPB
+  ( -- * Modules
+    module Dhall
+  )
+where
+import           Data.Functor.Contravariant  (contramap)
+import           Data.Int                    (Int32, Int64)
+import           Data.Word                   (Word32, Word64)
+import           Dhall                       (Inject (..), Interpret (..))
+import           GHC.Float                   (double2Float, float2Double)
+import           Proto3.Suite.Types          (Enumerated (..), Fixed (..))
 
-import           Data.Functor.Contravariant (contramap)
-import           Data.Int                   (Int32, Int64)
-import           Data.Word                  (Word32, Word64)
-import           GHC.Float                  (double2Float, float2Double)
-import           Proto3.Suite.Types         (Enumerated (..), Fixed (..))
-
+import qualified Data.ByteString
 import qualified Data.ByteString.Base64
 import qualified Data.ByteString.Base64.Lazy
-import qualified Data.ByteString
 import qualified Data.ByteString.Lazy
 import qualified Data.Text.Encoding
 import qualified Data.Text.Lazy.Encoding

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -531,8 +531,11 @@ protobufName name = Qual (Module "HsProtobuf") (HsIdent name)
 proxyName    name = Qual (Module "Proxy") (HsIdent name)
 
 #ifdef DHALL
-dhallName :: String -> HsQName
-dhallName    name = Qual (Module "HsDhall") (HsIdent name)
+hsDhallPB :: String
+hsDhallPB = "HsDhallPb"
+
+dhallPBName :: String -> HsQName
+dhallPBName name = Qual (Module hsDhallPB) (HsIdent name)
 #endif
 
 camelCased :: String -> String
@@ -1048,13 +1051,13 @@ fromJSONPBMessageInstD _ctxt parentIdent msgIdent messageParts = do
 
 dhallInterpretInstDecl :: String -> HsDecl
 dhallInterpretInstDecl typeName =
-  instDecl_ (dhallName "Interpret")
+  instDecl_ (dhallPBName "Interpret")
             [ type_ typeName ]
             [ ]
 
 dhallInjectInstDecl :: String -> HsDecl
 dhallInjectInstDecl typeName =
-  instDecl_ (dhallName "Inject")
+  instDecl_ (dhallPBName "Inject")
             [ type_ typeName ]
             [ ]
 #endif
@@ -1942,8 +1945,7 @@ defaultImports usesGrpc =
   [ importDecl_ preludeM                  True  (Just haskellNS)  Nothing
 
 #ifdef DHALL
-  , importDecl_ dhallM                    True  (Just dhallNS)    Nothing
-  , importDecl_ proto3SuiteDhallPBM       True  (Just dhallpbNS) Nothing
+  , importDecl_ proto3SuiteDhallPBM       True  (Just (Module hsDhallPB)) Nothing
 #endif
 
   , importDecl_ dataProtobufWireDotProtoM True  (Just protobufNS) Nothing
@@ -2013,10 +2015,6 @@ defaultImports usesGrpc =
 
 #ifdef DHALL
         proto3SuiteDhallPBM       = Module "Proto3.Suite.DhallPB"
-
-        dhallM                    = Module "Dhall"
-        dhallNS                   = Module "HsDhall"
-        dhallpbNS                 = Module "HsDhallPB"
 #endif
 
         grpcNS                    = Module "HsGRPC"


### PR DESCRIPTION
This change reexports the `Dhall.Interpret` and `Dhall.Inject` instances from the `Proto3.Suite.DhallPB` module so that projects compiling Haskell source code generated from proto files with Dhall enabled do not have to explicitly depend on Dhall to compile the module.