### PR TITLE
Fix so paths are split properly on Windows

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -47,6 +47,7 @@ library
                        cereal >= 0.5.1 && <0.6,
                        containers >=0.5 && < 0.7,
                        contravariant >=1.4 && <1.6,
+                       filepath,
                        foldl,
                        hashable,
                        haskell-src ==1.0.*,

--- a/src/Proto3/Suite/DotProto/Internal.hs
+++ b/src/Proto3/Suite/DotProto/Internal.hs
@@ -13,6 +13,7 @@ import           Control.Lens.Cons         (_head)
 import           Data.Char                 (toUpper)
 import           Data.Maybe                (fromMaybe)
 import qualified Data.Text                 as T
+import           System.FilePath           (isPathSeparator)
 import qualified Filesystem.Path.CurrentOS as FP
 import           Filesystem.Path.CurrentOS ((</>))
 import qualified NeatInterpolation         as Neat
@@ -101,7 +102,7 @@ toModulePath fp0@(fromMaybe fp0 . FP.stripPrefix "./" -> fp)
                               -- want to ignore. E.g. ".foo.proto" => ["","Foo"].
              . fmap (T.unpack . over _head toUpper)
              . concatMap (T.splitOn ".")
-             . T.splitOn "/"
+             . T.split isPathSeparator
              . Turtle.format F.fp
              . FP.collapse
              . Turtle.dropExtension


### PR DESCRIPTION
Turtle uses \ for path separators on Windows, proto3-suite used splitOn "/" which didn't work, resulting in garbled paths and not capitalising things correctly. I solved that by moving to split isPathSeparator from the filepath library.

Fixes #93 