### PR TITLE
expose internal modules

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -1,5 +1,5 @@
 name:                proto3-suite
-version:             0.4.0.2
+version:             0.4.1.0
 synopsis:            A low level library for writing out data in the Protocol Buffers wire format
 license:             Apache-2.0
 author:              Awake Security
@@ -35,7 +35,7 @@ library
                        Proto3.Suite.Tutorial
                        Proto3.Suite.Types
 
-  other-modules:       Proto3.Suite.DotProto.Internal
+                       Proto3.Suite.DotProto.Internal
                        Proto3.Suite.DotProto.Generate.Swagger
                        Proto3.Suite.JSONPB.Class
   build-depends:       aeson >= 1.1.1.0 && < 1.6,


### PR DESCRIPTION
I want to extend this to generate stuff besides Haskell by using it as a library, but to do so I need access to the Internal module. I figured might as well expose the other two as well.