### PR TITLE
Version 0.4.1

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -1,5 +1,5 @@
 name:                proto3-suite
-version:             0.4.2.0
+version:             0.4.1
 synopsis:            A low level library for writing out data in the Protocol Buffers wire format
 license:             Apache-2.0
 author:              Awake Security


### PR DESCRIPTION
This is to prepare for a Hackage release

I'm downgrading the version in `proto3-suite.cabal` to 0.4.1 because we
never cut a 0.4.1 release to Hackage, yet.