### PR TITLE
Render comments for messages, enums, and services.

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -1,5 +1,5 @@
 name:                proto3-suite
-version:             0.3.0.1
+version:             0.4.0.0
 synopsis:            A low level library for writing out data in the Protocol Buffers wire format
 license:             Apache-2.0
 author:              Awake Security

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -495,7 +495,7 @@ instance (Ord k, Primitive k, MessageField k, Primitive v, MessageField v) => Me
   --
   -- > When parsing from the wire or when merging, if there are duplicate map
   -- > keys the last key seen is used.
-  decodeMessageField = M.fromList . fromList
+  decodeMessageField = M.fromList
                        <$> repeated (Decode.embedded' (decodeMessage (fieldNumber 1)))
   protoType _ = messageField (Map (primType (proxy# :: Proxy# k)) (primType (proxy# :: Proxy# v))) Nothing
 
@@ -506,7 +506,7 @@ instance {-# OVERLAPS #-} (Ord k, Primitive k, Named v, Message v, MessageField 
   --
   -- > When parsing from the wire or when merging, if there are duplicate map
   -- > keys the last key seen is used.
-  decodeMessageField = M.fromList . fromList
+  decodeMessageField = M.fromList
                        <$> repeated (Decode.embedded' (decodeMessage (fieldNumber 1)))
   protoType _ = messageField (Map (primType (proxy# :: Proxy# k)) (Named . Single $ nameOf (proxy# :: Proxy# v))) Nothing
 

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -277,8 +277,7 @@ class Enum a => Finite a where
 
 -- | Generate metadata for an enum type.
 enum :: (Finite e, Named e) => Proxy# e -> DotProtoDefinition
-enum pr =
-    DotProtoEnum Nothing (Single $ nameOf pr) (map enumField $ enumerate pr)
+enum pr = DotProtoEnum "" (Single $ nameOf pr) (map enumField $ enumerate pr)
   where
     enumField (name, value) = DotProtoEnumField (Single name) value []
 
@@ -460,7 +459,7 @@ messageField ty packing = DotProtoField
     , dotProtoFieldType = ty
     , dotProtoFieldName = Anonymous
     , dotProtoFieldOptions = packingOption
-    , dotProtoFieldComment = Nothing
+    , dotProtoFieldComment = ""
     }
   where
     packingOption = maybe [] (toDotProtoOption . isPacked) packing
@@ -625,7 +624,7 @@ instance (MessageField e, KnownSymbol comments) => MessageField (e // comments) 
                               @(Parser RawField (Commented comments e))
                               decodeMessageField
   protoType p = (protoType (lowerProxy1 p))
-                  { dotProtoFieldComment = Just (symbolVal (lowerProxy2 p)) }
+                  { dotProtoFieldComment = symbolVal (lowerProxy2 p) }
     where
       lowerProxy1 :: forall f (a :: k). Proxy# (f a) -> Proxy# a
       lowerProxy1 _ = proxy#
@@ -670,7 +669,7 @@ instance (MessageField k, MessageField v) => Message (k, v)
 
 -- | Generate metadata for a message type.
 message :: (Message a, Named a) => Proxy# a -> DotProtoDefinition
-message proxy = DotProtoMessage Nothing
+message proxy = DotProtoMessage ""
                                 (Single $ nameOf proxy)
                                 (DotProtoMessageField <$> dotProto proxy)
 

--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -277,7 +277,8 @@ class Enum a => Finite a where
 
 -- | Generate metadata for an enum type.
 enum :: (Finite e, Named e) => Proxy# e -> DotProtoDefinition
-enum pr = DotProtoEnum (Single $ nameOf pr) (map enumField $ enumerate pr)
+enum pr =
+    DotProtoEnum Nothing (Single $ nameOf pr) (map enumField $ enumerate pr)
   where
     enumField (name, value) = DotProtoEnumField (Single name) value []
 
@@ -669,7 +670,8 @@ instance (MessageField k, MessageField v) => Message (k, v)
 
 -- | Generate metadata for a message type.
 message :: (Message a, Named a) => Proxy# a -> DotProtoDefinition
-message proxy = DotProtoMessage (Single $ nameOf proxy)
+message proxy = DotProtoMessage Nothing
+                                (Single $ nameOf proxy)
                                 (DotProtoMessageField <$> dotProto proxy)
 
 -- * Generic Instances

--- a/src/Proto3/Suite/DotProto/AST.hs
+++ b/src/Proto3/Suite/DotProto/AST.hs
@@ -136,9 +136,9 @@ instance Arbitrary DotProtoOption where
 
 -- | Top-level protocol definitions
 data DotProtoDefinition
-  = DotProtoMessage (Maybe String) DotProtoIdentifier [DotProtoMessagePart]
-  | DotProtoEnum    (Maybe String) DotProtoIdentifier [DotProtoEnumPart]
-  | DotProtoService (Maybe String) DotProtoIdentifier [DotProtoServicePart]
+  = DotProtoMessage String DotProtoIdentifier [DotProtoMessagePart]
+  | DotProtoEnum    String DotProtoIdentifier [DotProtoEnumPart]
+  | DotProtoService String DotProtoIdentifier [DotProtoServicePart]
   deriving (Show, Eq)
 
 
@@ -146,13 +146,13 @@ instance Arbitrary DotProtoDefinition where
   arbitrary = oneof [arbitraryMessage, arbitraryEnum]
     where
       arbitraryMessage = do
-        comment    <- pure Nothing  -- until parser supports comments
+        comment    <- pure mempty  -- until parser supports comments
         identifier <- arbitrarySingleIdentifier
         parts      <- smallListOf arbitrary
         return (DotProtoMessage comment identifier parts)
 
       arbitraryEnum = do
-        comment    <- pure Nothing  -- until parser supports comments
+        comment    <- pure mempty  -- until parser supports comments
         identifier <- arbitrarySingleIdentifier
         parts      <- smallListOf arbitrary
         return (DotProtoEnum comment identifier parts)
@@ -376,7 +376,7 @@ data DotProtoField = DotProtoField
   , dotProtoFieldType    :: DotProtoType
   , dotProtoFieldName    :: DotProtoIdentifier
   , dotProtoFieldOptions :: [DotProtoOption]
-  , dotProtoFieldComment :: Maybe String
+  , dotProtoFieldComment :: String
   }
   | DotProtoEmptyField
   deriving (Show, Eq)
@@ -388,7 +388,7 @@ instance Arbitrary DotProtoField where
     dotProtoFieldName    <- arbitraryIdentifier
     dotProtoFieldOptions <- smallListOf arbitrary
     -- TODO: Generate random comments once the parser supports comments
-    dotProtoFieldComment <- pure Nothing
+    dotProtoFieldComment <- pure mempty
     return (DotProtoField {..})
 
 data DotProtoReservedField
@@ -419,7 +419,7 @@ instance Arbitrary DotProtoReservedField where
 
 _arbitraryService :: Gen DotProtoDefinition
 _arbitraryService = do
-  comment    <- pure Nothing  -- until parser supports comments
+  comment    <- pure mempty  -- until parser supports comments
   identifier <- arbitrarySingleIdentifier
   parts      <- smallListOf arbitrary
   return (DotProtoService comment identifier parts)

--- a/src/Proto3/Suite/DotProto/AST.hs
+++ b/src/Proto3/Suite/DotProto/AST.hs
@@ -136,9 +136,9 @@ instance Arbitrary DotProtoOption where
 
 -- | Top-level protocol definitions
 data DotProtoDefinition
-  = DotProtoMessage DotProtoIdentifier [DotProtoMessagePart]
-  | DotProtoEnum    DotProtoIdentifier [DotProtoEnumPart]
-  | DotProtoService DotProtoIdentifier [DotProtoServicePart]
+  = DotProtoMessage (Maybe String) DotProtoIdentifier [DotProtoMessagePart]
+  | DotProtoEnum    (Maybe String) DotProtoIdentifier [DotProtoEnumPart]
+  | DotProtoService (Maybe String) DotProtoIdentifier [DotProtoServicePart]
   deriving (Show, Eq)
 
 
@@ -146,14 +146,16 @@ instance Arbitrary DotProtoDefinition where
   arbitrary = oneof [arbitraryMessage, arbitraryEnum]
     where
       arbitraryMessage = do
+        comment    <- pure Nothing  -- until parser supports comments
         identifier <- arbitrarySingleIdentifier
         parts      <- smallListOf arbitrary
-        return (DotProtoMessage identifier parts)
+        return (DotProtoMessage comment identifier parts)
 
       arbitraryEnum = do
+        comment    <- pure Nothing  -- until parser supports comments
         identifier <- arbitrarySingleIdentifier
         parts      <- smallListOf arbitrary
-        return (DotProtoEnum identifier parts)
+        return (DotProtoEnum comment identifier parts)
 
 -- | Tracks misc metadata about the AST
 data DotProtoMeta = DotProtoMeta
@@ -417,9 +419,10 @@ instance Arbitrary DotProtoReservedField where
 
 _arbitraryService :: Gen DotProtoDefinition
 _arbitraryService = do
+  comment    <- pure Nothing  -- until parser supports comments
   identifier <- arbitrarySingleIdentifier
   parts      <- smallListOf arbitrary
-  return (DotProtoService identifier parts)
+  return (DotProtoService comment identifier parts)
 
 arbitraryIdentifierName :: Gen String
 arbitraryIdentifierName = do

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -694,7 +694,7 @@ messageInstD ctxt parentIdent msgIdent messageParts = do
                         , dpTypeE dotProtoFieldType
                         , dpIdentE dotProtoFieldName
                         , HsList (map optionE dotProtoFieldOptions)
-                        , maybeE (HsLit . HsString) dotProtoFieldComment
+                        , HsLit (HsString dotProtoFieldComment)
                         ]
 
 
@@ -1476,7 +1476,7 @@ dotProtoFieldC, primC, optionalC, repeatedC, nestedRepeatedC, namedC, mapC,
   fieldNumberC, singleC, dotsC, pathC, nestedC, anonymousC, dotProtoOptionC,
   identifierC, stringLitC, intLitC, floatLitC, boolLitC, trueC, falseC,
   unaryHandlerC, clientStreamHandlerC, serverStreamHandlerC, biDiStreamHandlerC,
-  methodNameC, nothingC, justC, forceEmitC, mconcatE, encodeMessageFieldE,
+  methodNameC, justC, forceEmitC, mconcatE, encodeMessageFieldE,
   fromStringE, decodeMessageFieldE, pureE, returnE, memptyE, msumE, atE, oneofE,
   succErrorE, predErrorE, toEnumErrorE, fmapE, defaultOptionsE, serverLoopE,
   convertServerHandlerE, convertServerReaderHandlerE, convertServerWriterHandlerE,
@@ -1509,7 +1509,6 @@ oneofE               = HsVar (protobufName "oneof")
 
 trueC                       = HsVar (haskellName "True")
 falseC                      = HsVar (haskellName "False")
-nothingC                    = HsVar (haskellName "Nothing")
 justC                       = HsVar (haskellName "Just")
 mconcatE                    = HsVar (haskellName "mconcat")
 fromStringE                 = HsVar (haskellName "fromString")
@@ -1589,10 +1588,6 @@ forceEmitE = HsParen . HsApp forceEmitC
 
 fieldNumberE :: FieldNumber -> HsExp
 fieldNumberE = HsParen . HsApp fieldNumberC . intE . getFieldNumber
-
-maybeE :: (a -> HsExp) -> Maybe a -> HsExp
-maybeE _ Nothing = nothingC
-maybeE f (Just a) = HsApp justC (f a)
 
 dpIdentE :: DotProtoIdentifier -> HsExp
 dpIdentE (Single n)       = apply singleC [ str_ n ]

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -498,13 +498,13 @@ validMapKey = (`elem` [ Int32, Int64, SInt32, SInt64, UInt32, UInt64
 dotProtoDefinitionD :: MonadError CompileError m
                     => DotProtoIdentifier -> TypeContext -> DotProtoDefinition -> m [HsDecl]
 dotProtoDefinitionD pkgIdent ctxt = \case
-  DotProtoMessage messageName messageParts ->
+  DotProtoMessage _ messageName messageParts ->
     dotProtoMessageD ctxt Anonymous messageName messageParts
 
-  DotProtoEnum enumName enumParts ->
+  DotProtoEnum _ enumName enumParts ->
     dotProtoEnumD Anonymous enumName enumParts
 
-  DotProtoService serviceName serviceParts ->
+  DotProtoService _ serviceName serviceParts ->
     dotProtoServiceD pkgIdent ctxt serviceName serviceParts
 
 -- | Generate 'Named' instance for a type in this package
@@ -605,11 +605,11 @@ dotProtoMessageD ctxt parentIdent messageIdent messageParts = do
     messagePartFieldD _ _ = pure []
 
     nestedDecls :: DotProtoDefinition -> m [HsDecl]
-    nestedDecls (DotProtoMessage subMsgName subMessageDef) = do
+    nestedDecls (DotProtoMessage _ subMsgName subMessageDef) = do
       parentIdent' <- concatDotProtoIdentifier parentIdent messageIdent
       dotProtoMessageD ctxt' parentIdent' subMsgName subMessageDef
 
-    nestedDecls (DotProtoEnum subEnumName subEnumDef) = do
+    nestedDecls (DotProtoEnum _ subEnumName subEnumDef) = do
       parentIdent' <- concatDotProtoIdentifier parentIdent messageIdent
       dotProtoEnumD parentIdent' subEnumName subEnumDef
 

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -694,7 +694,7 @@ messageInstD ctxt parentIdent msgIdent messageParts = do
                         , dpTypeE dotProtoFieldType
                         , dpIdentE dotProtoFieldName
                         , HsList (map optionE dotProtoFieldOptions)
-                        , HsLit (HsString dotProtoFieldComment)
+                        , str_ dotProtoFieldComment
                         ]
 
 

--- a/src/Proto3/Suite/DotProto/Internal.hs
+++ b/src/Proto3/Suite/DotProto/Internal.hs
@@ -288,7 +288,7 @@ dotProtoTypeContext DotProto{..} =
 
 definitionTypeContext :: MonadError CompileError m
                       => Path -> DotProtoDefinition -> m TypeContext
-definitionTypeContext modulePath (DotProtoMessage msgIdent parts) = do
+definitionTypeContext modulePath (DotProtoMessage _ msgIdent parts) = do
   let updateParent = tiParent (concatDotProtoIdentifier msgIdent)
 
   childTyContext <- foldMapOfM (traverse . _DotProtoMessageDefinition)
@@ -306,7 +306,7 @@ definitionTypeContext modulePath (DotProtoMessage msgIdent parts) = do
 
   pure $ M.singleton msgIdent tyInfo <> qualifiedChildTyContext
 
-definitionTypeContext modulePath (DotProtoEnum enumIdent _) = do
+definitionTypeContext modulePath (DotProtoEnum _ enumIdent _) = do
   let tyInfo = DotProtoTypeInfo { dotProtoTypeInfoPackage = DotProtoNoPackage
                                 , dotProtoTypeInfoParent =  Anonymous
                                 , dotProtoTypeChildContext = mempty

--- a/src/Proto3/Suite/DotProto/Internal.hs
+++ b/src/Proto3/Suite/DotProto/Internal.hs
@@ -30,7 +30,7 @@ import           Data.List                 (find, intercalate)
 import qualified Data.List.NonEmpty        as NE
 import qualified Data.Map                  as M
 import           Data.Maybe                (fromMaybe)
-import           Data.Monoid
+import           Data.Semigroup            (Semigroup(..))
 import qualified Data.Text                 as T
 import           Data.Tuple                (swap)
 import           Filesystem.Path.CurrentOS ((</>))
@@ -60,7 +60,8 @@ liftEither = either throwError pure
 #endif
 
 -- | Like 'foldMap', but with an effectful projection.
-foldMapM :: (Foldable t, Monad m, Monoid b) => (a -> m b) -> t a -> m b
+foldMapM ::
+  (Foldable t, Monad m, Monoid b, Semigroup b) => (a -> m b) -> t a -> m b
 foldMapM f = foldM (\b a -> (b <>) <$> f a) mempty
 
 -- | Like 'Control.Lens.Getter.Getting', but allows for retrieving the 'r'

--- a/src/Proto3/Suite/DotProto/Parsing.hs
+++ b/src/Proto3/Suite/DotProto/Parsing.hs
@@ -265,7 +265,7 @@ service :: ProtoParser DotProtoDefinition
 service = do symbol "service"
              name <- singleIdentifier
              statements <- braces (many servicePart)
-             return $ DotProtoService Nothing name statements
+             return $ DotProtoService mempty name statements
 
 --------------------------------------------------------------------------------
 -- message definitions
@@ -274,7 +274,7 @@ message :: ProtoParser DotProtoDefinition
 message = do symbol "message"
              name <- singleIdentifier
              body <- braces (many messagePart)
-             return $ DotProtoMessage Nothing name body
+             return $ DotProtoMessage mempty name body
 
 messageOneOf :: ProtoParser DotProtoMessagePart
 messageOneOf = do symbol "oneof"
@@ -306,7 +306,7 @@ messageField = do mtype <- messageType
                   mnumber <- fieldNumber
                   moptions <- optionAnnotation
                   semi
-                  return $ DotProtoField mnumber mtype mname moptions Nothing
+                  return $ DotProtoField mnumber mtype mname moptions mempty
 
 --------------------------------------------------------------------------------
 -- enumerations
@@ -329,7 +329,7 @@ enum :: ProtoParser DotProtoDefinition
 enum = do symbol "enum"
           ename <- singleIdentifier
           ebody <- braces (many enumStatement)
-          return $ DotProtoEnum Nothing ename ebody
+          return $ DotProtoEnum mempty ename ebody
 
 --------------------------------------------------------------------------------
 -- field reservations

--- a/src/Proto3/Suite/DotProto/Parsing.hs
+++ b/src/Proto3/Suite/DotProto/Parsing.hs
@@ -265,7 +265,7 @@ service :: ProtoParser DotProtoDefinition
 service = do symbol "service"
              name <- singleIdentifier
              statements <- braces (many servicePart)
-             return $ DotProtoService name statements
+             return $ DotProtoService Nothing name statements
 
 --------------------------------------------------------------------------------
 -- message definitions
@@ -274,7 +274,7 @@ message :: ProtoParser DotProtoDefinition
 message = do symbol "message"
              name <- singleIdentifier
              body <- braces (many messagePart)
-             return $ DotProtoMessage name body
+             return $ DotProtoMessage Nothing name body
 
 messageOneOf :: ProtoParser DotProtoMessagePart
 messageOneOf = do symbol "oneof"
@@ -329,7 +329,7 @@ enum :: ProtoParser DotProtoDefinition
 enum = do symbol "enum"
           ename <- singleIdentifier
           ebody <- braces (many enumStatement)
-          return $ DotProtoEnum ename ebody
+          return $ DotProtoEnum Nothing ename ebody
 
 --------------------------------------------------------------------------------
 -- field reservations

--- a/src/Proto3/Suite/DotProto/Rendering.hs
+++ b/src/Proto3/Suite/DotProto/Rendering.hs
@@ -99,7 +99,10 @@ instance Pretty DotProtoOption where
   pPrint (DotProtoOption key value) = pPrint key <+> PP.text "=" <+> pPrint value
 
 renderComment :: String -> PP.Doc
-renderComment = PP.vcat . map (PP.text . ("// " ++)) . lines
+renderComment = PP.vcat . map ((PP.text "//" <+>) . textIfNonempty) . lines
+  where
+    textIfNonempty [] = PP.empty
+    textIfNonempty text = PP.text text
 
 -- Put the final closing brace on the next line.
 -- This is important, since the final field might have a comment, and

--- a/src/Proto3/Suite/DotProto/Rendering.hs
+++ b/src/Proto3/Suite/DotProto/Rendering.hs
@@ -99,6 +99,12 @@ topOption o = PP.text "option" <+> pPrint o <> PP.text ";"
 instance Pretty DotProtoOption where
   pPrint (DotProtoOption key value) = pPrint key <+> PP.text "=" <+> pPrint value
 
+renderComment :: String -> PP.Doc
+renderComment = PP.vcat . map (PP.text . ("// " ++)) . lines
+
+prefixAnyComment :: Maybe String -> PP.Doc -> PP.Doc
+prefixAnyComment = maybe id (($$) . renderComment)
+
 -- Put the final closing brace on the next line.
 -- This is important, since the final field might have a comment, and
 -- the brace cannot be part of the comment.
@@ -109,9 +115,12 @@ vbraces header body = header <+> PP.char '{' $$ PP.nest 2 body $$ PP.char '}'
 prettyPrintProtoDefinition :: RenderingOptions -> DotProtoDefinition -> PP.Doc
 prettyPrintProtoDefinition opts = defn where
   defn :: DotProtoDefinition -> PP.Doc
-  defn (DotProtoMessage name parts) = vbraces (PP.text "message" <+> pPrint name) (PP.vcat $ msgPart name <$> parts)
-  defn (DotProtoEnum    name parts) = vbraces (PP.text "enum"    <+> pPrint name) (PP.vcat $ enumPart name <$> parts)
-  defn (DotProtoService name parts) = vbraces (PP.text "service" <+> pPrint name) (PP.vcat $ pPrint <$> parts)
+  defn (DotProtoMessage comment name parts) = prefixAnyComment comment $
+    vbraces (PP.text "message" <+> pPrint name) (PP.vcat $ msgPart name <$> parts)
+  defn (DotProtoEnum    comment name parts) = prefixAnyComment comment $
+    vbraces (PP.text "enum"    <+> pPrint name) (PP.vcat $ enumPart name <$> parts)
+  defn (DotProtoService comment name parts) = prefixAnyComment comment $
+    vbraces (PP.text "service" <+> pPrint name) (PP.vcat $ pPrint <$> parts)
 
   msgPart :: DotProtoIdentifier -> DotProtoMessagePart -> PP.Doc
   msgPart msgName (DotProtoMessageField f)           = field msgName f
@@ -130,11 +139,8 @@ prettyPrintProtoDefinition opts = defn where
     <+> pPrint number
     <+> optionAnnotation options
     <>  PP.text ";"
-    & maybe id (flip ($$) . PP.nest 2 . comment) comments
+    & maybe id (flip ($$) . PP.nest 2 . renderComment) comments
   field _ DotProtoEmptyField = PP.empty
-
-  comment :: String -> PP.Doc
-  comment = PP.vcat . map (PP.text . ("// " ++)) . lines
 
   enumPart :: DotProtoIdentifier -> DotProtoEnumPart -> PP.Doc
   enumPart msgName (DotProtoEnumField name value options)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -265,9 +265,9 @@ dotProtoRoundtripTrivial = testCase
 
 dotProtoSimpleMessage :: DotProto
 dotProtoSimpleMessage = DotProto [] [] DotProtoNoPackage
-  [ DotProtoMessage Nothing (Single "MessageTest")
+  [ DotProtoMessage "" (Single "MessageTest")
       [ DotProtoMessageField $
-          DotProtoField (fieldNumber 1) (Prim Int32) (Single "testfield") [] Nothing
+          DotProtoField (fieldNumber 1) (Prim Int32) (Single "testfield") [] ""
       ]
   ]
   (DotProtoMeta (Path ("test-files" NE.:| ["simple"])))
@@ -307,9 +307,7 @@ qcDotProtoRoundtrip = testProperty
 dotProtoFor :: (Named a, Message a) => Proxy# a -> DotProto
 dotProtoFor proxy = DotProto [] [] DotProtoNoPackage
   [ DotProtoMessage
-      Nothing
-      (Single (nameOf proxy))
-      (DotProtoMessageField <$> dotProto proxy)
+      "" (Single (nameOf proxy)) (DotProtoMessageField <$> dotProto proxy)
   ]
   (DotProtoMeta (Path $ "mypath" NE.:| []))
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -265,7 +265,7 @@ dotProtoRoundtripTrivial = testCase
 
 dotProtoSimpleMessage :: DotProto
 dotProtoSimpleMessage = DotProto [] [] DotProtoNoPackage
-  [ DotProtoMessage (Single "MessageTest")
+  [ DotProtoMessage Nothing (Single "MessageTest")
       [ DotProtoMessageField $
           DotProtoField (fieldNumber 1) (Prim Int32) (Single "testfield") [] Nothing
       ]
@@ -306,7 +306,10 @@ qcDotProtoRoundtrip = testProperty
 
 dotProtoFor :: (Named a, Message a) => Proxy# a -> DotProto
 dotProtoFor proxy = DotProto [] [] DotProtoNoPackage
-  [ DotProtoMessage (Single (nameOf proxy)) (DotProtoMessageField <$> dotProto proxy)
+  [ DotProtoMessage
+      Nothing
+      (Single (nameOf proxy))
+      (DotProtoMessageField <$> dotProto proxy)
   ]
   (DotProtoMeta (Path $ "mypath" NE.:| []))
 

--- a/tools/canonicalize-proto-file/Main.hs
+++ b/tools/canonicalize-proto-file/Main.hs
@@ -92,11 +92,11 @@ instance CanonicalRank DotProtoDefinition (Int, DotProtoIdentifier) where
 instance Canonicalize DotProtoDefinition where
   canonicalize = \case
     DotProtoMessage _ name parts ->
-      DotProtoMessage Nothing (canonicalize name) (canonicalize parts)
+      DotProtoMessage "" (canonicalize name) (canonicalize parts)
     DotProtoEnum    _ name parts ->
-      DotProtoEnum    Nothing (canonicalize name) (canonicalize parts)
+      DotProtoEnum    "" (canonicalize name) (canonicalize parts)
     DotProtoService _ name parts ->
-      DotProtoService Nothing (canonicalize name) (canonicalize parts)
+      DotProtoService "" (canonicalize name) (canonicalize parts)
 
 instance Canonicalize [DotProtoMessagePart] where
   canonicalize parts = canonicalSort (resNumbers ++ resNames ++ other)
@@ -159,8 +159,8 @@ instance Canonicalize DotProtoField where
     , dotProtoFieldType = canonicalize dotProtoFieldType
     , dotProtoFieldName = canonicalize dotProtoFieldName
     , dotProtoFieldOptions = canonicalize dotProtoFieldOptions
-    , dotProtoFieldComment = Nothing  -- In future we might add a command-line
-                                      -- option to preserve comments.
+    , dotProtoFieldComment = ""  -- In future we might add a command-line
+                                 -- option to preserve comments.
     }
   canonicalize DotProtoEmptyField = DotProtoEmptyField
 

--- a/tools/canonicalize-proto-file/Main.hs
+++ b/tools/canonicalize-proto-file/Main.hs
@@ -85,18 +85,18 @@ instance Canonicalize [DotProtoDefinition] where canonicalize = canonicalSort
 
 instance CanonicalRank DotProtoDefinition (Int, DotProtoIdentifier) where
   canonicalRank = \case
-    DotProtoEnum    name _ -> (1, name)
-    DotProtoMessage name _ -> (2, name)
-    DotProtoService name _ -> (3, name)
+    DotProtoEnum    _ name _ -> (1, name)
+    DotProtoMessage _ name _ -> (2, name)
+    DotProtoService _ name _ -> (3, name)
 
 instance Canonicalize DotProtoDefinition where
   canonicalize = \case
-    DotProtoMessage name parts ->
-      DotProtoMessage (canonicalize name) (canonicalize parts)
-    DotProtoEnum    name parts ->
-      DotProtoEnum    (canonicalize name) (canonicalize parts)
-    DotProtoService name parts ->
-      DotProtoService (canonicalize name) (canonicalize parts)
+    DotProtoMessage _ name parts ->
+      DotProtoMessage Nothing (canonicalize name) (canonicalize parts)
+    DotProtoEnum    _ name parts ->
+      DotProtoEnum    Nothing (canonicalize name) (canonicalize parts)
+    DotProtoService _ name parts ->
+      DotProtoService Nothing (canonicalize name) (canonicalize parts)
 
 instance Canonicalize [DotProtoMessagePart] where
   canonicalize parts = canonicalSort (resNumbers ++ resNames ++ other)

--- a/tools/compile-proto-file/Main.hs
+++ b/tools/compile-proto-file/Main.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE StandaloneDeriving  #-}
 {-# LANGUAGE TypeOperators       #-}
 
+import           Data.Semigroup                 ((<>))
 import           Options.Applicative
 import           Prelude                        hiding (FilePath)
 import           Proto3.Suite.DotProto.Generate


### PR DESCRIPTION
Also, replace `Maybe String` with `String` as the way we note
comments in the AST.  The empty string renders as the absence of
a comment, whereas "\n" renders as an empty single-line comment.

Both of these changes modify the AST; therefore
we go to a new version of proto3-suite: 0.4.0.0.

This change also includes adaptations to support
multiple versions of GHC.