### PR TITLE
Don't render fixed scalar types with Fixed wrapper

### DIFF
--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -523,8 +523,10 @@ dpptToHsTypeWrapper :: DotProtoPrimType -> HsType -> HsType
 dpptToHsTypeWrapper = \case
   SInt32   -> HsTyApp (protobufType_ "Signed")
   SInt64   -> HsTyApp (protobufType_ "Signed")
-  SFixed32 -> HsTyApp (protobufType_ "Signed")
-  SFixed64 -> HsTyApp (protobufType_ "Signed")
+  SFixed32 -> HsTyApp (protobufType_ "Signed") . HsTyApp (protobufType_ "Fixed")
+  SFixed64 -> HsTyApp (protobufType_ "Signed") . HsTyApp (protobufType_ "Fixed")
+  Fixed32  -> HsTyApp (protobufType_ "Fixed")
+  Fixed64  -> HsTyApp (protobufType_ "Fixed")
   _        -> id
 
 -- Convert a dot proto prim type to an unwrapped Haskell type
@@ -536,10 +538,10 @@ dpptToHsType ctxt = \case
   SInt64   -> pure $ primType_ "Int64"
   UInt32   -> pure $ primType_ "Word32"
   UInt64   -> pure $ primType_ "Word64"
-  Fixed32  -> pure $ HsTyApp (protobufType_ "Fixed") (primType_ "Word32")
-  Fixed64  -> pure $ HsTyApp (protobufType_ "Fixed") (primType_ "Word64")
-  SFixed32 -> pure $ HsTyApp (protobufType_ "Fixed") (primType_ "Int32")
-  SFixed64 -> pure $ HsTyApp (protobufType_ "Fixed") (primType_ "Int64")
+  Fixed32  -> pure $ primType_ "Word32"
+  Fixed64  -> pure $ primType_ "Word64"
+  SFixed32 -> pure $ primType_ "Int32"
+  SFixed64 -> pure $ primType_ "Int64"
   String   -> pure $ primType_ "Text"
   Bytes    -> pure $ primType_ "ByteString"
   Bool     -> pure $ primType_ "Bool"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -180,7 +180,7 @@ parseFromGoldens = testGroup "Parse golden encodings"
   , check "with_enum0.bin"            $ TP.WithEnum $ Enumerated $ Right $ TP.WithEnum_TestEnumENUM1
   , check "with_enum1.bin"            $ TP.WithEnum $ Enumerated $ Right $ TP.WithEnum_TestEnumENUM2
   , check "with_repetition.bin"       $ TP.WithRepetition [1..5]
-  , check "with_fixed.bin"            $ TP.WithFixed (Fixed 16) (Fixed (-123)) (Fixed 4096) (Fixed (-4096))
+  , check "with_fixed.bin"            $ TP.WithFixed 16 (-123) 4096 (-4096)
   , check "with_bytes.bin"            $ TP.WithBytes (BC.pack "abc") (fromList $ map BC.pack ["abc","123"])
   , check "with_packing.bin"          $ TP.WithPacking [1,2,3] [1,2,3]
   , check "all_packed_types.bin"      $ TP.AllPackedTypes
@@ -188,12 +188,12 @@ parseFromGoldens = testGroup "Parse golden encodings"
                                           [1,2,3]
                                           [-1,-2,-3]
                                           [-1,-2,-3]
-                                          (fromList $ map Fixed [1..3])
-                                          (fromList $ map Fixed [1..3])
+                                          (fromList [1..3])
+                                          (fromList [1..3])
                                           [1.0,2.0]
                                           [1.0,-1.0]
-                                          (fromList $ map Fixed [1,2,3])
-                                          (fromList $ map Fixed [1,2,3])
+                                          (fromList [1,2,3])
+                                          (fromList [1,2,3])
                                           [False,True]
                                           (Enumerated . Right <$> [TP.EFLD0, TP.EFLD1])
                                           (Enumerated . Right <$> [TP.EFLD0, TP.EFLD1])


### PR DESCRIPTION
In #91 I preserved the old behaviour, but from #30 it seems that `Fixed` should really be applied along with the rest of the newtype wrappers and omitted from the Haskell type that fixed scalar types are translated to.