### PR TITLE
proto3-suite 0.4.2.0: Track grpc-haskell-0.0.2.0 changes

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -1,5 +1,5 @@
 name:                proto3-suite
-version:             0.4.1.0
+version:             0.4.2.0
 synopsis:            A low level library for writing out data in the Protocol Buffers wire format
 license:             Apache-2.0
 author:              Awake Security

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -1483,6 +1483,7 @@ dotProtoServiceD pkgIdent ctxt serviceIdent service = do
                                , patVar "initialMetadata"
                                , patVar "sslConfig"
                                , patVar "logger"
+                               , patVar "serverMaxReceiveMessageLength"
                                ]
                       ]
                       (HsUnGuardedRhs (apply serverLoopE [ serverOptsE ]))
@@ -1526,8 +1527,8 @@ dotProtoServiceD pkgIdent ctxt serviceIdent service = do
                  , update "optInitialMetadata" "initialMetadata"
                  , update "optSSLConfig" "sslConfig"
                  , update "optLogger" "logger"
+                 , update "optMaxReceiveMessageLength" "serverMaxReceiveMessageLength"
                  ]
-
 
      let clientT = tyApp (HsTyCon (unqual_ serviceName)) [ clientRequestT, clientResultT ]
 


### PR DESCRIPTION
`ServiceOptions` have been slightly extended to support the max receive message
length channel arg, so we need to tweak code generation slightly.