### PR TITLE
Use Data.Coerce.coerce and unboxed proxy

### DIFF
--- a/nix/proto3-wire.nix
+++ b/nix/proto3-wire.nix
@@ -18,6 +18,6 @@ mkDerivation {
     base bytestring cereal doctest QuickCheck tasty tasty-hunit
     tasty-quickcheck text
   ];
-  description = "A low-level implementation of the Protocol Buffers (version 3) wire format sd";
+  description = "A low-level implementation of the Protocol Buffers (version 3) wire format";
   license = stdenv.lib.licenses.asl20;
 }

--- a/nix/proto3-wire.nix
+++ b/nix/proto3-wire.nix
@@ -18,6 +18,6 @@ mkDerivation {
     base bytestring cereal doctest QuickCheck tasty tasty-hunit
     tasty-quickcheck text
   ];
-  description = "A low-level implementation of the Protocol Buffers (version 3) wire format";
+  description = "A low-level implementation of the Protocol Buffers (version 3) wire format sd";
   license = stdenv.lib.licenses.asl20;
 }

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -1,5 +1,5 @@
 name:                proto3-suite
-version:             0.2.1.0
+version:             0.3.0.0
 synopsis:            A low level library for writing out data in the Protocol Buffers wire format
 license:             Apache-2.0
 author:              Awake Security

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -72,8 +72,7 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
-  ghc-options:         -O2
-                       ---Wall -Werror
+  ghc-options:         -O2 -Wall -Werror
 
 test-suite tests
   type:                exitcode-stdio-1.0

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -1,5 +1,5 @@
 name:                proto3-suite
-version:             0.2.0.0
+version:             0.2.1.0
 synopsis:            A low level library for writing out data in the Protocol Buffers wire format
 license:             Apache-2.0
 author:              Awake Security

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -72,7 +72,8 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
-  ghc-options:         -O2 -Wall -Werror
+  ghc-options:         -O2
+                       ---Wall -Werror
 
 test-suite tests
   type:                exitcode-stdio-1.0

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -347,7 +347,7 @@ instance Primitive (Signed Int32) where
   primType _ = SInt32
 
 instance Primitive (Signed Int64) where
-  encodePrimitive num = Encode.sint64 num . signed
+  encodePrimitive num = Encode.sint64 num . coerce
   decodePrimitive = coerce Decode.sint64
   primType _ = SInt64
 

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -410,12 +410,12 @@ instance forall e. (Bounded e, Named e, Enum e) => Primitive (Enumerated e) wher
   encodePrimitive num = Encode.enum num . enumify . coerce @(Enumerated e) @(Either Int e)
     where enumify (Left i) = i
           enumify (Right x) = fromEnum x
