### PR TITLE
Widen upper dependency bounds

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -38,11 +38,11 @@ library
   other-modules:       Proto3.Suite.DotProto.Internal
                        Proto3.Suite.DotProto.Generate.Swagger
                        Proto3.Suite.JSONPB.Class
-  build-depends:       aeson >= 1.1.1.0 && < 1.5,
+  build-depends:       aeson >= 1.1.1.0 && < 1.6,
                        aeson-pretty,
                        attoparsec >= 0.13.0.1,
                        base >=4.8 && <5.0,
-                       base64-bytestring >= 1.0.0.1 && < 1.1,
+                       base64-bytestring >= 1.0.0.1 && < 1.2,
                        binary >=0.8.3,
                        bytestring >=0.10.6.0 && <0.11.0,
                        deepseq ==1.4.*,
@@ -62,7 +62,7 @@ library
                        pretty ==1.1.*,
                        pretty-show >= 1.6.12 && < 2.0,
                        proto3-wire == 1.2.*,
-                       QuickCheck >=2.10 && <2.14,
+                       QuickCheck >=2.10 && <2.15,
                        quickcheck-instances < 0.4,
                        safe ==0.3.*,
                        swagger2 >=2.1.6 && <2.7,
@@ -101,11 +101,11 @@ test-suite tests
   hs-source-dirs:      tests gen
   default-language:    Haskell2010
   build-depends:       base >=4.8 && <5.0,
-                       QuickCheck >=2.10 && <2.14,
-                       aeson >= 1.1.1.0 && < 1.5,
+                       QuickCheck >=2.10 && <2.15,
+                       aeson >= 1.1.1.0 && < 1.6,
                        attoparsec >= 0.13.0.1,
                        base >=4.8 && <5.0,
-                       base64-bytestring >= 1.0.0.1 && < 1.1,
+                       base64-bytestring >= 1.0.0.1 && < 1.2,
                        bytestring >=0.10.6.0 && <0.11.0,
                        cereal >= 0.5.1 && <0.6,
                        containers >=0.5 && < 0.7,


### PR DESCRIPTION
 - aeson: < 1.5 -> < 1.6
 - base64-bytestring: < 1.1 -> < 1.2
 - QuickCheck: < 2.14 -> < 2.15

(tested with `cabal test` in nix env)