### PR TITLE
Remove `Optional` from Protobuf AST

### DIFF
--- a/src/Proto3/Suite/DotProto/AST.hs
+++ b/src/Proto3/Suite/DotProto/AST.hs
@@ -268,7 +268,6 @@ instance Arbitrary Packing where
 --   are meaningful in every type context.
 data DotProtoType
   = Prim           DotProtoPrimType
-  | Optional       DotProtoPrimType
   | Repeated       DotProtoPrimType
   | NestedRepeated DotProtoPrimType
   | Map            DotProtoPrimType DotProtoPrimType

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -464,7 +464,6 @@ foldDPT dptToHsCont foldPrim ctxt dpt =
   in
     case dpt of
       Prim pType           -> cont <$> prim pType
-      Optional pType       -> cont <$> prim pType
       Repeated pType       -> cont <$> prim pType
       NestedRepeated pType -> cont <$> prim pType
       Map k v  | validMapKey k -> HsTyApp . cont <$> prim k <*> go (Prim v) -- need to 'Nest' message types
@@ -490,7 +489,6 @@ dptToHsContType :: TypeContext -> DotProtoType -> HsType -> HsType
 dptToHsContType ctxt = \case
   Prim (Named tyName) | isMessage ctxt tyName
                      -> HsTyApp $ primType_ "Maybe"
-  Optional _         -> HsTyApp $ primType_ "Maybe"
   Repeated _         -> HsTyApp $ primType_ "Vector"
   NestedRepeated _   -> HsTyApp $ primType_ "Vector"
   Map _ _            -> HsTyApp $ primType_ "Map"
@@ -1583,7 +1581,7 @@ dotProtoServiceD pkgIdent ctxt serviceIdent service = do
 -- * Common Haskell expressions, constructors, and operators
 --
 
-dotProtoFieldC, primC, optionalC, repeatedC, nestedRepeatedC, namedC, mapC,
+dotProtoFieldC, primC, repeatedC, nestedRepeatedC, namedC, mapC,
   fieldNumberC, singleC, dotsC, pathC, nestedC, anonymousC, dotProtoOptionC,
   identifierC, stringLitC, intLitC, floatLitC, boolLitC, trueC, falseC,
   unaryHandlerC, clientStreamHandlerC, serverStreamHandlerC, biDiStreamHandlerC,
@@ -1595,7 +1593,6 @@ dotProtoFieldC, primC, optionalC, repeatedC, nestedRepeatedC, namedC, mapC,
 
 dotProtoFieldC       = HsVar (protobufName "DotProtoField")
 primC                = HsVar (protobufName "Prim")
-optionalC            = HsVar (protobufName "Optional")
 repeatedC            = HsVar (protobufName "Repeated")
 nestedRepeatedC      = HsVar (protobufName "NestedRepeated")
 namedC               = HsVar (protobufName "Named")
@@ -1720,7 +1717,6 @@ optionE (DotProtoOption name value) =
 -- | Translate a dot proto type to its Haskell AST type
 dpTypeE :: DotProtoType -> HsExp
 dpTypeE (Prim p)           = apply primC           [ dpPrimTypeE p ]
-dpTypeE (Optional p)       = apply optionalC       [ dpPrimTypeE p ]
 dpTypeE (Repeated p)       = apply repeatedC       [ dpPrimTypeE p ]
 dpTypeE (NestedRepeated p) = apply nestedRepeatedC [ dpPrimTypeE p ]
 dpTypeE (Map k v)          = apply mapC            [ dpPrimTypeE k, dpPrimTypeE v]

--- a/src/Proto3/Suite/DotProto/Rendering.hs
+++ b/src/Proto3/Suite/DotProto/Rendering.hs
@@ -187,7 +187,6 @@ instance Pretty DotProtoValue where
 
 instance Pretty DotProtoType where
   pPrint (Prim           ty) = pPrint ty
-  pPrint (Optional       ty) = pPrint ty
   pPrint (Repeated       ty) = PP.text "repeated" <+> pPrint ty
   pPrint (NestedRepeated ty) = PP.text "repeated" <+> pPrint ty
   pPrint (Map keyty valuety) = PP.text "map<" <> pPrint keyty <> PP.text ", " <> pPrint valuety <> PP.text ">"


### PR DESCRIPTION
It's a `proto2` feature (and this is `proto3-suite`), and our parser
doesn't look for it, so it never appears in the AST anyways.

Also, I'd value the ability to treat e.g. `Maybe ByteString` as a
`BytesValue` and not be uncertain whether it's actually a `optional
bytes`.