### PR TITLE
Bump QuickCheck upper bound

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -61,7 +61,7 @@ library
                        pretty ==1.1.*,
                        pretty-show >= 1.6.12 && < 2.0,
                        proto3-wire == 1.1.*,
-                       QuickCheck >=2.10 && <2.13,
+                       QuickCheck >=2.10 && <2.14,
                        quickcheck-instances < 0.4,
                        safe ==0.3.*,
                        semigroups ==0.18.*,
@@ -95,7 +95,7 @@ test-suite tests
   hs-source-dirs:      tests gen
   default-language:    Haskell2010
   build-depends:       base >=4.8 && <5.0,
-                       QuickCheck >=2.10 && <2.13,
+                       QuickCheck >=2.10 && <2.14,
                        aeson >= 1.1.1.0 && < 1.5,
                        attoparsec >= 0.13.0.1,
                        base >=4.8 && <5.0,


### PR DESCRIPTION
The tests seem to work fine with QuickCheck 2.13.2