### PR TITLE
Revert accidental commit

### DIFF
--- a/nix/fetchNixpkgs.nix
+++ b/nix/fetchNixpkgs.nix
@@ -1,10 +1,56 @@
 { rev                             # The Git revision of nixpkgs to fetch
-, outputSha256 ? null             # The SHA256 fixed-output hash
+, sha256                          # The SHA256 of the downloaded data
+, outputSha256 ? null             # The SHA256 output hash
 , system ? builtins.currentSystem # This is overridable if necessary
 }:
 
-# In Nix 1.12, we can just give a `sha256` to `builtins.fetchTarball`.
-builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
-  sha256 = outputSha256;
+with {
+  ifThenElse = { bool, thenValue, elseValue }: (
+    if bool then thenValue else elseValue);
+};
+
+ifThenElse {
+  bool = (0 <= builtins.compareVersions builtins.nixVersion "1.12");
+
+  # In Nix 1.12, we can just give a `sha256` to `builtins.fetchTarball`.
+  thenValue = (
+    builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+      sha256 = outputSha256;
+    });
+
+  # This hack should at least work for Nix 1.11
+  elseValue = (
+    (rec {
+      tarball = import <nix/fetchurl.nix> {
+        url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+        inherit sha256;
+      };
+
+      builtin-paths = import <nix/config.nix>;
+      
+      script = builtins.toFile "nixpkgs-unpacker" ''
+        "$coreutils/mkdir" "$out"
+        cd "$out"
+        "$gzip" --decompress < "$tarball" | "$tar" -x --strip-components=1
+      '';
+
+      nixpkgs = builtins.derivation ({
+        name = "nixpkgs-${builtins.substring 0 6 rev}";
+
+        builder = builtins.storePath builtin-paths.shell;
+
+        args = [ script ];
+
+        inherit tarball system;
+
+        tar       = builtins.storePath builtin-paths.tar;
+        gzip      = builtins.storePath builtin-paths.gzip;
+        coreutils = builtins.storePath builtin-paths.coreutils;
+      } // (if null == outputSha256 then { } else {
+        outputHashMode = "recursive";
+        outputHashAlgo = "sha256";
+        outputHash = outputSha256;
+      }));
+    }).nixpkgs);
 }

