### PR TITLE
Adjust indentation of generated .proto files.

### DIFF
--- a/src/Proto3/Suite/DotProto/Rendering.hs
+++ b/src/Proto3/Suite/DotProto/Rendering.hs
@@ -20,6 +20,7 @@ module Proto3.Suite.DotProto.Rendering
   ) where
 
 import           Data.Char
+import           Data.Function                   ((&))
 import qualified Data.List.NonEmpty              as NE
 import qualified Data.Text                       as T
 import           Filesystem.Path.CurrentOS       (toText)
@@ -129,8 +130,11 @@ prettyPrintProtoDefinition opts = defn where
     <+> pPrint number
     <+> optionAnnotation options
     <>  PP.text ";"
-    <>  maybe PP.empty (PP.text . (" // " ++)) comments
+    & maybe id (flip ($$) . PP.nest 2 . comment) comments
   field _ DotProtoEmptyField = PP.empty
+
+  comment :: String -> PP.Doc
+  comment = PP.vcat . map (PP.text . ("// " ++)) . lines
 
   enumPart :: DotProtoIdentifier -> DotProtoEnumPart -> PP.Doc
   enumPart msgName (DotProtoEnumField name value options)


### PR DESCRIPTION
When generating .proto source code or files,
indent 2 spaces within most nested constructs, such
as messages, instead of a variable amount depending
upon the keyword and name of the nested construct.

This change should improve readability by
reducing the typical amount of indentation.

Also fix rendering of multi-line comments.
