### PR TITLE
Fix cabal build (for version 3.2) and add newline in generated haskell file

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -87,8 +87,13 @@ test-suite tests
     cpp-options:       -DDHALL
 
   other-modules:       ArbitraryGeneratedTestTypes
-                       TestProto
                        TestCodeGen
+                       TestProto
+                       TestProtoImport
+                       TestProtoOneof
+                       TestProtoOneofImport
+  autogen-modules:
+                       TestProto
                        TestProtoImport
                        TestProtoOneof
                        TestProtoOneofImport

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -115,7 +115,7 @@ renderHsModuleForDotProto
     => ([HsImportDecl],[HsDecl]) -> DotProto -> TypeContext -> m String
 renderHsModuleForDotProto extraInstanceFiles dotProto importCtxt = do
     haskellModule <- hsModuleForDotProto extraInstanceFiles dotProto importCtxt
-    return (T.unpack header ++ prettyPrint haskellModule)
+    return (T.unpack header ++ "\n" ++ prettyPrint haskellModule)
   where
     header = [Neat.text|
       {-# LANGUAGE DeriveGeneric     #-}


### PR DESCRIPTION
Hello. I currently ran into a couple of issues in terms of how I am using this project, and so I fixed them in my fork. Feel free to take my changes or reject if they will not fit into the way you are using.

I am building with cabal inside of a larger project and I am using compile-proto-file to generate a clean haskell interface into a larger protocol buffer based ecosystem.

I am experiencing 2 issues which this pull request addresses:

1. When I try to install compile-proto-file using cabal, it complains about missing test modules which I fixed by adding an "autogenerated-modules" section to the cabal file.

1. All of the haskell files that compile-proto-file produces in my local build put the module name on the same line as the comment at the end of the header section so I added a newline in between.

Since I am not seeing any issues for these large breakages I am experiencing, I have a hunch that the issues have something to do with a dependency mismatch since I am not using nix to build. In that case, possibly these changes will make this module more useful, although possibly not.