### PR TITLE
Remove useLegacyTypes flag that guards old behavior of compile-to-proto

### DIFF
--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -73,54 +73,7 @@ data CompileArgs = CompileArgs
   , extraInstanceFiles :: [FilePath]
   , inputProto         :: FilePath
   , outputDir          :: FilePath
-  , useLegacyTypes     :: UseLegacyTypes
   }
-
-{-|
-Used as a compiler arg that determines whether or not to use the legacy
-behavior for handling protocol buffer Wrapper messages. These Wrapper
-messages can be found in @test-files/google/protobuf/wrappers.proto@
-(path is relative to root).
-
-Example @.proto@ file:
-@
-syntax = "proto3";
-package example;
-import "google/protobuf/wrappers.proto";
-
-message Test {
-  google.protobuf.Int32Value x = 1;
-  google.protobuf.BytesValue y = 2;
-}
-@
-
-From the @.proto@ file above, the legacy behavior
-generates the corresponding @Example.hs@ file:
-@
-module Example where
-
-import qualified Google.Protobuf.Wrappers
-
-data Test = Test
-  { testX :: Maybe Google.Protobuf.Wrappers.Int32Value
-  , testY :: Maybe Google.Protobuf.Wrappers.BytesValue
-  } deriving (...)
-@
-
-The new behavior generates:
-@
-module Example where
-
-import qualified Google.Protobuf.Wrappers
-
-data Test = Test
-  { testX :: Maybe Int32
-  , testY :: Maybe ByteString
-  } deriving (...)
-@
--}
-data UseLegacyTypes = YesLegacy | NoLegacy
-  deriving (Eq, Show)
 
 -- | Generate a Haskell module corresponding to a @.proto@ file
 compileDotProtoFile :: CompileArgs -> IO (Either CompileError ())

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -92,18 +92,12 @@ message Test {
   google.protobuf.Int32Value x = 1;
   google.protobuf.BytesValue y = 2;
 }
-
-...
 @
 
 From the @.proto@ file above, the legacy behavior
 generates the corresponding @Example.hs@ file:
 @
-...
-
 module Example where
-
-...
 
 import qualified Google.Protobuf.Wrappers
 
@@ -111,17 +105,11 @@ data Test = Test
   { testX :: Maybe Google.Protobuf.Wrappers.Int32Value
   , testY :: Maybe Google.Protobuf.Wrappers.BytesValue
   } deriving (...)
-
-...
 @
 
 The new behavior generates:
 @
-...
-
 module Example where
-
-...
 
 import qualified Google.Protobuf.Wrappers
 
@@ -129,8 +117,6 @@ data Test = Test
   { testX :: Maybe Int32
   , testY :: Maybe ByteString
   } deriving (...)
-
-...
 @
 -}
 data UseLegacyTypes = YesLegacy | NoLegacy

--- a/tests/TestCodeGen.hs
+++ b/tests/TestCodeGen.hs
@@ -130,11 +130,11 @@ simpleDecodeDotProto =
 
 -- * Helpers
 
--- E.g. dumpAST NoLegacy ["test-files"] "test_proto.proto"
-dumpAST :: UseLegacyTypes -> [FilePath] -> FilePath -> IO ()
-dumpAST useLegacyTypes incs fp = (either (error . show) putStrLn <=< runExceptT) $ do
+-- E.g. dumpAST ["test-files"] "test_proto.proto"
+dumpAST :: [FilePath] -> FilePath -> IO ()
+dumpAST incs fp = (either (error . show) putStrLn <=< runExceptT) $ do
   (dp, tc) <- readDotProtoWithContext incs fp
-  src <- renderHsModuleForDotProto useLegacyTypes mempty dp tc
+  src <- renderHsModuleForDotProto mempty dp tc
   pure src
 
 hsTmpDir, pyTmpDir :: IsString a => a
@@ -158,7 +158,6 @@ compileTestDotProtos = do
                    , extraInstanceFiles = []
                    , outputDir = hsTmpDir
                    , inputProto = protoFile
-                   , useLegacyTypes = NoLegacy
                    }
 
     let cmd = T.concat [ "protoc --python_out="

--- a/tools/compile-proto-file/Main.hs
+++ b/tools/compile-proto-file/Main.hs
@@ -16,7 +16,7 @@ import           Proto3.Suite.DotProto.Generate
 parseArgs :: ParserInfo CompileArgs
 parseArgs = info (helper <*> parser) (fullDesc <> progDesc "Compiles a .proto file to a Haskell module")
   where
-    parser = CompileArgs <$> includes <*> extraInstances <*> proto <*> out <*> useLegacyTypes
+    parser = CompileArgs <$> includes <*> extraInstances <*> proto <*> out
 
     includes = many $ strOption $
       long "includeDir"
@@ -37,14 +37,6 @@ parseArgs = info (helper <*> parser) (fullDesc <> progDesc "Compiles a .proto fi
       long "out"
         <> metavar "DIR"
         <> help "Output directory path where generated Haskell modules will be written (directory is created if it does not exist; note that files in the output directory may be overwritten!)"
-
-    boolToUseLegacyTypes = \bool -> case bool of
-      True -> YesLegacy
-      False -> NoLegacy
-
-    useLegacyTypes = boolToUseLegacyTypes <$> (switch $
-      long "use-legacy-types"
-        <> help "If this flag is set, the program will use legacy behavior to wrap protobuf Wrapper types (e.g. Int32Value) with Maybe in the generated Haskell code (provided for backwards compatibility).")
 
 main :: IO ()
 main = execParser parseArgs >>= compileDotProtoFileOrDie


### PR DESCRIPTION
When adding the new behavior for translating `protobuf` files to Haskell modules, we added a flag to keep the old behavior for backwards compatibility (the new behavior became the default). In this PR we are now completely removing that flag and completely removing the old behavior.