### PR TITLE
Remove autogen-modules from `proto3-suite.cabal`

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -104,11 +104,6 @@ test-suite tests
                        TestProtoImport
                        TestProtoOneof
                        TestProtoOneofImport
-  autogen-modules:
-                       TestProto
-                       TestProtoImport
-                       TestProtoOneof
-                       TestProtoOneofImport
 
   hs-source-dirs:      tests gen
   default-language:    Haskell2010


### PR DESCRIPTION
Based on https://github.com/haskell/cabal/issues/7348 it appears that
this is a misuse of autogen-modules and the simplest fix is to remove
the annotation.

The practical consequence of fixing this is that we will be able to
now upload `proto3-suite` to Hackage again.