### PR TITLE
Support disabling swagger conditionally.

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -7,7 +7,7 @@ maintainer:          opensource@awakesecurity.com
 copyright:           2017-2018 Awake Security
 category:            Codec
 build-type:          Simple
-cabal-version:       >=1.10
+cabal-version:       2.0
 data-files:          test-files/*.bin tests/encode.sh tests/decode.sh
 
 Flag dhall

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -96,6 +96,7 @@ test-suite tests
 
   if flag(swagger)
     build-depends:     swagger2
+    cpp-options:       -DSWAGGER
 
   other-modules:       ArbitraryGeneratedTestTypes
                        TestCodeGen

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -15,13 +15,22 @@ Flag dhall
   Default:       False
   Manual:        True
 
+Flag swagger
+  Description:   Turn on Swagger doc generation.
+  Default:       False
+  Manual:        True
+
 library
 
   if flag(dhall)
     exposed-modules:   Proto3.Suite.DhallPB
     build-depends:     dhall >=1.13 && < 1.34
-
     cpp-options:       -DDHALL
+
+  if flag(swagger)
+    exposed-modules:   Proto3.Suite.DotProto.Generate.Swagger
+    build-depends:     swagger2 >=2.1.6 && <2.7
+    cpp-options:       -DSWAGGER
 
   exposed-modules:     Proto3.Suite
                        Proto3.Suite.Class
@@ -36,8 +45,8 @@ library
                        Proto3.Suite.Types
 
                        Proto3.Suite.DotProto.Internal
-                       Proto3.Suite.DotProto.Generate.Swagger
                        Proto3.Suite.JSONPB.Class
+
   build-depends:       aeson >= 1.1.1.0 && < 1.6,
                        aeson-pretty,
                        attoparsec >= 0.13.0.1,
@@ -65,7 +74,6 @@ library
                        QuickCheck >=2.10 && <2.15,
                        quickcheck-instances < 0.4,
                        safe ==0.3.*,
-                       swagger2 >=2.1.6 && <2.7,
                        system-filepath,
                        text >= 0.2 && <1.3,
                        transformers >=0.4 && <0.6,
@@ -85,6 +93,9 @@ test-suite tests
     other-modules:     TestDhall
     build-depends:     dhall >=1.13 && < 1.34
     cpp-options:       -DDHALL
+
+  if flag(swagger)
+    build-depends:     swagger2
 
   other-modules:       ArbitraryGeneratedTestTypes
                        TestCodeGen
@@ -116,7 +127,6 @@ test-suite tests
                        pretty-show >= 1.6.12 && < 2.0,
                        proto3-suite,
                        proto3-wire == 1.2.*,
-                       swagger2,
                        tasty >= 0.11 && <1.3,
                        tasty-hunit >= 0.9 && <0.11,
                        tasty-quickcheck >= 0.8.4 && <0.11,

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -17,7 +17,7 @@ Flag dhall
 
 Flag swagger
   Description:   Turn on Swagger doc generation.
-  Default:       False
+  Default:       True
   Manual:        True
 
 library

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -626,9 +626,11 @@ dotProtoMessageD ctxt parentIdent messageIdent messageParts = do
           , pure (toJSONInstDecl messageName)
           , pure (fromJSONInstDecl messageName)
 
+#ifdef SWAGGER
           -- And the Swagger ToSchema instance corresponding to JSONPB encodings
           , toSchemaInstanceDeclaration messageName Nothing
               =<< foldMapM (traverse dpIdentUnqualName . getName) messageParts
+#endif
 
 #ifdef DHALL
           -- Generate Dhall instances
@@ -683,12 +685,16 @@ dotProtoMessageD ctxt parentIdent messageIdent messageParts = do
 
       (cons, idents) <- fmap unzip (mapM (oneOfCons fullName) fields)
 
+#ifdef SWAGGER
       toSchemaInstance <- toSchemaInstanceDeclaration fullName (Just idents)
                             =<< mapM (dpIdentUnqualName . dotProtoFieldName) fields
+#endif
 
       pure [ dataDecl_ fullName cons defaultMessageDeriving
            , namedInstD fullName
+#ifdef SWAGGER
            , toSchemaInstance
+#endif
 
 #ifdef DHALL
            , dhallInterpretInstDecl fullName

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -1077,6 +1077,7 @@ toSchemaInstanceDeclaration messageName maybeConstructors fieldNames = do
 
   let _namedSchemaNameExpression = HsApp justC (str_ messageName)
 
+#ifdef SWAGGER
       -- { _paramSchemaType = HsJSONPB.SwaggerObject
       -- }
   let paramSchemaUpdates =
@@ -1089,6 +1090,9 @@ toSchemaInstanceDeclaration messageName maybeConstructors fieldNames = do
           _paramSchemaTypeExpression = HsApp justC (HsVar (jsonpbName "SwaggerObject"))
 #else
           _paramSchemaTypeExpression = HsVar (jsonpbName "SwaggerObject")
+#endif
+#else
+  let paramSchemaUpdates = []
 #endif
 
   let _schemaParamSchemaExpression = HsRecUpdate memptyE paramSchemaUpdates

--- a/src/Proto3/Suite/JSONPB.hs
+++ b/src/Proto3/Suite/JSONPB.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP                       #-}
+
 module Proto3.Suite.JSONPB
   ( -- * Typeclasses
     FromJSONPB(..)
@@ -30,6 +32,7 @@ module Proto3.Suite.JSONPB
   , A.FromJSON(..)
   , A.typeMismatch
   , A.withObject
+#ifdef SWAGGER
     -- * Swagger schema helpers
   , Swagger.ToSchema(..)
   , Swagger.NamedSchema(..)
@@ -40,11 +43,14 @@ module Proto3.Suite.JSONPB
   , Proto3.Suite.DotProto.Generate.Swagger.OverrideToSchema(..)
   , Proto3.Suite.DotProto.Generate.Swagger.asProxy
   , Proto3.Suite.DotProto.Generate.Swagger.insOrdFromList
+#endif
   )
 where
 
 import qualified Data.Aeson                             as A
 import qualified Data.Aeson.Types                       as A
+#ifdef SWAGGER
 import qualified Data.Swagger                           as Swagger
 import           Proto3.Suite.DotProto.Generate.Swagger
+#endif
 import           Proto3.Suite.JSONPB.Class

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -63,6 +63,12 @@ docTests = testCase "doctests" $ do
     [ "-isrc"
     , "-itests"
     , "-igen"
+#ifdef SWAGGER
+    , "-DSWAGGER"
+#endif
+#ifdef DHALL
+    , "-DDHALL"
+#endif
     , "src/Proto3/Suite/DotProto/Internal.hs"
     , "src/Proto3/Suite/JSONPB/Class.hs"
     , "tests/TestCodeGen.hs"


### PR DESCRIPTION
The swagger2 library is broken under recent versions of cabal and ghc, causing this library unusable.

This pull request import a flag to disable the swagger part conditionally.