--- a/nix/proto3-wire.nix
+++ b/nix/proto3-wire.nix
@@ -1,25 +1,22 @@
 { mkDerivation, base, bytestring, cereal, containers, deepseq
-, doctest, fetchgit, ghc-prim, hashable, primitive, QuickCheck
-, safe, stdenv, tasty, tasty-hunit, tasty-quickcheck, text
-, transformers, unordered-containers, vector
+, doctest, fetchgit, hashable, QuickCheck, safe, stdenv, tasty
+, tasty-hunit, tasty-quickcheck, text, unordered-containers
 }:
 mkDerivation {
   pname = "proto3-wire";
-  version = "1.2.0";
+  version = "1.1.0";
   src = fetchgit {
     url = "https://github.com/awakesecurity/proto3-wire";
-    sha256 = "0vac5a82ip20pclb80kh2a39z285a866ki6d06hh7fam300k6q3i";
-    rev = "99a8a2c70a80e62c4a09d41689ec3aa5efe2f67a";
-    fetchSubmodules = true;
+    sha256 = "16l1rnnygwk1b2sb3l6klhr6ad0wvry204icxnc81c6rbzbk6rqc";
+    rev = "4f355bbac895d577d8a28f567ab4380f042ccc24";
   };
   libraryHaskellDepends = [
-    base bytestring cereal containers deepseq ghc-prim hashable
-    primitive QuickCheck safe text transformers unordered-containers
-    vector
+    base bytestring cereal containers deepseq hashable QuickCheck safe
+    text unordered-containers
   ];
   testHaskellDepends = [
     base bytestring cereal doctest QuickCheck tasty tasty-hunit
-    tasty-quickcheck text transformers vector
+    tasty-quickcheck text
   ];
   description = "A low-level implementation of the Protocol Buffers (version 3) wire format";
   license = stdenv.lib.licenses.asl20;

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -1,5 +1,5 @@
 name:                proto3-suite
-version:             0.4.0.1
+version:             0.4.0.0
 synopsis:            A low level library for writing out data in the Protocol Buffers wire format
 license:             Apache-2.0
 author:              Awake Security
@@ -60,7 +60,7 @@ library
                        parsers >= 0.12 && <0.13,
                        pretty ==1.1.*,
                        pretty-show >= 1.6.12 && < 2.0,
-                       proto3-wire == 1.2.*,
+                       proto3-wire == 1.1.*,
                        QuickCheck >=2.10 && <2.14,
                        quickcheck-instances < 0.4,
                        safe ==0.3.*,
@@ -109,10 +109,10 @@ test-suite tests
                        mtl ==2.2.*,
                        pretty-show >= 1.6.12 && < 2.0,
                        proto3-suite,
-                       proto3-wire == 1.2.*,
+                       proto3-wire == 1.1.*,
                        semigroups ==0.18.*,
                        swagger2,
-                       tasty >= 0.11 && <1.3,
+                       tasty >= 0.11 && <1.2,
                        tasty-hunit >= 0.9 && <0.11,
                        tasty-quickcheck >= 0.8.4 && <0.11,
                        text >= 0.2 && <1.3,
@@ -125,7 +125,7 @@ executable compile-proto-file
   main-is:             Main.hs
   hs-source-dirs:      tools/compile-proto-file
   default-language:    Haskell2010
-  build-depends:       base >=4.12 && <5.0
+  build-depends:       base >=4.8 && <5.0
                        , optparse-applicative
                        , proto3-suite
                        , system-filepath
@@ -142,7 +142,7 @@ executable canonicalize-proto-file
                        , mtl ==2.2.*
                        , optparse-generic
                        , proto3-suite
-                       , proto3-wire == 1.2.*
+                       , proto3-wire == 1.1.*
                        , range-set-list >=0.1.2 && <0.2
                        , system-filepath
                        , turtle

--- a/release.nix
+++ b/release.nix
@@ -7,14 +7,15 @@
 #     [nix-shell]$ cabal configure --enable-tests
 #     [nix-shell]$ cabal test
 
-{ compiler ? "ghc865", enableDhall ? false }:
+{ compiler ? "ghc844", enableDhall ? false }:
 
 let
   fetchNixpkgs = import ./nix/fetchNixpkgs.nix;
 
   nixpkgs = fetchNixpkgs {
-    rev          = "d2a2ec2ebe49c42127cbf316d215a64c60d68fde";
-    outputSha256 = "09p9cr07frsqh7vip2i7cp86xnafg1pxhbnphx0q4sd5bvilqpfm";
+    rev          = "bedbba61380a4da0318de41fcb790c176e1f26d1";
+    sha256       = "0z4fgh15nz86kxib9ildmh49v6jim6vgbjyla7jbmgdcl0vd9qsg";
+    outputSha256 = "0dxxw2ipa9403nk8lggjsypbr1a9jpb3q4hkjsg89gr5wz26p217";
   };
 
   config = { };
@@ -35,8 +36,7 @@ let
                     haskellPackagesNew.callPackage ./nix/formatting.nix { };
 
                   megaparsec =
-                    pkgsNew.haskell.lib.dontCheck
-                      (haskellPackagesNew.callPackage ./nix/megaparsec.nix { });
+                    haskellPackagesNew.callPackage ./nix/megaparsec.nix { };
 
                   neat-interpolation =
                     haskellPackagesNew.callPackage ./nix/neat-interpolation.nix { };


### PR DESCRIPTION
Revert to ca03aa9d846d88b0762e40f9588b4927de22f798

Commit e740674a4c70f3fb0bae34c8bff3c31c70359c77 was meant for a PR,
not for direct inclusion into master.