### PR TITLE
Fix incorrect `enableSwagger` behavior in Nix code

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 { compiler ? "ghc884"
 , enableDhall ? false
-, enableSwagger ? false
+, enableSwagger ? true
 }:
 
 let

--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -35,7 +35,7 @@ pkgsNew: pkgsOld:
                 let
                   cabal2nixFlags = pkgsNew.lib.concatStringsSep " " [
                     (if enableDhall then "-fdhall" else "")
-                    (if enableSwagger then "-fswagger" else "")
+                    (if enableSwagger then "" else "-f-swagger")
                   ];
                 in
                 (haskellPackagesNew.callCabal2nixWithOptions
@@ -52,7 +52,7 @@ pkgsNew: pkgsOld:
                     configureFlags = (oldArgs.configureFlags or [ ])
                       ++ [ "--disable-optimization" ]
                       ++ (if enableDhall then [ "-fdhall" ] else [ ])
-                      ++ (if enableSwagger then [ "-fswagger" ] else [ ]);
+                      ++ (if enableSwagger then [ "" ] else [ "-f-swagger" ]);
                     doCheck = false;
                     doHaddock = false;
                   });
@@ -113,7 +113,7 @@ pkgsNew: pkgsOld:
 
                       configureFlags = (oldArgs.configureFlags or [ ])
                         ++ (if enableDhall then [ "-fdhall" ] else [ ])
-                        ++ (if enableSwagger then [ "-fswagger" ] else [ ]);
+                        ++ (if enableSwagger then [ "" ] else [ "-f-swagger" ]);
 
                       postPatch = (oldArgs.postPatch or "") + copyGeneratedCode;
 

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -22,12 +22,12 @@ category:            Codec
 build-type:          Simple
 data-files:          test-files/*.bin tests/encode.sh tests/decode.sh
 
-Flag dhall
+flag dhall
   Description:   Turn on Dhall interpret and inject codegen
   Default:       False
   Manual:        True
 
-Flag swagger
+flag swagger
   Description:   Turn on Swagger doc generation.
   Default:       True
   Manual:        True

--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,7 @@
 { fast ? false
 , compiler ? "ghc884"
 , enableDhall ? false
-, enableSwagger ? false
+, enableSwagger ? true
 }@args:
 
 with (import ./default.nix { inherit compiler enableDhall enableSwagger; });


### PR DESCRIPTION
I implemented this incorrectly in https://github.com/awakesecurity/proto3-suite/pull/159.

The `swagger` Cabal flag is enabled by default, so we need to specify
the negative version instead.