### PR TITLE
Update dependencies for Stackage

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -110,7 +110,7 @@ test-suite tests
                        pretty-show >= 1.6.12 && < 2.0,
                        proto3-suite,
                        proto3-wire == 1.2.*,
-                       semigroups ==0.18.*,
+                       semigroups >= 0.18 && < 0.20,
                        swagger2,
                        tasty >= 0.11 && <1.3,
                        tasty-hunit >= 0.9 && <0.11,

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -64,14 +64,14 @@ library
                        QuickCheck >=2.10 && <2.14,
                        quickcheck-instances < 0.4,
                        safe ==0.3.*,
-                       semigroups >= 0.18 && < 0.20,
                        swagger2 >=2.1.6 && <2.6,
                        system-filepath,
                        text >= 0.2 && <1.3,
                        transformers >=0.4 && <0.6,
                        turtle,
                        vector >=0.11 && < 0.13
-
+  if !impl(ghc >= 8.0)
+    build-depends:     semigroups >= 0.18 && < 0.20
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -O2 -Wall
@@ -110,7 +110,6 @@ test-suite tests
                        pretty-show >= 1.6.12 && < 2.0,
                        proto3-suite,
                        proto3-wire == 1.2.*,
-                       semigroups >= 0.18 && < 0.20,
                        swagger2,
                        tasty >= 0.11 && <1.3,
                        tasty-hunit >= 0.9 && <0.11,
@@ -119,6 +118,8 @@ test-suite tests
                        transformers >=0.4 && <0.6,
                        turtle,
                        vector >=0.11 && < 0.13
+  if !impl(ghc >= 8.0)
+    build-depends:     semigroups >= 0.18 && < 0.20
   ghc-options:         -O2 -Wall
 
 executable compile-proto-file


### PR DESCRIPTION
Relaxes semigroups version bounds on tests and makes them conditional on GHC>8.0

Done for [gRPC-haskell#97](https://github.com/awakesecurity/gRPC-haskell/issues/97)