### PR TITLE
Use Swagger schema `format` to distinguish wrapper types from primitives

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -32,6 +32,11 @@ flag swagger
   Default:       True
   Manual:        True
 
+flag swagger-wrapper-format
+  Description:   Change Swagger schema format for Protobuf wrapper types
+  Default:       False
+  Manual:        True
+
 library
 
   if flag(dhall)
@@ -43,6 +48,8 @@ library
     exposed-modules:   Proto3.Suite.DotProto.Generate.Swagger
     build-depends:     swagger2 >=2.1.6 && <2.7
     cpp-options:       -DSWAGGER
+    if flag(swagger-wrapper-format)
+      cpp-options:       -DSWAGGER_WRAPPER_FORMAT
 
   exposed-modules:     Proto3.Suite
                        Proto3.Suite.Class
@@ -112,6 +119,8 @@ test-suite tests
   if flag(swagger)
     build-depends:     swagger2
     cpp-options:       -DSWAGGER
+    if flag(swagger-wrapper-format)
+      cpp-options:       -DSWAGGER_WRAPPER_FORMAT
 
   other-modules:       ArbitraryGeneratedTestTypes
                        TestCodeGen

--- a/src/Proto3/Suite/DotProto/Generate/Swagger.hs
+++ b/src/Proto3/Suite/DotProto/Generate/Swagger.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -27,7 +27,8 @@ import           Data.Aeson                      (Value (String), ToJSONKey,
                                                   ToJSONKeyFunction(..))
 import qualified Data.Aeson                      as Aeson
 import           Data.Aeson.Encode.Pretty        (encodePretty)
-import           Data.ByteString                 (ByteString)
+import qualified Data.ByteString                 as B
+import qualified Data.ByteString.Lazy            as BL
 import qualified Data.ByteString.Lazy.Char8      as LC8
 import           Data.Hashable                   (Hashable)
 import           Data.HashMap.Strict.InsOrd      (InsOrdHashMap)
@@ -35,6 +36,7 @@ import qualified Data.HashMap.Strict.InsOrd
 import           Data.Map                        (Map)
 import           Data.Swagger
 import qualified Data.Text                       as T
+import qualified Data.Text.Lazy                  as TL
 import           Data.Proxy
 import qualified Data.Vector                     as V
 import           GHC.Exts                        (Proxy#, proxy#)
@@ -56,15 +58,15 @@ newtype OverrideToSchema a = OverrideToSchema { unOverride :: a }
 instance {-# OVERLAPPABLE #-} ToSchema a => ToSchema (OverrideToSchema a) where
   declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy a)
 
-instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema ByteString) where
+instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema B.ByteString) where
   declareNamedSchema _ = return (NamedSchema Nothing byteSchema)
 
 -- | This instance is the same as the instance for @OverrideToSchema ByteString@.
 -- See: https://hackage.haskell.org/package/swagger2-2.6/docs/src/Data.Swagger.Internal.Schema.html#line-451
-instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (Maybe ByteString)) where
+instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (Maybe B.ByteString)) where
   declareNamedSchema _ = return (NamedSchema Nothing byteSchema)
 
-instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (V.Vector ByteString)) where
+instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (V.Vector B.ByteString)) where
   declareNamedSchema _ = return (NamedSchema Nothing schema_)
     where
       schema_ = mempty
@@ -75,12 +77,12 @@ instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (V.Vector ByteString)) w
 #endif
         & items ?~ SwaggerItemsObject (Inline byteSchema)
 
