### PR TITLE
Remove `-Werror` flag

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -141,4 +141,4 @@ executable canonicalize-proto-file
                        , range-set-list >=0.1.2 && <0.2
                        , system-filepath
                        , turtle
-  ghc-options:         -O2 -Wall -Werror
+  ghc-options:         -O2 -Wall


### PR DESCRIPTION
Hackage rejects uploading any package with the `-Werror` flag since it
becomes likely to break due to non-breaking changes in dependencies