-  decodePrimitive = coerce @(_ (Either Int e)) @(_ (Enumerated e)) Decode.enum
+  decodePrimitive = coerce @(Parser RawPrimitive (Either Int e)) @(Parser RawPrimitive (Enumerated e)) Decode.enum
   primType _ = Named (Single (nameOf (proxy# :: Proxy# e)))
 
 instance (Primitive a) => Primitive (ForceEmit a) where
   encodePrimitive num = encodePrimitive num . coerce @(ForceEmit a) @a
-  decodePrimitive     = coerce @(_ a) @(_ (ForceEmit a)) decodePrimitive
+  decodePrimitive     = coerce @(Parser RawPrimitive a) @(Parser RawPrimitive (ForceEmit a)) decodePrimitive
   primType _          = primType (proxy# :: Proxy# a)
 
 -- | This class captures those types which can appear as message fields in
@@ -504,7 +504,7 @@ instance (HasDefault a, Primitive a) => MessageField (ForceEmit a) where
 instance (Named a, Message a) => MessageField (Nested a) where
   encodeMessageField num = foldMap (Encode.embedded num . encodeMessage (fieldNumber 1))
                            . coerce @(Nested a) @(Maybe a)
-  decodeMessageField = coerce @(_ (Maybe a)) @(_ (Nested a))
+  decodeMessageField = coerce @(Parser RawField (Maybe a)) @(Parser RawField (Nested a))
                        (Decode.embedded (decodeMessage (fieldNumber 1)))
   protoType _ = messageField (Prim . Named . Single $ nameOf (proxy# :: Proxy# a)) Nothing
 
@@ -570,25 +570,29 @@ instance MessageField (PackedVec Int64) where
 
 instance MessageField (PackedVec (Fixed Word32)) where
   encodeMessageField fn = omittingDefault (Encode.packedFixed32 fn) . coerce @_ @(PackedVec Word32)
-  decodeMessageField = coerce @(_ (PackedVec Word32)) @(_ (PackedVec (Fixed Word32)))
+  decodeMessageField = coerce @(Parser RawField (PackedVec Word32))
+                              @(Parser RawField (PackedVec (Fixed Word32)))
                        (decodePacked Decode.packedFixed32)
   protoType _ = messageField (Repeated DotProto.Fixed32) (Just DotProto.PackedField)
 
 instance MessageField (PackedVec (Fixed Word64)) where
   encodeMessageField fn = omittingDefault (Encode.packedFixed64 fn) . coerce @_ @(PackedVec Word64)
-  decodeMessageField = coerce @(_ (PackedVec Word64)) @(_ (PackedVec (Fixed Word64)))
+  decodeMessageField = coerce @(Parser RawField (PackedVec Word64))
+                              @(Parser RawField (PackedVec (Fixed Word64)))
                        (decodePacked Decode.packedFixed64)
   protoType _ = messageField (Repeated DotProto.Fixed64) (Just DotProto.PackedField)
 
 instance MessageField (PackedVec (Signed (Fixed Int32))) where
   encodeMessageField fn = omittingDefault (Encode.packedFixed32 fn) . fmap (fromIntegral . coerce @_ @Int32)
-  decodeMessageField = coerce @(_ (PackedVec Int32)) @(_ (PackedVec (Signed (Fixed Int32))))
+  decodeMessageField = coerce @(Parser RawField (PackedVec Int32))
+                              @(Parser RawField (PackedVec (Signed (Fixed Int32))))
                        (decodePacked Decode.packedFixed32)
   protoType _ = messageField (Repeated SFixed32) (Just DotProto.PackedField)
 
 instance MessageField (PackedVec (Signed (Fixed Int64))) where
   encodeMessageField fn = omittingDefault (Encode.packedFixed64 fn) . fmap (fromIntegral . coerce @_ @Int64)
-  decodeMessageField = coerce @(_ (PackedVec Int64)) @(_ (PackedVec (Signed (Fixed Int64))))
+  decodeMessageField = coerce @(Parser RawField (PackedVec Int64))
+                              @(Parser RawField (PackedVec (Signed (Fixed Int64))))
                        (decodePacked Decode.packedFixed64)
   protoType _ = messageField (Repeated SFixed64) (Just DotProto.PackedField)
 
@@ -604,7 +608,7 @@ instance MessageField (PackedVec Double) where
 
 instance (MessageField e, KnownSymbol comments) => MessageField (e // comments) where
   encodeMessageField fn = encodeMessageField fn . unCommented
-  decodeMessageField = coerce @(_ e) @(_ (Commented comments e)) decodeMessageField
+  decodeMessageField = fmap Commented decodeMessageField
   protoType p = (protoType (lowerProxy1 p))
                   { dotProtoFieldComment = Just (symbolVal (lowerProxy2 p)) }
     where

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -481,14 +481,14 @@ foldDPT dptToHsCont foldPrim ctxt dpt =
   let
       prim = foldPrim ctxt
       go = foldDPT dptToHsCont foldPrim ctxt
-      coll = dptToHsCont ctxt dpt
+      cont = dptToHsCont ctxt dpt
   in
     case dpt of
-      Prim pType           -> coll <$> prim pType
-      Optional pType       -> coll <$> prim pType
-      Repeated pType       -> coll <$> prim pType
-      NestedRepeated pType -> coll <$> prim pType
-      Map k v  | validMapKey k -> HsTyApp . coll <$> prim k <*> go (Prim v) -- need to 'Nest' message types
+      Prim pType           -> cont <$> prim pType
+      Optional pType       -> cont <$> prim pType
+      Repeated pType       -> cont <$> prim pType
+      NestedRepeated pType -> cont <$> prim pType
+      Map k v  | validMapKey k -> HsTyApp . cont <$> prim k <*> go (Prim v) -- need to 'Nest' message types
                | otherwise -> throwError $ InvalidMapKeyType (show k)
 
 validMapKey :: DotProtoPrimType -> Bool

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -538,7 +538,7 @@ dpptToHsWrapper ctxt isRepeated = \case
   SFixed64 -> HsTyApp (protobufType_ "Signed") . HsTyApp (protobufType_ "Fixed")
   Named msgName
     | Just (DotProtoTypeInfo { dotProtoTypeInfoKind = DotProtoKindMessage }) <- M.lookup msgName ctxt
-    , isRepeated
+    , not isRepeated
     -> HsTyApp (protobufType_ "Nested")
   _ -> id
 

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -869,7 +869,7 @@ messageInstD ctxt parentIdent msgIdent messageParts = do
                                    , Just DotProtoKindMessage <- dotProtoTypeInfoKind <$> M.lookup tyName ctxt
                                    = HsParen . HsApp (HsVar (haskellName "Just"))
                                    | otherwise
-                                   = id
+                                   = forceEmitE
 
                             xE <- wrapE ctxt options dpType
                                    . wrapMaybe
@@ -1841,7 +1841,7 @@ dotProtoFieldC, primC, optionalC, repeatedC, nestedRepeatedC, namedC, mapC,
   fieldNumberC, singleC, dotsC, pathC, nestedC, anonymousC, dotProtoOptionC,
   identifierC, stringLitC, intLitC, floatLitC, boolLitC, trueC, falseC,
   unaryHandlerC, clientStreamHandlerC, serverStreamHandlerC, biDiStreamHandlerC,
-  methodNameC, nothingC, justC, mconcatE, encodeMessageFieldE,
+  methodNameC, nothingC, justC, forceEmitC, mconcatE, encodeMessageFieldE,
   fromStringE, decodeMessageFieldE, pureE, returnE, memptyE, msumE, atE, oneofE,
   succErrorE, predErrorE, toEnumErrorE, fmapE, defaultOptionsE, serverLoopE,
   convertServerHandlerE, convertServerReaderHandlerE, convertServerWriterHandlerE,
@@ -1866,6 +1866,7 @@ stringLitC           = HsVar (protobufName "StringLit")
 intLitC              = HsVar (protobufName "IntLit")
 floatLitC            = HsVar (protobufName "FloatLit")
 boolLitC             = HsVar (protobufName "BoolLit")
+forceEmitC           = HsVar (protobufName "ForceEmit")
 encodeMessageFieldE  = HsVar (protobufName "encodeMessageField")
 decodeMessageFieldE  = HsVar (protobufName "decodeMessageField")
 atE                  = HsVar (protobufName "at")
@@ -1944,6 +1945,9 @@ intP :: Integral a => a -> HsPat
 intP x = (if x < 0 then HsPParen else id) . HsPLit . HsInt . fromIntegral $ x
 
 -- ** Expressions for protobuf-wire types
+
+forceEmitE :: HsExp -> HsExp
+forceEmitE = HsParen . HsApp forceEmitC
 
 fieldNumberE :: FieldNumber -> HsExp
 fieldNumberE = HsParen . HsApp fieldNumberC . intE . getFieldNumber

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -492,7 +492,9 @@ foldDPT dptToHsCont foldPrim ctxt dpt =
                | otherwise -> throwError $ InvalidMapKeyType (show k)
 
 validMapKey :: DotProtoPrimType -> Bool
-validMapKey = (`elem` [ Int32, Int64, SInt32, SInt64, UInt32, UInt64, Fixed32, Fixed64, SFixed32, SFixed64, String, Bool])
+validMapKey = (`elem` [ Int32, Int64, SInt32, SInt64, UInt32, UInt64
+                      , Fixed32, Fixed64, SFixed32, SFixed64
+                      , String, Bool])
 
 isMessage :: TypeContext -> DotProtoIdentifier -> Bool
 isMessage ctxt n = Just DotProtoKindMessage == (dotProtoTypeInfoKind <$> M.lookup n ctxt)
@@ -562,10 +564,8 @@ dpptToHsTypeWrapper :: DotProtoPrimType -> HsType -> HsType
 dpptToHsTypeWrapper = \case
   SInt32   -> HsTyApp (protobufType_ "Signed")
   SInt64   -> HsTyApp (protobufType_ "Signed")
-  Fixed32  -> HsTyApp (protobufType_ "Fixed")
-  Fixed64  -> HsTyApp (protobufType_ "Fixed")
-  SFixed32 -> HsTyApp (protobufType_ "Signed") . HsTyApp (protobufType_ "Fixed")
-  SFixed64 -> HsTyApp (protobufType_ "Signed") . HsTyApp (protobufType_ "Fixed")
+  SFixed32 -> HsTyApp (protobufType_ "Signed")
+  SFixed64 -> HsTyApp (protobufType_ "Signed")
   _        -> id
 
 -- Convert a dot proto prim type to an unwrapped Haskell type
@@ -577,10 +577,10 @@ dpptToHsType ctxt = \case
   SInt64   -> pure $ primType_ "Int64"
   UInt32   -> pure $ primType_ "Word32"
   UInt64   -> pure $ primType_ "Word64"
-  Fixed32  -> pure $ primType_ "Word32"
-  Fixed64  -> pure $ primType_ "Word64"
-  SFixed32 -> pure $ primType_ "Int32"
-  SFixed64 -> pure $ primType_ "Int64"
+  Fixed32  -> pure $ HsTyApp (protobufType_ "Fixed") (primType_ "Word32")
+  Fixed64  -> pure $ HsTyApp (protobufType_ "Fixed") (primType_ "Word64")
+  SFixed32 -> pure $ HsTyApp (protobufType_ "Fixed") (primType_ "Int32")
+  SFixed64 -> pure $ HsTyApp (protobufType_ "Fixed") (primType_ "Int64")
   String   -> pure $ primType_ "Text"
   Bytes    -> pure $ primType_ "ByteString"
   Bool     -> pure $ primType_ "Bool"

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -470,7 +470,7 @@ dptToHsType = foldDPT (const id) (\ctxt _ -> dpptToHsType ctxt)
 -- Convert a dot proto type to a wrapped Haskell type
 dptToHsTypeWrapped :: MonadError CompileError m => TypeContext -> [DotProtoOption] -> DotProtoType -> m HsType
 dptToHsTypeWrapped ctxt opts = foldDPT (dptToHsWrapper ctxt opts)
-                                       (\ctxt isContainer ty -> dpptToHsWrapper ctxt isContainer ty <$> dpptToHsType ctxt ty)
+                                       (\ctxt' isContainer ty -> dpptToHsWrapper ctxt' isContainer ty <$> dpptToHsType ctxt' ty)
                                        ctxt
 
 {-
@@ -537,7 +537,7 @@ dpptToHsWrapper ctxt isRepeated = \case
   SFixed32 -> HsTyApp (protobufType_ "Signed") . HsTyApp (protobufType_ "Fixed")
   SFixed64 -> HsTyApp (protobufType_ "Signed") . HsTyApp (protobufType_ "Fixed")
   Named msgName
-    | Just ty@(DotProtoTypeInfo { dotProtoTypeInfoKind = DotProtoKindMessage }) <- M.lookup msgName ctxt
+    | Just (DotProtoTypeInfo { dotProtoTypeInfoKind = DotProtoKindMessage }) <- M.lookup msgName ctxt
     , isRepeated
     -> HsTyApp (protobufType_ "Nested")
   _ -> id
@@ -1574,8 +1574,8 @@ isUnpacked opts =
         Just (DotProtoOption _ (BoolLit x)) -> not x
         _ -> False
 
-isSignedPrim :: DotProtoPrimType -> Bool
-isSignedPrim ty = ty `elem` [ SFixed32, SFixed64, SInt32, SInt64 ]
+--isSignedPrim :: DotProtoPrimType -> Bool
+--isSignedPrim ty = ty `elem` [ SFixed32, SFixed64, SInt32, SInt64 ]
 
 -- | Returns 'True' if the given primitive type is packable. The 'TypeContext'
 -- is used to distinguish Named enums and messages, only the former of which are

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -57,6 +57,7 @@ import           Language.Haskell.Parser        (ParseResult(..), parseModule)
 import qualified NeatInterpolation              as Neat
 import           Prelude                        hiding (FilePath)
 import           Proto3.Suite.DotProto
+import           Proto3.Suite.DotProto.Rendering (Pretty(..))
 import           Proto3.Suite.DotProto.Internal
 import           Proto3.Wire.Types              (FieldNumber (..))
 import           System.IO                      (writeFile, readFile)
@@ -489,7 +490,7 @@ foldDPT dptToHsCont foldPrim ctxt dpt =
       Repeated pType       -> cont <$> prim pType
       NestedRepeated pType -> cont <$> prim pType
       Map k v  | validMapKey k -> HsTyApp . cont <$> prim k <*> go (Prim v) -- need to 'Nest' message types
-               | otherwise -> throwError $ InvalidMapKeyType (show k)
+               | otherwise -> throwError $ InvalidMapKeyType (show $ pPrint k)
 
 validMapKey :: DotProtoPrimType -> Bool
 validMapKey = (`elem` [ Int32, Int64, SInt32, SInt64, UInt32, UInt64

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -1478,11 +1478,11 @@ oneofSubDisjunctBinder = intercalate "_or_" . fmap oneofSubBinder
 
 
 wrapE :: MonadError CompileError m => TypeContext -> DotProtoType -> [DotProtoOption] -> HsExp -> m HsExp
-wrapE ctxt dpt opts e = HsParen <$> ( (HsApp . HsParen) <$> (coerce <$> dptToHsType ctxt dpt <*> dptToHsTypeWrapped ctxt opts dpt) <*> pure e )-- (mkWrapE ctxt dpt opts) e
+wrapE ctxt dpt opts e = HsParen <$> ( (HsApp . HsParen) <$> (coerceE <$> dptToHsType ctxt dpt <*> dptToHsTypeWrapped ctxt opts dpt) <*> pure e )-- (mkWrapE ctxt dpt opts) e
 
 -- the unwrapping function has to be fmapped over the parser.
 unwrapE :: MonadError CompileError m => TypeContext -> DotProtoType -> [DotProtoOption] -> HsExp -> m HsExp
-unwrapE ctxt dpt opts e = HsParen <$> ( (\f -> HsInfixApp f fmapOp) <$> (coerce <$> dptToHsTypeWrapped ctxt opts dpt <*> dptToHsType ctxt dpt) <*> pure e )
+unwrapE ctxt dpt opts e = HsParen <$> ( (\f -> HsInfixApp f fmapOp) <$> (coerceE <$> dptToHsTypeWrapped ctxt opts dpt <*> dptToHsType ctxt dpt) <*> pure e )
  --(mkUnwrapE ctxt dpt opts) e
 
 {-

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -456,6 +456,24 @@ ctxtImports tyCtxt =
 
 -- * Functions to convert 'DotProtoType' into Haskell types
 
+
+coerceE :: HsType -> HsType -> HsExp
+coerceE from to = HsApp (HsApp (HsVar (haskellName "coerce")) (typeApp from)) (typeApp to)
+  where
+    typeApp ty = HsVar (UnQual (HsIdent ("@("++ prettyPrint ty ++ ")")))
+
+
+-- Convert a dot proto type to a Haskell type
+dptToHsType :: MonadError CompileError m => TypeContext -> DotProtoType -> m HsType
+dptToHsType = foldDPT (const id) (\ctxt _ -> dpptToHsType ctxt)
+
+-- Convert a dot proto type to a wrapped Haskell type
+dptToHsTypeWrapped :: MonadError CompileError m => TypeContext -> [DotProtoOption] -> DotProtoType -> m HsType
+dptToHsTypeWrapped ctxt opts = foldDPT (dptToHsWrapper ctxt opts)
+                                       (\ctxt isContainer ty -> dpptToHsWrapper ctxt isContainer ty <$> dpptToHsType ctxt ty)
+                                       ctxt
+
+{-
 -- | Produce the Haskell type for the given 'DotProtoType' in the
 --   given 'TypeContext'
 hsTypeFromDotProto :: MonadError CompileError m => TypeContext -> DotProtoType -> m HsType
@@ -471,29 +489,101 @@ hsTypeFromDotProto ctxt = \case
   Map k v              -> HsTyApp . HsTyApp (primType_ "Map")
                           <$> hsTypeFromDotProtoPrim ctxt k
                           <*> hsTypeFromDotProto ctxt (Prim v) -- need to 'Nest' message types
+-}
 
-hsTypeFromDotProtoPrim :: MonadError CompileError m => TypeContext -> DotProtoPrimType -> m HsType
-hsTypeFromDotProtoPrim _    Int32    = pure $ primType_ "Int32"
-hsTypeFromDotProtoPrim _    Int64    = pure $ primType_ "Int64"
-hsTypeFromDotProtoPrim _    SInt32   = pure $ primType_ "Int32"
-hsTypeFromDotProtoPrim _    SInt64   = pure $ primType_ "Int64"
-hsTypeFromDotProtoPrim _    UInt32   = pure $ primType_ "Word32"
-hsTypeFromDotProtoPrim _    UInt64   = pure $ primType_ "Word64"
-hsTypeFromDotProtoPrim _    Fixed32  = pure $ HsTyApp (protobufType_ "Fixed") (primType_ "Word32")
-hsTypeFromDotProtoPrim _    Fixed64  = pure $ HsTyApp (protobufType_ "Fixed") (primType_ "Word64")
-hsTypeFromDotProtoPrim _    SFixed32 = pure $ HsTyApp (protobufType_ "Fixed") (primType_ "Int32")
-hsTypeFromDotProtoPrim _    SFixed64 = pure $ HsTyApp (protobufType_ "Fixed") (primType_ "Int64")
-hsTypeFromDotProtoPrim _    String   = pure $ primType_ "Text"
-hsTypeFromDotProtoPrim _    Bytes    = pure $ primType_ "ByteString"
-hsTypeFromDotProtoPrim _    Bool     = pure $ primType_ "Bool"
-hsTypeFromDotProtoPrim _    Float    = pure $ primType_ "Float"
-hsTypeFromDotProtoPrim _    Double   = pure $ primType_ "Double"
-hsTypeFromDotProtoPrim ctxt (Named msgName) =
+foldDPT :: MonadError CompileError m
+        => (DotProtoType -> HsType -> HsType)
+        -> (TypeContext -> Bool -> DotProtoPrimType -> m HsType)
+        -> TypeContext
+        -> DotProtoType
+        -> m HsType
+foldDPT wrapDPT foldPrim ctxt dpt =
+  let
+      primRep = foldPrim ctxt True
+      prim = foldPrim ctxt False
+      go = foldDPT wrapDPT foldPrim ctxt
+  in
+    wrapDPT dpt <$>
+    case dpt of
+      Prim (Named msgName)
+        | Just DotProtoKindMessage <- dotProtoTypeInfoKind <$> M.lookup msgName ctxt
+        -> HsTyApp (primType_ "Maybe") <$> prim (Named msgName)
+      Prim pType           -> prim pType
+      Optional (Named nm)  -> go (Prim (Named nm))
+      Optional pType       -> HsTyApp (primType_ "Maybe") <$> prim pType
+      Repeated pType       -> HsTyApp (primType_ "Vector") <$> primRep pType
+      NestedRepeated pType -> HsTyApp (primType_ "Vector") <$> prim pType
+      Map k v              -> HsTyApp . HsTyApp (primType_ "Map") <$> prim k <*> go (Prim v) -- need to 'Nest' message types
+
+-- Haskell wrapper for dot proto compound types
+dptToHsWrapper :: TypeContext -> [DotProtoOption] -> DotProtoType -> (HsType -> HsType)
+dptToHsWrapper ctxt opts = \case
+  Repeated (Named tyName)
+    | Just DotProtoKindMessage <- dotProtoTypeInfoKind <$> M.lookup tyName ctxt
+    -> HsTyApp (protobufType_ "NestedVec")
+  Repeated ty
+    | isUnpacked opts -> HsTyApp (protobufType_ "UnpackedVec")
+    | isPacked opts || isPackable ctxt ty -> HsTyApp (protobufType_ "PackedVec")
+    | otherwise -> HsTyApp (protobufType_ "UnpackedVec")
+  _ -> id
+
+-- Haskell wrapper for primitive dot proto types
+dpptToHsWrapper :: TypeContext -> Bool -> DotProtoPrimType -> (HsType -> HsType)
+dpptToHsWrapper ctxt isRepeated = \case
+  SInt32   -> HsTyApp (protobufType_ "Signed")
+  SInt64   -> HsTyApp (protobufType_ "Signed")
+  Fixed32  -> HsTyApp (protobufType_ "Fixed")
+  Fixed64  -> HsTyApp (protobufType_ "Fixed")
+  SFixed32 -> HsTyApp (protobufType_ "Signed") . HsTyApp (protobufType_ "Fixed")
+  SFixed64 -> HsTyApp (protobufType_ "Signed") . HsTyApp (protobufType_ "Fixed")
+  Named msgName
+    | Just ty@(DotProtoTypeInfo { dotProtoTypeInfoKind = DotProtoKindMessage }) <- M.lookup msgName ctxt
+    , isRepeated
+    -> HsTyApp (protobufType_ "Nested")
+  _ -> id
+
+-- Convert a dot proto prim type to an unwrapped Haskell type
+dpptToHsType :: MonadError CompileError m => TypeContext -> DotProtoPrimType -> m HsType
+dpptToHsType ctxt = \case
+  Int32    -> pure $ primType_ "Int32"
+  Int64    -> pure $ primType_ "Int64"
+  SInt32   -> pure $ primType_ "Int32"
+  SInt64   -> pure $ primType_ "Int64"
+  UInt32   -> pure $ primType_ "Word32"
+  UInt64   -> pure $ primType_ "Word64"
+  Fixed32  -> pure $ primType_ "Word32"
+  Fixed64  -> pure $ primType_ "Word64"
+  SFixed32 -> pure $ primType_ "Int32"
+  SFixed64 -> pure $ primType_ "Int64"
+  String   -> pure $ primType_ "Text"
+  Bytes    -> pure $ primType_ "ByteString"
+  Bool     -> pure $ primType_ "Bool"
+  Float    -> pure $ primType_ "Float"
+  Double   -> pure $ primType_ "Double"
+  Named msgName ->
     case M.lookup msgName ctxt of
       Just ty@(DotProtoTypeInfo { dotProtoTypeInfoKind = DotProtoKindEnum }) ->
           HsTyApp (protobufType_ "Enumerated") <$> msgTypeFromDpTypeInfo ty msgName
       Just ty -> msgTypeFromDpTypeInfo ty msgName
       Nothing -> noSuchTypeError msgName
+
+-- wrappedHsTypeFromDotProto :: MonadError CompileError m => TypeContext -> DotProtoType -> m HsType
+-- wrappedHsTypeFromDotProto ctxt = \case
+--   Prim (Named msgName)
+--      | Just DotProtoKindMessage <- dotProtoTypeInfoKind <$> M.lookup msgName ctxt
+--      -> HsTyApp (primType_ "Maybe") <$> hsTypeFromDotProtoPrim ctxt (Named msgName)
+--   Prim pType           -> hsTypeFromDotProtoPrim ctxt pType
+--   Optional (Named nm)  -> hsTypeFromDotProto ctxt (Prim (Named nm))
+--   Optional pType       -> HsTyApp (primType_ "Maybe")  <$> hsTypeFromDotProtoPrim ctxt pType
+--   Repeated pType       -> HsTyApp (primType_ "Vector") <$> hsTypeFromDotProtoPrim ctxt pType
+--   NestedRepeated pType -> HsTyApp (primType_ "Vector") <$> hsTypeFromDotProtoPrim ctxt pType
+--   Map k v              -> HsTyApp . HsTyApp (primType_ "Map")
+--                           <$> hsTypeFromDotProtoPrim ctxt k
+--                           <*> hsTypeFromDotProto ctxt (Prim v) -- need to 'Nest' message types
+
+
+-- wrappedHsTypeFromDotProtoPrim :: MonadError CompileError m => TypeContext -> DotProtoPrimType -> HsType
+-- wrappedHsTypeFromDotProtoPrim = undefined
 
 -- | Generate the Haskell type name for a 'DotProtoTypeInfo' for a message /
 --   enumeration being compiled. NB: We ignore the 'dotProtoTypeInfoPackage'
@@ -637,7 +727,7 @@ dotProtoMessageD ctxt parentIdent messageIdent message = do
 
            messagePartFieldD (DotProtoMessageField (DotProtoField _ ty fieldName _ _)) = do
                fullName <- prefixedFieldName messageName =<< dpIdentUnqualName fieldName
-               fullTy <- hsTypeFromDotProto ctxt' ty
+               fullTy <- dptToHsType ctxt' ty
                pure [ ([HsIdent fullName], HsUnBangedTy fullTy ) ]
 
            messagePartFieldD (DotProtoMessageOneOf fieldName _) = do
@@ -668,9 +758,9 @@ dotProtoMessageD ctxt parentIdent messageIdent message = do
                             Prim msg@(Named msgName)
                               | Just DotProtoKindMessage <- dotProtoTypeInfoKind <$> M.lookup msgName ctxt'
                                 -> -- Do not wrap message summands with Maybe.
-                                   hsTypeFromDotProtoPrim ctxt' msg
+                                   dpptToHsType ctxt' msg
 
-                            _   -> hsTypeFromDotProto ctxt' ty
+                            _   -> dptToHsType ctxt' ty
 
                        consName <- prefixedConName fullName =<< dpIdentUnqualName fieldName
                        let ident = HsIdent consName
@@ -755,15 +845,15 @@ messageInstD ctxt parentIdent msgIdent messageParts = do
      let encodeMessageField QualifiedField{recordFieldName, fieldInfo} =
              let recordFieldName' = HsVar (unqual_ (coerce recordFieldName)) in
              case fieldInfo of
-                 FieldNormal _fieldName fieldNum dpType options ->
-                     let fieldE = wrapE ctxt dpType options recordFieldName'
-                     in apply encodeMessageFieldE [ fieldNumberE fieldNum, fieldE ]
+                 FieldNormal _fieldName fieldNum dpType options -> do
+                     fieldE <- wrapE ctxt dpType options recordFieldName'
+                     pure $ apply encodeMessageFieldE [ fieldNumberE fieldNum, fieldE ]
 
-                 FieldOneOf OneofField{subfields} ->
+                 FieldOneOf OneofField{subfields} -> do
                       -- Create all pattern match & expr for each constructor:
                       --    Constructor y -> encodeMessageField num (Nested (Just y)) -- for embedded messages
                       --    Constructor y -> encodeMessageField num (ForceEmit y)     -- for everything else
-                      let mkAlt (OneofSubfield fieldNum conName _ dpType options) =
+                      let mkAlt (OneofSubfield fieldNum conName _ dpType options) = do
                             let wrapMaybe
                                    | Prim (Named tyName) <- dpType
                                    , Just DotProtoKindMessage <- dotProtoTypeInfoKind <$> M.lookup tyName ctxt
@@ -771,32 +861,34 @@ messageInstD ctxt parentIdent msgIdent messageParts = do
                                    | otherwise
                                    = forceEmitE
 
-                                xE = wrapE ctxt dpType options
+                            xE <- wrapE ctxt dpType options
                                    . wrapMaybe
                                    $ HsVar (unqual_ "y")
 
-                            in
-                              alt_ (HsPApp (unqual_ conName) [patVar "y"])
-                                   (HsUnGuardedAlt (apply encodeMessageFieldE [fieldNumberE fieldNum, xE]))
-                                   []
 
-                      in HsCase recordFieldName'
+                            pure $ alt_ (HsPApp (unqual_ conName) [patVar "y"])
+                                        (HsUnGuardedAlt (apply encodeMessageFieldE [fieldNumberE fieldNum, xE]))
+                                        []
+
+                      alts <- mapM mkAlt subfields
+
+                      pure $ HsCase recordFieldName'
                              [ alt_ (HsPApp (haskellName "Nothing") [])
                                     (HsUnGuardedAlt memptyE)
                                     []
                              , alt_ (HsPApp (haskellName "Just") [patVar "x"])
-                                    (HsUnGuardedAlt (HsCase (HsVar (unqual_ "x")) (map mkAlt subfields)))
+                                    (HsUnGuardedAlt (HsCase (HsVar (unqual_ "x")) alts))
                                     []
                              ]
 
-     let decodeMessageField QualifiedField{fieldInfo} =
+     let decodeMessageField QualifiedField{fieldInfo} = do
              case fieldInfo of
                  FieldNormal _fieldName fieldNum dpType options ->
                      unwrapE ctxt dpType options $ apply atE [ decodeMessageFieldE, fieldNumberE fieldNum ]
 
-                 FieldOneOf OneofField{subfields} ->
+                 FieldOneOf OneofField{subfields} -> do
                      -- create a list of (fieldNumber, Cons <$> parser)
-                     let subfieldParserE (OneofSubfield fieldNumber consName _ dpType options) =
+                     let subfieldParserE (OneofSubfield fieldNumber consName _ dpType options) = do
                            let fE = case dpType of
                                       Prim (Named tyName)
                                         | Just DotProtoKindMessage <- dotProtoTypeInfoKind <$> M.lookup tyName ctxt
@@ -804,16 +896,19 @@ messageInstD ctxt parentIdent msgIdent messageParts = do
                                       _ -> HsParen (HsInfixApp (HsVar (haskellName "Just"))
                                                                composeOp
                                                                (HsVar (unqual_ consName)))
-                           in HsTuple
+
+                           alts <- unwrapE ctxt dpType options decodeMessageFieldE
+
+                           pure $ HsTuple
                                 [ fieldNumberE fieldNumber
-                                , HsInfixApp (apply pureE [ fE ])
-                                             apOp
-                                             (unwrapE ctxt dpType options decodeMessageFieldE)
+                                , HsInfixApp (apply pureE [ fE ]) apOp alts
                                 ]
 
-                     in apply oneofE [ HsVar (haskellName "Nothing")
-                                     , HsList (map subfieldParserE subfields)
-                                     ]
+                     parsers <- mapM subfieldParserE subfields
+
+                     pure $  apply oneofE [ HsVar (haskellName "Nothing")
+                                          , HsList parsers
+                                          ]
 
      let dotProtoE = HsList
              [ apply dotProtoFieldC
@@ -832,10 +927,13 @@ messageInstD ctxt parentIdent msgIdent messageParts = do
              | QualifiedField (coerce -> fieldName) _ <- qualifiedFields
              ]
 
-     let encodeMessageE = apply mconcatE [ HsList (map encodeMessageField qualifiedFields) ]
+     encodedFields <- mapM encodeMessageField qualifiedFields
+     decodedFields <- mapM decodeMessageField qualifiedFields
+
+     let encodeMessageE = apply mconcatE [ HsList encodedFields]
      let decodeMessageE = foldl (\f -> HsInfixApp f apOp)
                                 (apply pureE [ HsVar (unqual_ msgName) ])
-                                (map decodeMessageField qualifiedFields)
+                                decodedFields
 
      let encodeMessageDecl = match_ (HsIdent "encodeMessage")
                                     [HsPWildCard, HsPRec (unqual_ msgName) punnedFieldsP]
@@ -1378,13 +1476,16 @@ oneofSubDisjunctBinder = intercalate "_or_" . fmap oneofSubBinder
 
 -- ** Helpers to wrap/unwrap types for protobuf (de-)serialization
 
-wrapE :: TypeContext -> DotProtoType -> [DotProtoOption] -> HsExp -> HsExp
-wrapE ctxt dpt opts e = HsParen $ maybe id (HsApp . HsParen) (mkWrapE ctxt dpt opts) e
+
+wrapE :: MonadError CompileError m => TypeContext -> DotProtoType -> [DotProtoOption] -> HsExp -> m HsExp
+wrapE ctxt dpt opts e = HsParen <$> ( (HsApp . HsParen) <$> (coerce <$> dptToHsType ctxt dpt <*> dptToHsTypeWrapped ctxt opts dpt) <*> pure e )-- (mkWrapE ctxt dpt opts) e
 
 -- the unwrapping function has to be fmapped over the parser.
-unwrapE :: TypeContext -> DotProtoType -> [DotProtoOption] -> HsExp -> HsExp
-unwrapE ctxt dpt opts e = HsParen $ maybe id (\f -> HsInfixApp f fmapOp) (mkUnwrapE ctxt dpt opts) e
+unwrapE :: MonadError CompileError m => TypeContext -> DotProtoType -> [DotProtoOption] -> HsExp -> m HsExp
+unwrapE ctxt dpt opts e = HsParen <$> ( (\f -> HsInfixApp f fmapOp) <$> (coerce <$> dptToHsTypeWrapped ctxt opts dpt <*> dptToHsType ctxt dpt) <*> pure e )
+ --(mkUnwrapE ctxt dpt opts) e
 
+{-
 maybeCompose :: Maybe HsExp -> Maybe HsExp -> Maybe HsExp
 maybeCompose Nothing e = e
 maybeCompose e Nothing = e
@@ -1459,13 +1560,15 @@ unwrapPrimE ctxt (Named tyName)
     = Just . HsVar . protobufName $ "nested"
 unwrapPrimE _ ty | isSignedPrim ty = Just . HsVar . protobufName $ "signed"
 unwrapPrimE _ _ = Nothing
+-}
 
-isPacked, isUnpacked :: [DotProtoOption] -> Bool
+isPacked :: [DotProtoOption] -> Bool
 isPacked opts =
     case find (\(DotProtoOption name _) -> name == Single "packed") opts of
         Just (DotProtoOption _ (BoolLit x)) -> x
         _ -> False
 
+isUnpacked :: [DotProtoOption] -> Bool
 isUnpacked opts =
     case find (\(DotProtoOption name _) -> name == Single "packed") opts of
         Just (DotProtoOption _ (BoolLit x)) -> not x
@@ -1659,8 +1762,8 @@ dotProtoServiceD pkgIdent ctxt serviceIdent service = do
                            Single nm -> pure nm
                            _ -> invalidMethodNameError rpcName
 
-           requestTy <- hsTypeFromDotProtoPrim ctxt  (Named request)
-           responseTy <- hsTypeFromDotProtoPrim ctxt (Named response)
+           requestTy <- dpptToHsType ctxt  (Named request)
+           responseTy <- dpptToHsType ctxt (Named response)
 
            let streamingType =
                  case (requestStreaming, responseStreaming) of
@@ -1980,7 +2083,10 @@ defaultImports usesGrpc =
     , importDecl_ proto3SuiteJSONPBM        True  (Just jsonpbNS) Nothing
     , importDecl_ proto3SuiteJSONPBM        False  Nothing
                   (Just (False, [ HsIAbs (HsSymbol ".=")
-                                , HsIAbs (HsSymbol ".:") ]))
+                                , HsIAbs (HsSymbol ".:")
+                                ]
+                        )
+                  )
     , importDecl_ proto3WireM               True  (Just protobufNS) Nothing
     , importDecl_ controlApplicativeM       False Nothing
                   (Just (False, [ HsIAbs (HsSymbol "<*>")
@@ -2002,11 +2108,9 @@ defaultImports usesGrpc =
     , importDecl_ dataMapM               True  (Just haskellNS)
                   (Just (False, [ importSym "Map", importSym "mapKeysMonotonic" ]))
     , importDecl_ dataIntM                  True  (Just haskellNS)
-                  (Just (False, [ importSym "Int16", importSym "Int32"
-                                , importSym "Int64" ]))
+                  (Just (False, [ importSym "Int16", importSym "Int32", importSym "Int64" ]))
     , importDecl_ dataWordM                 True  (Just haskellNS)
-                  (Just (False, [ importSym "Word16", importSym "Word32"
-                                , importSym "Word64" ]))
+                  (Just (False, [ importSym "Word16", importSym "Word32", importSym "Word64" ]))
     , importDecl_ dataProxy                 True (Just proxyNS)   Nothing
     , importDecl_ ghcGenericsM              True (Just haskellNS) Nothing
     , importDecl_ ghcEnumM                  True (Just haskellNS) Nothing
@@ -2061,10 +2165,10 @@ haskellNS :: Module
 haskellNS = Module "Hs"
 
 defaultMessageDeriving :: [HsQName]
-defaultMessageDeriving = map haskellName [ "Show", "Eq", "Ord" , "Generic" ]
+defaultMessageDeriving = map haskellName [ "Show", "Eq", "Ord", "Generic" ]
 
 defaultEnumDeriving :: [HsQName]
-defaultEnumDeriving = map haskellName [ "Show", "Bounded", "Eq",   "Ord" , "Generic" ]
+defaultEnumDeriving = map haskellName [ "Show", "Bounded", "Eq", "Ord", "Generic" ]
 
 defaultServiceDeriving :: [HsQName]
 defaultServiceDeriving = map haskellName [ "Generic" ]

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -457,21 +457,28 @@ ctxtImports tyCtxt =
 -- * Functions to convert 'DotProtoType' into Haskell types
 
 
-coerceE :: HsType -> HsType -> HsExp
-coerceE from to = HsApp (HsApp (HsVar (haskellName "coerce")) (typeApp from)) (typeApp to)
+coerceE :: HsType -> HsType -> Maybe HsExp
+coerceE from to | from == to = Nothing
+coerceE from to = Just $ HsApp (HsApp (HsVar (haskellName "coerce")) (typeApp from)) (typeApp to)
   where
-    typeApp ty = HsVar (UnQual (HsIdent ("@("++ prettyPrint ty ++ ")")))
+    -- Do not add linebreaks to typeapps as that causes parse errors
+    pp = prettyPrintStyleMode style{mode=OneLineMode} defaultMode
+    typeApp ty = HsVar (UnQual (HsIdent ("@("++ pp ty ++ ")")))
 
 
 -- Convert a dot proto type to a Haskell type
 dptToHsType :: MonadError CompileError m => TypeContext -> DotProtoType -> m HsType
-dptToHsType = foldDPT (const id) (\ctxt _ -> dpptToHsType ctxt)
+dptToHsType = foldDPT dptToHsContType dpptToHsType
 
 -- Convert a dot proto type to a wrapped Haskell type
-dptToHsTypeWrapped :: MonadError CompileError m => TypeContext -> [DotProtoOption] -> DotProtoType -> m HsType
-dptToHsTypeWrapped ctxt opts = foldDPT (dptToHsWrapper ctxt opts)
-                                       (\ctxt' isContainer ty -> dpptToHsWrapper ctxt' isContainer ty <$> dpptToHsType ctxt' ty)
-                                       ctxt
+dptToHsTypeWrapped :: MonadError CompileError m => [DotProtoOption] -> TypeContext -> DotProtoType -> m HsType
+dptToHsTypeWrapped opts =
+   foldDPT
+     -- The wrapper for the collection type replaces the native haskell
+     -- collection type, so try that first.
+     (\ctxt ty -> maybe (dptToHsContType ctxt ty) id (dptToHsWrappedContType ctxt opts ty))
+     -- Always wrap the primitive type.
+     (\ctxt ty -> dpptToHsTypeWrapper ty <$> dpptToHsType ctxt ty)
 
 {-
 -- | Produce the Haskell type for the given 'DotProtoType' in the
@@ -492,55 +499,74 @@ hsTypeFromDotProto ctxt = \case
 -}
 
 foldDPT :: MonadError CompileError m
-        => (DotProtoType -> HsType -> HsType)
-        -> (TypeContext -> Bool -> DotProtoPrimType -> m HsType)
+        => (TypeContext -> DotProtoType -> HsType -> HsType)
+        -> (TypeContext -> DotProtoPrimType -> m HsType)
         -> TypeContext
         -> DotProtoType
         -> m HsType
-foldDPT wrapDPT foldPrim ctxt dpt =
+foldDPT dptToHsCont foldPrim ctxt dpt =
   let
-      primRep = foldPrim ctxt True
-      prim = foldPrim ctxt False
-      go = foldDPT wrapDPT foldPrim ctxt
+--      primRep = foldPrim ctxt
+      prim = foldPrim ctxt
+--      go = foldDPT dptToHsCont foldPrim ctxt
+      coll = dptToHsCont ctxt dpt
   in
-    wrapDPT dpt <$>
     case dpt of
-      Prim (Named msgName)
-        | Just DotProtoKindMessage <- dotProtoTypeInfoKind <$> M.lookup msgName ctxt
-        -> HsTyApp (primType_ "Maybe") <$> prim (Named msgName)
-      Prim pType           -> prim pType
-      Optional (Named nm)  -> go (Prim (Named nm))
-      Optional pType       -> HsTyApp (primType_ "Maybe") <$> prim pType
-      Repeated pType       -> HsTyApp (primType_ "Vector") <$> primRep pType
-      NestedRepeated pType -> HsTyApp (primType_ "Vector") <$> prim pType
-      Map k v              -> HsTyApp . HsTyApp (primType_ "Map") <$> prim k <*> go (Prim v) -- need to 'Nest' message types
+      -- Prim (Named msgName)
+      --   | Just DotProtoKindMessage <- dotProtoTypeInfoKind <$> M.lookup msgName ctxt
+      --   -> -- HsTyApp (primType_ "Maybe") <$>
+      --      coll <$> prim (Named msgName)
+      Prim pType           -> coll <$> prim pType
+--      Optional (Named nm)  -> go (Prim (Named nm))
+      Optional pType       -> coll <$> prim pType
+      Repeated pType       -> coll <$> prim pType
+      NestedRepeated pType -> coll <$> prim pType
+      Map k v              -> HsTyApp . coll <$> prim k <*> prim v --- go (Prim v) -- need to 'Nest' message types
 
--- Haskell wrapper for dot proto compound types
-dptToHsWrapper :: TypeContext -> [DotProtoOption] -> DotProtoType -> (HsType -> HsType)
-dptToHsWrapper ctxt opts = \case
+
+-- Translate DotProtoType constructors to wrapped Haskell container types
+-- (for Message serde instances).
+dptToHsWrappedContType :: TypeContext -> [DotProtoOption] -> DotProtoType -> Maybe (HsType -> HsType)
+dptToHsWrappedContType ctxt opts = \case
+  Prim (Named _) -> Just $ HsTyApp (protobufType_ "Nested")
   Repeated (Named tyName)
     | Just DotProtoKindMessage <- dotProtoTypeInfoKind <$> M.lookup tyName ctxt
-    -> HsTyApp (protobufType_ "NestedVec")
+    -> Just $ HsTyApp (protobufType_ "NestedVec")
   Repeated ty
-    | isUnpacked opts -> HsTyApp (protobufType_ "UnpackedVec")
-    | isPacked opts || isPackable ctxt ty -> HsTyApp (protobufType_ "PackedVec")
-    | otherwise -> HsTyApp (protobufType_ "UnpackedVec")
-  _ -> id
+    | isUnpacked opts -> Just $ HsTyApp (protobufType_ "UnpackedVec")
+    | isPacked opts || isPackable ctxt ty -> Just $ HsTyApp (protobufType_ "PackedVec")
+    | otherwise -> Just $ HsTyApp (protobufType_ "UnpackedVec")
+  _ -> Nothing
+
+-- Translate DotProtoType to Haskell container types.
+dptToHsContType :: TypeContext -> DotProtoType -> HsType -> HsType
+dptToHsContType ctxt = \case
+  Prim (Named tyName) | Just DotProtoKindMessage <- dotProtoTypeInfoKind <$> M.lookup tyName ctxt
+                     -> HsTyApp $ primType_ "Maybe"
+--  Optional (Named _) -> Nothing
+  Optional _         -> HsTyApp $ primType_ "Maybe"
+  Repeated _         -> HsTyApp $ primType_ "Vector"
+  NestedRepeated _   -> HsTyApp $ primType_ "Vector"
+  Map _ _            -> HsTyApp $ primType_ "Map"
+  _                  -> id
+--  _                  -> Nothing
 
 -- Haskell wrapper for primitive dot proto types
-dpptToHsWrapper :: TypeContext -> Bool -> DotProtoPrimType -> (HsType -> HsType)
-dpptToHsWrapper ctxt isRepeated = \case
+dpptToHsTypeWrapper :: DotProtoPrimType -> HsType -> HsType
+dpptToHsTypeWrapper = \case
   SInt32   -> HsTyApp (protobufType_ "Signed")
   SInt64   -> HsTyApp (protobufType_ "Signed")
   Fixed32  -> HsTyApp (protobufType_ "Fixed")
   Fixed64  -> HsTyApp (protobufType_ "Fixed")
   SFixed32 -> HsTyApp (protobufType_ "Signed") . HsTyApp (protobufType_ "Fixed")
   SFixed64 -> HsTyApp (protobufType_ "Signed") . HsTyApp (protobufType_ "Fixed")
-  Named msgName
-    | Just (DotProtoTypeInfo { dotProtoTypeInfoKind = DotProtoKindMessage }) <- M.lookup msgName ctxt
-    , not isRepeated
-    -> HsTyApp (protobufType_ "Nested")
-  _ -> id
+-- only nested if this appears in a compound type, so do that logic in dpt
+  -- Named msgName
+  --   | Just (DotProtoTypeInfo { dotProtoTypeInfoKind = DotProtoKindMessage }) <- M.lookup msgName ctxt
+  --   , not isRepeated
+  --   -> Just $ HsTyApp (protobufType_ "Nested")
+--  Named _ -> id
+  _ -> id --HsTyApp (protobufType_ "ForceEmit")
 
 -- Convert a dot proto prim type to an unwrapped Haskell type
 dpptToHsType :: MonadError CompileError m => TypeContext -> DotProtoPrimType -> m HsType
@@ -567,27 +593,9 @@ dpptToHsType ctxt = \case
       Just ty -> msgTypeFromDpTypeInfo ty msgName
       Nothing -> noSuchTypeError msgName
 
--- wrappedHsTypeFromDotProto :: MonadError CompileError m => TypeContext -> DotProtoType -> m HsType
--- wrappedHsTypeFromDotProto ctxt = \case
---   Prim (Named msgName)
---      | Just DotProtoKindMessage <- dotProtoTypeInfoKind <$> M.lookup msgName ctxt
---      -> HsTyApp (primType_ "Maybe") <$> hsTypeFromDotProtoPrim ctxt (Named msgName)
---   Prim pType           -> hsTypeFromDotProtoPrim ctxt pType
---   Optional (Named nm)  -> hsTypeFromDotProto ctxt (Prim (Named nm))
---   Optional pType       -> HsTyApp (primType_ "Maybe")  <$> hsTypeFromDotProtoPrim ctxt pType
---   Repeated pType       -> HsTyApp (primType_ "Vector") <$> hsTypeFromDotProtoPrim ctxt pType
---   NestedRepeated pType -> HsTyApp (primType_ "Vector") <$> hsTypeFromDotProtoPrim ctxt pType
---   Map k v              -> HsTyApp . HsTyApp (primType_ "Map")
---                           <$> hsTypeFromDotProtoPrim ctxt k
---                           <*> hsTypeFromDotProto ctxt (Prim v) -- need to 'Nest' message types
-
-
--- wrappedHsTypeFromDotProtoPrim :: MonadError CompileError m => TypeContext -> DotProtoPrimType -> HsType
--- wrappedHsTypeFromDotProtoPrim = undefined
-
 -- | Generate the Haskell type name for a 'DotProtoTypeInfo' for a message /
 --   enumeration being compiled. NB: We ignore the 'dotProtoTypeInfoPackage'
---   field of the 'DotProtoTypeInfo' parameter, instead demanding that we have
+--   field Of the 'DotProtoTypeInfo' parameter, instead demanding that we have
 --   been provided with a valid module path in its 'dotProtoTypeInfoModulePath'
 --   field. The latter describes the name of the Haskell module being generated.
 msgTypeFromDpTypeInfo :: MonadError CompileError m
@@ -859,7 +867,7 @@ messageInstD ctxt parentIdent msgIdent messageParts = do
                                    , Just DotProtoKindMessage <- dotProtoTypeInfoKind <$> M.lookup tyName ctxt
                                    = HsParen . HsApp (HsVar (haskellName "Just"))
                                    | otherwise
-                                   = forceEmitE
+                                   = id
 
                             xE <- wrapE ctxt dpType options
                                    . wrapMaybe
@@ -1478,14 +1486,24 @@ oneofSubDisjunctBinder = intercalate "_or_" . fmap oneofSubBinder
 
 
 wrapE :: MonadError CompileError m => TypeContext -> DotProtoType -> [DotProtoOption] -> HsExp -> m HsExp
-wrapE ctxt dpt opts e = HsParen <$> ( (HsApp . HsParen) <$> (coerceE <$> dptToHsType ctxt dpt <*> dptToHsTypeWrapped ctxt opts dpt) <*> pure e )-- (mkWrapE ctxt dpt opts) e
+wrapE ctxt dpt opts e = do
+  c <- coerceE <$> dptToHsType ctxt dpt <*> dptToHsTypeWrapped opts ctxt dpt
+  case c of
+    Nothing -> pure e
+    Just f -> pure $ HsParen (HsApp (HsParen f) e)
 
 -- the unwrapping function has to be fmapped over the parser.
 unwrapE :: MonadError CompileError m => TypeContext -> DotProtoType -> [DotProtoOption] -> HsExp -> m HsExp
-unwrapE ctxt dpt opts e = HsParen <$> ( (\f -> HsInfixApp f fmapOp) <$> (coerceE <$> dptToHsTypeWrapped ctxt opts dpt <*> dptToHsType ctxt dpt) <*> pure e )
- --(mkUnwrapE ctxt dpt opts) e
+unwrapE ctxt dpt opts e = do
+  c <- coerceE <$> dptToHsTypeWrapped opts ctxt dpt <*> dptToHsType ctxt dpt
+  case c of
+    Nothing -> pure e
+    Just f -> pure $ HsParen (HsInfixApp (HsParen f) fmapOp e)
+-- unwrapE ctxt dpt opts e = fmap HsParen $
+--   (\f -> HsInfixApp f fmapOp) <$> (coerceE <$> dptToHsTypeWrapped opts ctxt dpt <*> dptToHsType ctxt dpt)
+--                               <*> pure e
 
-{-
+
 maybeCompose :: Maybe HsExp -> Maybe HsExp -> Maybe HsExp
 maybeCompose Nothing e = e
 maybeCompose e Nothing = e
@@ -1560,7 +1578,7 @@ unwrapPrimE ctxt (Named tyName)
     = Just . HsVar . protobufName $ "nested"
 unwrapPrimE _ ty | isSignedPrim ty = Just . HsVar . protobufName $ "signed"
 unwrapPrimE _ _ = Nothing
--}
+
 
 isPacked :: [DotProtoOption] -> Bool
 isPacked opts =
@@ -1574,8 +1592,8 @@ isUnpacked opts =
         Just (DotProtoOption _ (BoolLit x)) -> not x
         _ -> False
 
---isSignedPrim :: DotProtoPrimType -> Bool
---isSignedPrim ty = ty `elem` [ SFixed32, SFixed64, SInt32, SInt64 ]
+isSignedPrim :: DotProtoPrimType -> Bool
+isSignedPrim ty = ty `elem` [ SFixed32, SFixed64, SInt32, SInt64 ]
 
 -- | Returns 'True' if the given primitive type is packable. The 'TypeContext'
 -- is used to distinguish Named enums and messages, only the former of which are
@@ -1904,7 +1922,7 @@ dotProtoFieldC, primC, optionalC, repeatedC, nestedRepeatedC, namedC, mapC,
   fieldNumberC, singleC, dotsC, pathC, nestedC, anonymousC, dotProtoOptionC,
   identifierC, stringLitC, intLitC, floatLitC, boolLitC, trueC, falseC,
   unaryHandlerC, clientStreamHandlerC, serverStreamHandlerC, biDiStreamHandlerC,
-  methodNameC, nothingC, justC, forceEmitC, mconcatE, encodeMessageFieldE,
+  methodNameC, nothingC, justC, mconcatE, encodeMessageFieldE,
   fromStringE, decodeMessageFieldE, pureE, returnE, memptyE, msumE, atE, oneofE,
   succErrorE, predErrorE, toEnumErrorE, fmapE, defaultOptionsE, serverLoopE,
   convertServerHandlerE, convertServerReaderHandlerE, convertServerWriterHandlerE,
@@ -1929,7 +1947,6 @@ stringLitC           = HsVar (protobufName "StringLit")
 intLitC              = HsVar (protobufName "IntLit")
 floatLitC            = HsVar (protobufName "FloatLit")
 boolLitC             = HsVar (protobufName "BoolLit")
-forceEmitC           = HsVar (protobufName "ForceEmit")
 encodeMessageFieldE  = HsVar (protobufName "encodeMessageField")
 decodeMessageFieldE  = HsVar (protobufName "decodeMessageField")
 atE                  = HsVar (protobufName "at")
@@ -2008,9 +2025,6 @@ intP :: Integral a => a -> HsPat
 intP x = (if x < 0 then HsPParen else id) . HsPLit . HsInt . fromIntegral $ x
 
 -- ** Expressions for protobuf-wire types
-
-forceEmitE :: HsExp -> HsExp
-forceEmitE = HsParen . HsApp forceEmitC
 
 fieldNumberE :: FieldNumber -> HsExp
 fieldNumberE = HsParen . HsApp fieldNumberC . intE . getFieldNumber

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -2059,11 +2059,11 @@ defaultImports usesGrpc =
     dataProxy                 = Module "Data.Proxy"
     ghcGenericsM              = Module "GHC.Generics"
     ghcEnumM                  = Module "GHC.Enum"
+    unsafeCoerceM             = Module "Unsafe.Coerce"
     networkGrpcHighLevelGeneratedM   = Module "Network.GRPC.HighLevel.Generated"
     networkGrpcHighLevelServerM      = Module "Network.GRPC.HighLevel.Server"
     networkGrpcHighLevelClientM      = Module "Network.GRPC.HighLevel.Client"
     networkGrpcHighLevelServerUnregM = Module "Network.GRPC.HighLevel.Server.Unregistered"
-    unsafeCoerceM             = Module "Unsafe.Coerce"
 
 #ifdef DHALL
     proto3SuiteDhallPBM       = Module "Proto3.Suite.DhallPB"

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -492,48 +492,6 @@ foldDPT dptToHsCont foldPrim ctxt dpt =
       Map k v  | validMapKey k -> HsTyApp . cont <$> prim k <*> go (Prim v) -- need to 'Nest' message types
                | otherwise -> throwError $ InvalidMapKeyType (show $ pPrint k)
 
-validMapKey :: DotProtoPrimType -> Bool
-validMapKey = (`elem` [ Int32, Int64, SInt32, SInt64, UInt32, UInt64
-                      , Fixed32, Fixed64, SFixed32, SFixed64
-                      , String, Bool])
-
-isMessage :: TypeContext -> DotProtoIdentifier -> Bool
-isMessage ctxt n = Just DotProtoKindMessage == (dotProtoTypeInfoKind <$> M.lookup n ctxt)
-
-isPacked :: [DotProtoOption] -> Bool
-isPacked opts =
-    case find (\(DotProtoOption name _) -> name == Single "packed") opts of
-        Just (DotProtoOption _ (BoolLit x)) -> x
-        _ -> False
-
-isUnpacked :: [DotProtoOption] -> Bool
-isUnpacked opts =
-    case find (\(DotProtoOption name _) -> name == Single "packed") opts of
-        Just (DotProtoOption _ (BoolLit x)) -> not x
-        _ -> False
-
--- | Returns 'True' if the given primitive type is packable. The 'TypeContext'
--- is used to distinguish Named enums and messages, only the former of which are
--- packable.
-isPackable :: TypeContext -> DotProtoPrimType -> Bool
-isPackable _ Bytes    = False
-isPackable _ String   = False
-isPackable _ Int32    = True
-isPackable _ Int64    = True
-isPackable _ SInt32   = True
-isPackable _ SInt64   = True
-isPackable _ UInt32   = True
-isPackable _ UInt64   = True
-isPackable _ Fixed32  = True
-isPackable _ Fixed64  = True
-isPackable _ SFixed32 = True
-isPackable _ SFixed64 = True
-isPackable _ Bool     = True
-isPackable _ Float    = True
-isPackable _ Double   = True
-isPackable ctxt (Named tyName) =
-  Just DotProtoKindEnum == (dotProtoTypeInfoKind <$> M.lookup tyName ctxt)
-
 -- Translate DotProtoType constructors to wrapped Haskell container types
 -- (for Message serde instances).
 dptToHsWrappedContType :: TypeContext -> [DotProtoOption] -> DotProtoType -> Maybe (HsType -> HsType)
@@ -593,6 +551,49 @@ dpptToHsType ctxt = \case
           HsTyApp (protobufType_ "Enumerated") <$> msgTypeFromDpTypeInfo ty msgName
       Just ty -> msgTypeFromDpTypeInfo ty msgName
       Nothing -> noSuchTypeError msgName
+
+
+validMapKey :: DotProtoPrimType -> Bool
+validMapKey = (`elem` [ Int32, Int64, SInt32, SInt64, UInt32, UInt64
+                      , Fixed32, Fixed64, SFixed32, SFixed64
+                      , String, Bool])
+
+isMessage :: TypeContext -> DotProtoIdentifier -> Bool
+isMessage ctxt n = Just DotProtoKindMessage == (dotProtoTypeInfoKind <$> M.lookup n ctxt)
+
+isPacked :: [DotProtoOption] -> Bool
+isPacked opts =
+    case find (\(DotProtoOption name _) -> name == Single "packed") opts of
+        Just (DotProtoOption _ (BoolLit x)) -> x
+        _ -> False
+
+isUnpacked :: [DotProtoOption] -> Bool
+isUnpacked opts =
+    case find (\(DotProtoOption name _) -> name == Single "packed") opts of
+        Just (DotProtoOption _ (BoolLit x)) -> not x
+        _ -> False
+
+-- | Returns 'True' if the given primitive type is packable. The 'TypeContext'
+-- is used to distinguish Named enums and messages, only the former of which are
+-- packable.
+isPackable :: TypeContext -> DotProtoPrimType -> Bool
+isPackable _ Bytes    = False
+isPackable _ String   = False
+isPackable _ Int32    = True
+isPackable _ Int64    = True
+isPackable _ SInt32   = True
+isPackable _ SInt64   = True
+isPackable _ UInt32   = True
+isPackable _ UInt64   = True
+isPackable _ Fixed32  = True
+isPackable _ Fixed64  = True
+isPackable _ SFixed32 = True
+isPackable _ SFixed64 = True
+isPackable _ Bool     = True
+isPackable _ Float    = True
+isPackable _ Double   = True
+isPackable ctxt (Named tyName) =
+  Just DotProtoKindEnum == (dotProtoTypeInfoKind <$> M.lookup tyName ctxt)
 
 -- *** Helper functions for names
 

--- a/src/Proto3/Suite/DotProto/Generate/Swagger.hs
+++ b/src/Proto3/Suite/DotProto/Generate/Swagger.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE MagicHash           #-}
 {-# LANGUAGE TypeApplications    #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -28,6 +29,7 @@ import           Data.Swagger
 import qualified Data.Text                       as T
 import           Data.Proxy
 import qualified Data.Vector                     as V
+import           GHC.Exts                        (Proxy#, proxy#)
 import           GHC.Int
 import           GHC.Word
 import           Proto3.Suite                    (Enumerated (..), Finite (..),
@@ -70,9 +72,9 @@ ppSchema = LC8.putStrLn . encodePretty . toSchema
 -- | JSONPB schemas for protobuf enumerations
 instance (Finite e, Named e) => ToSchema (Enumerated e) where
   declareNamedSchema _ = do
-    let enumName        = nameOf (Proxy @e)
+    let enumName        = nameOf (proxy# :: Proxy# e)
     let dropPrefix      = T.drop (T.length enumName)
-    let enumMemberNames = dropPrefix . fst <$> enumerate (Proxy @e)
+    let enumMemberNames = dropPrefix . fst <$> enumerate (proxy# :: Proxy# e)
     return $ NamedSchema (Just enumName)
            $ mempty
              & type_ .~ SwaggerString

--- a/src/Proto3/Suite/DotProto/Rendering.hs
+++ b/src/Proto3/Suite/DotProto/Rendering.hs
@@ -16,6 +16,7 @@ module Proto3.Suite.DotProto.Rendering
   , toProtoFile
   , toProtoFileDef
   , RenderingOptions(..)
+  , Pretty(..)
   ) where
 
 import           Data.Char

--- a/src/Proto3/Suite/JSONPB/Class.hs
+++ b/src/Proto3/Suite/JSONPB/Class.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE OverloadedLists     #-}
 {-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE MagicHash           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE ViewPatterns        #-}
@@ -84,13 +85,13 @@ import qualified Data.ByteString.Lazy             as LBS
 import           Data.Coerce
 import           Data.Maybe
 import qualified Data.Map                         as M
-import           Data.Proxy
 import           Data.Text                        (Text)
 import qualified Data.Text                        as T
 import qualified Data.Text.Encoding               as T
 import qualified Data.Text.Lazy                   as TL
 import qualified Data.Text.Lazy.Encoding          as TL
 import qualified Data.Vector                      as V
+import           GHC.Exts                         (Proxy#, proxy#)
 import           GHC.Int                          (Int32, Int64)
 import           GHC.Word                         (Word32, Word64)
 import           Proto3.Suite.Class               (HasDefault (def, isDefault),
@@ -240,7 +241,7 @@ jsonPBOptions = Options
 
 -- * Helper types and functions
 
-dropNamedPrefix :: Named a => Proxy a -> String -> String
+dropNamedPrefix :: Named a => Proxy# a -> String -> String
 dropNamedPrefix p = drop (length (nameOf p :: String))
 
 object :: [Options -> [A.Pair]] -> Options -> A.Value
@@ -274,10 +275,10 @@ pairsOrNull fs options = case mconcat fs options of
   nonEmpty -> E.pairs nonEmpty
 
 enumFieldString :: forall a. (Named a, Show a) => a -> A.Value
-enumFieldString = A.String . T.pack . dropNamedPrefix (Proxy @a) . show
+enumFieldString = A.String . T.pack . dropNamedPrefix (proxy# :: Proxy# a) . show
 
 enumFieldEncoding :: forall a. (Named a, Show a) => a -> A.Encoding
-enumFieldEncoding = E.string . dropNamedPrefix (Proxy @a) . show
+enumFieldEncoding = E.string . dropNamedPrefix (proxy# :: Proxy# a) . show
 
 -- | A 'Data.Aeson' 'A.Value' encoder for values which can be
 -- JSONPB-encoded.

--- a/src/Proto3/Suite/Tutorial.hs
+++ b/src/Proto3/Suite/Tutorial.hs
@@ -23,6 +23,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -35,8 +36,8 @@ import Data.Int (Int32)
 import Proto3.Suite (Enumerated, Nested, NestedVec, PackedVec,
                      Message, Named, Finite,
                      DotProtoDefinition, enum, message, packageFromDefs, toProtoFileDef)
-import Data.Proxy
 import Data.Word (Word32)
+import GHC.Exts (Proxy#, proxy#)
 import GHC.Generics
 
 -- |
@@ -133,7 +134,7 @@ data Shape
 
 protoFile :: String
 protoFile = toProtoFileDef $ packageFromDefs "examplePackageName"
-  ([ enum    (Proxy :: Proxy Shape)
-   , message (Proxy :: Proxy Foo)
-   , message (Proxy :: Proxy Bar)
+  ([ enum    (proxy# :: Proxy# Shape)
+   , message (proxy# :: Proxy# Foo)
+   , message (proxy# :: Proxy# Bar)
    ] :: [DotProtoDefinition])

--- a/test-files/test_proto_oneof_import.proto
+++ b/test-files/test_proto_oneof_import.proto
@@ -1,8 +1,13 @@
 syntax="proto3";
 package TestProtoOneofImport;
+message AMessage {
+  string x = 1;
+  int32 y = 2;
+}
 message WithOneof {
   oneof pickOne {
     string a = 1;
     int32  b = 2;
+    AMessage c = 3;
   }
 }

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE MagicHash         #-}
 {-# LANGUAGE OverloadedLists   #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP               #-}
@@ -12,10 +13,9 @@ import qualified Data.ByteString             as B
 import qualified Data.ByteString.Char8       as BC
 import qualified Data.ByteString.Lazy        as BL
 import           Data.Either                 (isRight)
-import           Data.Proxy
 import           Data.String
 import           Data.Semigroup              ((<>))
-import           GHC.Exts                    (fromList)
+import           GHC.Exts                    (fromList, Proxy#)
 import           Proto3.Suite
 import           Proto3.Wire.Decode          (ParseError)
 import qualified Proto3.Wire.Decode          as Decode
@@ -302,14 +302,14 @@ qcDotProtoRoundtrip = testProperty
 --------------------------------------------------------------------------------
 -- Helpers
 
-dotProtoFor :: (Named a, Message a) => Proxy a -> DotProto
+dotProtoFor :: (Named a, Message a) => Proxy# a -> DotProto
 dotProtoFor proxy = DotProto [] [] DotProtoNoPackage
   [ DotProtoMessage (Single (nameOf proxy)) (DotProtoMessageField <$> dotProto proxy)
   ]
   (DotProtoMeta (Path []))
 
-showDotProtoFor :: (Named a, Message a) => Proxy a -> IO ()
-showDotProtoFor = putStrLn . toProtoFileDef . dotProtoFor
+showDotProtoFor :: (Named a, Message a) => Proxy# a -> IO ()
+showDotProtoFor proxy = putStrLn . toProtoFileDef $ dotProtoFor proxy
 
 instance Arbitrary WireType where
   arbitrary = oneof $ map return [Varint, P.Fixed32, P.Fixed64, LengthDelimited]


### PR DESCRIPTION
This should speed up protobuf serde a bit (not sure by how much), by getting rid of the container traversals to wrap things in newtypes in `encodeMessage/decodeMessage`. 

Using unboxed proxy couples us to GHC, but that's ok because we only officially support GHC 8.0+. Because this changes the API for the `Named, Finite, Primitive` classes, the version has been bumped to `0.3.0.0`.