-instance {-# OVERLAPPING #-} (ToJSONKey k, ToSchema k) => ToSchema (OverrideToSchema (Map k ByteString)) where
+instance {-# OVERLAPPING #-} (ToJSONKey k, ToSchema k) => ToSchema (OverrideToSchema (Map k B.ByteString)) where
   declareNamedSchema _ = case Aeson.toJSONKey :: ToJSONKeyFunction k of
       ToJSONKeyText _ _ -> do
           return (NamedSchema Nothing schema_)
       ToJSONKeyValue _ _ -> do
-          declareNamedSchema (Proxy :: Proxy [(k, (OverrideToSchema ByteString))])
+          declareNamedSchema (Proxy :: Proxy [(k, (OverrideToSchema B.ByteString))])
     where
       schema_ = mempty
 #if MIN_VERSION_swagger2(2,4,0)

--- a/src/Proto3/Suite/DotProto/Generate/Swagger.hs
+++ b/src/Proto3/Suite/DotProto/Generate/Swagger.hs
@@ -90,6 +90,7 @@ instance {-# OVERLAPPING #-} (ToJSONKey k, ToSchema k) => ToSchema (OverrideToSc
 #endif
         & additionalProperties ?~ AdditionalPropertiesSchema (Inline byteSchema)
 
+#ifdef SWAGGER_WRAPPER_FORMAT
 -- | Wrapped Type Schemas
 
 setFormat
@@ -147,6 +148,7 @@ instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (Maybe B.ByteString)) wh
 instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (Maybe BL.ByteString)) where
   declareNamedSchema _ =
     setFormat "BytesValue" (pure (NamedSchema Nothing byteSchema))
+#endif
 
 {-| This is a convenience function that uses type inference to select the
     correct instance of `ToSchema` to use for fields of a message

--- a/src/Proto3/Suite/DotProto/Generate/Swagger.hs
+++ b/src/Proto3/Suite/DotProto/Generate/Swagger.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
@@ -30,11 +31,13 @@ import           Data.Aeson.Encode.Pretty        (encodePretty)
 import qualified Data.ByteString                 as B
 import qualified Data.ByteString.Lazy            as BL
 import qualified Data.ByteString.Lazy.Char8      as LC8
+import           Data.Functor                    ((<&>))
 import           Data.Hashable                   (Hashable)
 import           Data.HashMap.Strict.InsOrd      (InsOrdHashMap)
 import qualified Data.HashMap.Strict.InsOrd
 import           Data.Map                        (Map)
 import           Data.Swagger
+import           Data.Swagger.Declare            (Declare)
 import qualified Data.Text                       as T
 import qualified Data.Text.Lazy                  as TL
 import           Data.Proxy
@@ -91,6 +94,58 @@ instance {-# OVERLAPPING #-} (ToJSONKey k, ToSchema k) => ToSchema (OverrideToSc
         & type_ .~ SwaggerObject
 #endif
         & additionalProperties ?~ AdditionalPropertiesSchema (Inline byteSchema)
+
+-- | Wrapped Type Schemas
+
+declareWrapperNamedSchema
+  :: forall a
+   . ToSchema a
+  => T.Text
+  -> Proxy (OverrideToSchema a)
+  -> Declare (Definitions Schema) NamedSchema
+declareWrapperNamedSchema formatValue _ =
+  declareNamedSchema (Proxy :: Proxy a)
+#if MIN_VERSION_swagger2(2,4,0)
+    <&> schema . paramSchema . format ?~ formatValue
+#else
+    <&> schema . paramSchema . format .~ formatValue
+#endif
+
+instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (Maybe Double)) where
+  declareNamedSchema = declareWrapperNamedSchema "DoubleValue"
+
+instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (Maybe Float)) where
+  declareNamedSchema = declareWrapperNamedSchema "FloatValue"
+
+instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (Maybe Int64)) where
+  declareNamedSchema = declareWrapperNamedSchema "Int64Value"
+
+instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (Maybe Word64)) where
+  declareNamedSchema = declareWrapperNamedSchema "UInt64Value"
+
+instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (Maybe Int32)) where
+  declareNamedSchema = declareWrapperNamedSchema "Int32Value"
+
+instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (Maybe Word32)) where
+  declareNamedSchema = declareWrapperNamedSchema "UInt32Value"
+
+instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (Maybe Bool)) where
+  declareNamedSchema = declareWrapperNamedSchema "BoolValue"
+
+instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (Maybe T.Text)) where
+  declareNamedSchema = declareWrapperNamedSchema "StringValue"
+
+instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (Maybe TL.Text)) where
+  declareNamedSchema = declareWrapperNamedSchema "StringValue"
+
+-- TODO: Figure out what to do about conflicting `Maybe ByteString` instance
+-- above
+
+-- instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (Maybe B.ByteString)) where
+--   declareNamedSchema = declareWrapperNamedSchema "BytesValue"
+
+-- instance {-# OVERLAPPING #-} ToSchema (OverrideToSchema (Maybe BL.ByteString)) where
+--   declareNamedSchema = declareWrapperNamedSchema "BytesValue"
 
 {-| This is a convenience function that uses type inference to select the
     correct instance of `ToSchema` to use for fields of a message


### PR DESCRIPTION
Notes:

- These `format` values are non-standard / incorrect Swagger, so they're hidden behind a flag (off by default).
- Replacing the original `instance ToSchema (OverrideToSchema ByteString)` is okay because [we don't have `optional` anymore](https://github.com/awakesecurity/proto3-suite/pull/165), therefore `Maybe ByteString` now unambiguously refers to `BytesValue`.

cc @natefaubion

Commits are atomic.