### PR TITLE
Make oneof default value encoding more consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ test-files/test_files/
 *.hi
 # Ignore Emacs backup files
 *~
+# Ignore code generation artifacts
+gen/

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -2,9 +2,9 @@ name:                proto3-suite
 version:             0.2.0.0
 synopsis:            A low level library for writing out data in the Protocol Buffers wire format
 license:             Apache-2.0
-author:              Awake Networks
-maintainer:          opensource@awakenetworks.com
-copyright:           2017 Awake Networks
+author:              Awake Security
+maintainer:          opensource@awakesecurity.com
+copyright:           2017-2018 Awake Security
 category:            Codec
 build-type:          Simple
 cabal-version:       >=1.10
@@ -72,7 +72,7 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
-  ghc-options:         -O2 -Wall
+  ghc-options:         -O2 -Wall -Werror
 
 test-suite tests
   type:                exitcode-stdio-1.0
@@ -83,8 +83,13 @@ test-suite tests
     build-depends:     dhall >=1.13.0 && < 1.16
     cpp-options:       -DDHALL
 
-  other-modules:       TestProto
+  other-modules:       ArbitraryGeneratedTestTypes
+                       TestProto
                        TestCodeGen
+                       TestProtoImport
+                       TestProtoOneof
+                       TestProtoOneofImport
+
   hs-source-dirs:      tests gen
   default-language:    Haskell2010
   build-depends:       base >=4.8 && <5.0,
@@ -108,6 +113,7 @@ test-suite tests
                        transformers >=0.4 && <0.6,
                        turtle,
                        vector >=0.11 && < 0.13
+  ghc-options:         -O2 -Wall -Werror
 
 executable compile-proto-file
   main-is:             Main.hs
@@ -119,6 +125,7 @@ executable compile-proto-file
                        , system-filepath
                        , text
                        , turtle
+  ghc-options:         -O2 -Wall -Werror
 
 executable canonicalize-proto-file
   main-is:             Main.hs
@@ -132,3 +139,4 @@ executable canonicalize-proto-file
                        , range-set-list >=0.1.2 && <0.2
                        , system-filepath
                        , turtle
+  ghc-options:         -O2 -Wall -Werror

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -2099,4 +2099,4 @@ l :: SrcLoc
 l = SrcLoc "<generated>" 0 0
 
 __nowarn_unused :: a
