### PR TITLE
Update codegen to add the `serverMaxMetadataSize` field to generated `ServiceOptions`

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.0
 name:                proto3-suite
-version:             0.4.2
+version:             0.4.3
 synopsis:            A higher-level API to the proto3-wire library
 description:
   This library provides a higher-level API to <https://github.com/awakesecurity/proto3-wire the `proto3-wire` library>

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -1488,7 +1488,7 @@ dotProtoServiceD pkgIdent ctxt serviceIdent service = do
                                , patVar "sslConfig"
                                , patVar "logger"
                                , patVar "serverMaxReceiveMessageLength"
-                               , patVar "serverMaxMetdataSize"
+                               , patVar "serverMaxMetadataSize"
                                ]
                       ]
                       (HsUnGuardedRhs (apply serverLoopE [ serverOptsE ]))

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -1488,6 +1488,7 @@ dotProtoServiceD pkgIdent ctxt serviceIdent service = do
                                , patVar "sslConfig"
                                , patVar "logger"
                                , patVar "serverMaxReceiveMessageLength"
+                               , patVar "serverMaxMetdataSize"
                                ]
                       ]
                       (HsUnGuardedRhs (apply serverLoopE [ serverOptsE ]))
@@ -1532,6 +1533,7 @@ dotProtoServiceD pkgIdent ctxt serviceIdent service = do
                  , update "optSSLConfig" "sslConfig"
                  , update "optLogger" "logger"
                  , update "optMaxReceiveMessageLength" "serverMaxReceiveMessageLength"
+                 , update "optMaxMetadataSize" "serverMaxMetadataSize"
                  ]
 
      let clientT = tyApp (HsTyCon (unqual_ serviceName)) [ clientRequestT, clientResultT ]


### PR DESCRIPTION
This change is required for the matching change in grpc-haskell made here: https://github.com/awakesecurity/gRPC-haskell/pull/134.

Additionally, we bump the patch release version of `proto3-suite` to `0.4.3`.