### PR TITLE
Remove more `-Werror`

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -73,7 +73,7 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
-  ghc-options:         -O2 -Wall -Werror
+  ghc-options:         -O2 -Wall
 
 test-suite tests
   type:                exitcode-stdio-1.0
@@ -115,7 +115,7 @@ test-suite tests
                        transformers >=0.4 && <0.6,
                        turtle,
                        vector >=0.11 && < 0.13
-  ghc-options:         -O2 -Wall -Werror
+  ghc-options:         -O2 -Wall
 
 executable compile-proto-file
   main-is:             Main.hs
@@ -127,7 +127,7 @@ executable compile-proto-file
                        , system-filepath
                        , text
                        , turtle
-  ghc-options:         -O2 -Wall -Werror
+  ghc-options:         -O2 -Wall
 
 executable canonicalize-proto-file
   main-is:             Main.hs


### PR DESCRIPTION
This is the same as #101, except I realized that there was more than one
`-Werror` in the `proto3-suite.cabal` file