-__nowarn_unused = subfieldType `undefined` subfieldOptions
+__nowarn_unused = subfieldType `undefined` subfieldOptions `undefined` oneofType

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -885,7 +885,7 @@ toJSONPBMessageInstD _ctxt parentIdent msgIdent messageParts = do
   -- >   HsJSONPB.object
   -- >     [ (let encodeFoo = (<case expr scrutinising foo> :: Options -> Value)
   -- >        in \option -> if optEmitNamedOneof option
-  -- >                      then ("Foo" .= (PB.object [encodeFoo] option)) option
+  -- >                      then ("Foo" .= (PB.objectOrNull [encodeFoo] option)) option
   -- >                      else encodeFoo option
   -- >       )
   -- >     , <encode more>
@@ -940,18 +940,23 @@ toJSONPBMessageInstD _ctxt parentIdent msgIdent messageParts = do
                      []
 
   let patBinder = onQF (const fieldBinder) (oneofSubDisjunctBinder . subfields)
-  let applyE nm = apply (HsVar (jsonpbName nm)) [ HsList (onQF defPairE (oneofCaseE nm) <$> qualFields) ]
 
-  let matchE nm appNm = match_ (HsIdent nm)
-                               [ HsPApp (unqual_ msgName)
-                                        (patVar . patBinder <$> qualFields) ]
-                               (HsUnGuardedRhs (applyE appNm))
-                               []
+  let applyE nm oneofNm =
+        apply (HsVar (jsonpbName nm))
+              [ HsList (onQF defPairE (oneofCaseE oneofNm) <$> qualFields) ]
+
+  let matchE nm appNm oneofAppNm =
+        match_
+          (HsIdent nm)
+          [ HsPApp (unqual_ msgName)
+                   (patVar . patBinder <$> qualFields) ]
+          (HsUnGuardedRhs (applyE appNm oneofAppNm))
+          []
 
   pure $ instDecl_ (jsonpbName "ToJSONPB")
                    [ type_ msgName ]
-                   [ HsFunBind [matchE "toJSONPB" "object"]
-                   , HsFunBind [matchE "toEncodingPB" "pairs"]
+                   [ HsFunBind [matchE "toJSONPB"     "object" "objectOrNull"]
+                   , HsFunBind [matchE "toEncodingPB" "pairs"  "pairsOrNull" ]
                    ]
 
 

--- a/src/Proto3/Suite/JSONPB.hs
+++ b/src/Proto3/Suite/JSONPB.hs
@@ -17,8 +17,10 @@ module Proto3.Suite.JSONPB
   , enumFieldEncoding
   , enumFieldString
   , object
+  , objectOrNull
   , pair
   , pairs
+  , pairsOrNull
   , parseField
   , toAesonEncoding
   , toAesonValue

--- a/src/Proto3/Suite/JSONPB/Class.hs
+++ b/src/Proto3/Suite/JSONPB/Class.hs
@@ -65,6 +65,7 @@ import qualified Data.Aeson                       as A (Encoding, FromJSON (..),
                                                         decode, eitherDecode, json,
                                                         (.!=))
 import qualified Data.Aeson.Encoding              as E
+import qualified Data.Aeson.Encoding.Internal     as E
 import qualified Data.Aeson.Internal              as A (formatError, iparse)
 import qualified Data.Aeson.Parser                as A (eitherDecodeWith)
 import qualified Data.Aeson.Types                 as A (Object, Pair, Parser,
@@ -182,10 +183,14 @@ parseField :: FromJSONPB a
            => A.Object -> Text -> A.Parser a
 parseField = A.explicitParseField parseJSONPB
 
+-- | >>> isDefault (def @E.Encoding)
+-- True
 instance HasDefault E.Encoding where
-  def       = E.pairs mempty
+  def       = E.empty
   isDefault = E.nullEncoding
 
+-- | >>> isDefault (def @A.Value)
+-- True
 instance HasDefault A.Value where
   def       = A.Null
   isDefault = (== A.Null)

--- a/src/Proto3/Suite/JSONPB/Class.hs
+++ b/src/Proto3/Suite/JSONPB/Class.hs
@@ -243,8 +243,32 @@ dropNamedPrefix p = drop (length (nameOf p :: String))
 object :: [Options -> [A.Pair]] -> Options -> A.Value
 object fs = A.object . mconcat fs
 
+-- | As 'object', but produces 'A.Null' when there are no pairs to wrap (cf. the
+-- empty object result of 'object)
+--
+-- >>> object [const []] defaultOptions
+-- Object (fromList [])
+-- >>> objectOrNull [const []] defaultOptions
+-- Null
+objectOrNull :: [Options -> [A.Pair]] -> Options -> A.Value
+objectOrNull fs options = case mconcat fs options of
+  []       -> A.Null
+  nonEmpty -> A.object nonEmpty
+
 pairs :: [Options -> A.Series] -> Options -> E.Encoding
 pairs fs = E.pairs . mconcat fs
+
+-- | As 'pairs', but produces the "null" when there is no series to encode
+-- (cf. the empty object encoding of 'pairs')
+--
+-- >>> pairs [const mempty] defaultOptions
+-- "{}"
+-- >>> pairsOrNull [const mempty] defaultOptions
+-- "null"
+pairsOrNull :: [Options -> A.Series] -> Options -> E.Encoding
+pairsOrNull fs options = case mconcat fs options of
+  E.Empty  -> E.null_
+  nonEmpty -> E.pairs nonEmpty
 
 enumFieldString :: forall a. (Named a, Show a) => a -> A.Value
 enumFieldString = A.String . T.pack . dropNamedPrefix (Proxy @a) . show

--- a/tests/ArbitraryGeneratedTestTypes.hs
+++ b/tests/ArbitraryGeneratedTestTypes.hs
@@ -2,7 +2,6 @@
 
 module ArbitraryGeneratedTestTypes where
 
-import qualified Data.ByteString       as BS
 import qualified Data.Text.Lazy        as T
 import qualified Data.Vector           as V
 import qualified Proto3.Suite.Types as DotProto

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -64,6 +64,7 @@ docTests = testCase "doctests" $ do
     , "-itests"
     , "-igen"
     , "src/Proto3/Suite/DotProto/Internal.hs"
+    , "src/Proto3/Suite/JSONPB/Class.hs"
     , "tests/TestCodeGen.hs"
     ]
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -8,21 +8,13 @@
 module Main where
 
 import           ArbitraryGeneratedTestTypes ()
-import           Control.Applicative
-import           Control.Exception
 import qualified Data.ByteString             as B
-import qualified Data.ByteString.Builder     as BB
 import qualified Data.ByteString.Char8       as BC
 import qualified Data.ByteString.Lazy        as BL
 import           Data.Either                 (isRight)
-import           Data.Int
-import           Data.Maybe                  (fromJust)
 import           Data.Monoid
 import           Data.Proxy
-import           Data.Serialize.Get          (runGet)
 import           Data.String
-import qualified Data.Text.Lazy              as TL
-import           Data.Word                   (Word64)
 import           GHC.Exts                    (fromList)
 import           Proto3.Suite
 import           Proto3.Wire.Decode          (ParseError)

--- a/tests/TestCodeGen.hs
+++ b/tests/TestCodeGen.hs
@@ -193,7 +193,7 @@ compileTestDotProtos = do
 -- prop> encodesAs json   (Something 42 99 (Just (SomethingPickOneDummyMsg1 (DummyMsg 66))))                        "{\"value\":\"42\",\"another\":99,\"pickOne\":{\"dummyMsg1\":{\"dummy\":66}}}"
 -- prop> encodesAs json   (Something 42 99 (Just (SomethingPickOneDummyMsg2 (DummyMsg 67))))                        "{\"value\":\"42\",\"another\":99,\"pickOne\":{\"dummyMsg2\":{\"dummy\":67}}}"
 -- prop> encodesAs json   (Something 42 99 (Just (SomethingPickOneDummyEnum (Enumerated (Right DummyEnumDUMMY0))))) "{\"value\":\"42\",\"another\":99,\"pickOne\":{\"dummyEnum\":\"DUMMY0\"}}"
--- prop> encodesAs json   (Something 42 99 Nothing)                                                                 "{\"value\":\"42\",\"another\":99,\"pickOne\":{}}"
+-- prop> encodesAs json   (Something 42 99 Nothing)                                                                 "{\"value\":\"42\",\"another\":99,\"pickOne\":null}"
 
 -- | Specific decoding tests
 -- prop> decodesAs "{\"signed32\":2147483647,\"signed64\":\"9223372036854775807\"}"   (SignedInts 2147483647 9223372036854775807)
@@ -219,6 +219,7 @@ compileTestDotProtos = do
 -- prop> decodesAs "{\"value\":\"42\",\"another\":99,\"pickOne\":{\"dummyMsg2\":{\"dummy\":67}}}"  (Something 42 99 (Just (SomethingPickOneDummyMsg2 (DummyMsg 67))))
 -- prop> decodesAs "{\"value\":\"42\",\"another\":99,\"pickOne\":{\"dummyEnum\":\"DUMMY0\"}}"      (Something 42 99 (Just (SomethingPickOneDummyEnum (Enumerated (Right DummyEnumDUMMY0)))))
 -- prop> decodesAs "{\"value\":\"42\",\"another\":99,\"pickOne\":{}}"                              (Something 42 99 Nothing)
+-- prop> decodesAs "{\"value\":\"42\",\"another\":99,\"pickOne\":null}"                            (Something 42 99 Nothing)
 --
 -- Swagger
 --

--- a/tests/TestCodeGen.hs
+++ b/tests/TestCodeGen.hs
@@ -19,20 +19,15 @@ import           Data.Swagger                   (ToSchema)
 import qualified Data.Swagger
 import qualified Data.Text                      as T
 import           Prelude                        hiding (FilePath)
-import qualified Prelude
-import           Proto3.Suite
 import           Proto3.Suite.DotProto.Generate
 import           Proto3.Suite.JSONPB            (FromJSONPB (..), Options (..),
                                                  ToJSONPB (..), eitherDecode,
-                                                 encode, defaultOptions, jsonPBOptions)
+                                                 encode, defaultOptions)
 import           System.Exit
 import           Test.Tasty
 import           Test.Tasty.HUnit               (testCase, (@?=))
-import           TestProto
-import           TestProtoOneof
 import           Turtle                         (FilePath)
 import qualified Turtle
-import           Turtle.Format                  ((%))
 import qualified Turtle.Format                  as F
 
 codeGenTests :: TestTree
@@ -151,7 +146,10 @@ compileTestDotProtos = do
 -- $setup
 -- >>> import qualified Data.Text.Lazy as TL
 -- >>> import qualified Data.Vector    as V
+-- >>> import Proto3.Suite
 -- >>> import Proto3.Suite.JSONPB
+-- >>> import TestProto
+-- >>> import TestProtoOneof
 -- >>> :set -XOverloadedStrings
 -- >>> :set -XOverloadedLists
 -- >>> :set -XTypeApplications

--- a/tools/canonicalize-proto-file/Main.hs
+++ b/tools/canonicalize-proto-file/Main.hs
@@ -121,7 +121,7 @@ instance CanonicalRank DotProtoMessagePart
     DotProtoMessageField f -> Right (canonicalRank f)
     DotProtoMessageOneOf _ fs -> Right (canonicalRank fs)
     DotProtoMessageDefinition d -> Left (Left (canonicalRank d))
-    DotProtoMessageReserved fs -> Left (Right ())
+    DotProtoMessageReserved _fs -> Left (Right ())
       -- We use '()' here because 'Canonicalize [DotProtoMessagePart]'
       -- collapses all of the 'DotProtoMessageReserved's into just one.
 


### PR DESCRIPTION
Before this change, we JSON-encoded omitted `oneof` fields (when the emit default values option is enabled) as `"keyname":{}`. After this change, the encoding is `"keyname":null` to be more consistent with encoding of omitted message fields elsewhere. 

Note that the wire encoding for both is the same; this is just to make the JSON encoding more consistent.