### PR TITLE
Add failing test case for unsigned integers

### DIFF
--- a/test-files/test_proto.proto
+++ b/test-files/test_proto.proto
@@ -20,6 +20,11 @@ message SignedInts {
   sint64 signed64 = 2;
 }
 
+message UnsignedInts {
+  uint32 unsigned32 = 1;
+  uint64 unsigned64 = 2;
+}
+
 message WithEnum {
   enum TestEnum {
     ENUM1 = 0;

--- a/tests/TestCodeGen.hs
+++ b/tests/TestCodeGen.hs
@@ -256,6 +256,8 @@ compileTestDotProtos = do
 -- {"properties":{"dummy":{"maximum":2147483647,"format":"int32","minimum":-2147483648,"type":"integer"}},"type":"object"}
 -- >>> schemaOf @(Enumerated DummyEnum)
 -- {"type":"string","enum":["DUMMY0","DUMMY1"]}
+-- >>> schemaOf @UnsignedInts
+-- {"properties":{"unsigned32":{"maximum":2147483647,"format":"int32","minimum":-2147483648,"type":"integer"},"unsigned64":{"maximum":9223372036854775807,"format":"int64","minimum":-9223372036854775808,"type":"integer"}},"type":"object"}
 --
 -- Generic HasDefault
 --

--- a/tests/TestCodeGen.hs
+++ b/tests/TestCodeGen.hs
@@ -257,7 +257,7 @@ compileTestDotProtos = do
 -- >>> schemaOf @(Enumerated DummyEnum)
 -- {"type":"string","enum":["DUMMY0","DUMMY1"]}
 -- >>> schemaOf @UnsignedInts
--- {"properties":{"unsigned32":{"maximum":2147483647,"format":"int32","minimum":-2147483648,"type":"integer"},"unsigned64":{"maximum":9223372036854775807,"format":"int64","minimum":-9223372036854775808,"type":"integer"}},"type":"object"}
+-- {"properties":{"unsigned32":{"maximum":2147483647,"format":"int32","minimum":0,"type":"integer"},"unsigned64":{"maximum":9223372036854775807,"format":"int64","minimum":0,"type":"integer"}},"type":"object"}
 --
 -- Generic HasDefault
 --

--- a/tests/TestCodeGen.hs
+++ b/tests/TestCodeGen.hs
@@ -257,7 +257,7 @@ compileTestDotProtos = do
 -- >>> schemaOf @(Enumerated DummyEnum)
 -- {"type":"string","enum":["DUMMY0","DUMMY1"]}
 -- >>> schemaOf @UnsignedInts
--- {"properties":{"unsigned32":{"maximum":2147483647,"format":"int32","minimum":0,"type":"integer"},"unsigned64":{"maximum":9223372036854775807,"format":"int64","minimum":0,"type":"integer"}},"type":"object"}
+-- {"properties":{"unsigned32":{"maximum":4294967295,"format":"int32","minimum":0,"type":"integer"},"unsigned64":{"maximum":18446744073709551615,"format":"int64","minimum":0,"type":"integer"}},"type":"object"}
 --
 -- Generic HasDefault
 --


### PR DESCRIPTION
According to @natefaubion, the representation of `uint64` over the wire should be the same as `int64`. These changes demonstrate that when using `proto3-suite`, it isn't.

@gbaz suggested that this is actually a `swagger2` issue, but I'm not familiar enough with protobuf and/or swagger to know where this falls so I've added a failing test case here for now.

For me the test fails as follows:

```
Running 1 test suites...
Test suite tests: RUNNING...
Tests
  doctests:                                                                 Running all doctests...
tests/TestCodeGen.hs:259: failure in expression `schemaOf @UnsignedInts'
expected: {"properties":{"unsigned32":{"maximum":2147483647,"format":"int32","minimum":-2147483648,"type":"integer"},"unsigned64":{"maximum":9223372036854775807,"format":"int64","minimum":-9223372036854775808,"type":"integer"}},"type":"object"}
 but got: {"properties":{"unsigned32":{"maximum":4294967295,"minimum":0,"type":"integer"},"unsigned64":{"maximum":18446744073709551615,"minimum":0,"type":"integer"}},"type":"object"}
```