### PR TITLE
Fix module renaming in `compile-proto-file`

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -111,8 +111,13 @@ library
   ghc-options:         -O2 -Wall
 
 test-suite tests
-  type:                exitcode-stdio-1.0
-  main-is:             Main.hs
+  default-language: Haskell2010
+  type:             exitcode-stdio-1.0
+  main-is:          Main.hs
+
+  hs-source-dirs:
+    gen
+    tests
 
   if flag(dhall)
     other-modules:     TestDhall
@@ -125,41 +130,45 @@ test-suite tests
     if flag(swagger-wrapper-format)
       cpp-options:       -DSWAGGER_WRAPPER_FORMAT
 
-  other-modules:       ArbitraryGeneratedTestTypes
-                       TestCodeGen
-                       TestProto
-                       TestProtoImport
-                       TestProtoOneof
-                       TestProtoOneofImport
-                       --TestProtoLeadingDot
-                       TestProtoNestedMessage
-                       --TestProtoProtocPlugin
+  other-modules:
+    ArbitraryGeneratedTestTypes
+    TestCodeGen
+    TestProto
+    TestProtoImport
+    TestProtoOneof
+    TestProtoOneofImport
+    --TestProtoLeadingDot
+    TestProtoNestedMessage
+    --TestProtoProtocPlugin
+    Test.Proto.Generate.Name
+    Test.Proto.Generate.Name.Gen
 
-  hs-source-dirs:      tests gen
-  default-language:    Haskell2010
-  build-depends:       base >=4.8 && <5.0,
-                       QuickCheck >=2.10 && <2.15,
-                       aeson >= 1.1.1.0 && < 2.1,
-                       attoparsec >= 0.13.0.1,
-                       base >=4.8 && <5.0,
-                       base64-bytestring >= 1.0.0.1 && < 1.3,
-                       bytestring >=0.10.6.0 && <0.11.0,
-                       cereal >= 0.5.1 && <0.6,
-                       containers >=0.5 && < 0.7,
-                       deepseq ==1.4.*,
-                       doctest,
-                       generic-arbitrary,
-                       mtl ==2.2.*,
-                       pretty-show >= 1.6.12 && < 2.0,
-                       proto3-suite,
-                       proto3-wire == 1.2.*,
-                       tasty >= 0.11 && <1.5,
-                       tasty-hunit >= 0.9 && <0.11,
-                       tasty-quickcheck >= 0.8.4 && <0.11,
-                       text >= 0.2 && <1.3,
-                       transformers >=0.4 && <0.6,
-                       turtle,
-                       vector >=0.11 && < 0.13
+  build-depends:
+      aeson >= 1.1.1.0 && < 2.1
+    , attoparsec >= 0.13.0.1
+    , base >=4.8 && <5.0
+    , base64-bytestring >= 1.0.0.1 && < 1.3
+    , bytestring >=0.10.6.0 && <0.11.0
+    , cereal >= 0.5.1 && <0.6
+    , containers >=0.5 && < 0.7
+    , deepseq ==1.4.*
+    , doctest
+    , generic-arbitrary
+    , hedgehog
+    , mtl ==2.2.*
+    , pretty-show >= 1.6.12 && < 2.0
+    , proto3-suite
+    , proto3-wire == 1.2.*
+    , QuickCheck >=2.10 && <2.15
+    , tasty >= 0.11 && <1.5
+    , tasty-hedgehog
+    , tasty-hunit >= 0.9 && <0.11
+    , tasty-quickcheck >= 0.8.4 && <0.11
+    , text >= 0.2 && <1.3
+    , transformers >=0.4 && <0.6
+    , turtle
+    , vector >=0.11 && < 0.13
+
   if !impl(ghc >= 8.0)
     build-depends:     semigroups >= 0.18 && < 0.20
   ghc-options:         -O2 -Wall

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.0
 name:                proto3-suite
-version:             0.4.3
+version:             0.5.0
 synopsis:            A higher-level API to the proto3-wire library
 description:
   This library provides a higher-level API to <https://github.com/awakesecurity/proto3-wire the `proto3-wire` library>

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE DataKinds                 #-}
 {-# LANGUAGE ExistentialQuantification #-}

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE DataKinds                 #-}
 {-# LANGUAGE ExistentialQuantification #-}
@@ -26,6 +27,7 @@ module Proto3.Suite.DotProto.Generate
   , CompileArgs(..)
   , compileDotProtoFile
   , compileDotProtoFileOrDie
+  , rnProtoFile
   , hsModuleForDotProto
   , renderHsModuleForDotProto
   , readDotProtoWithContext
@@ -61,6 +63,7 @@ import           Proto3.Wire.Types              (FieldNumber (..))
 import qualified Turtle
 import           Turtle                         (FilePath)
 
+--------------------------------------------------------------------------------
 
 --
 -- * Public interface
@@ -75,20 +78,21 @@ data CompileArgs = CompileArgs
 -- | Generate a Haskell module corresponding to a @.proto@ file
 compileDotProtoFile :: CompileArgs -> IO (Either CompileError ())
 compileDotProtoFile CompileArgs{..} = runExceptT $ do
-    (dotProto, importTypeContext) <- readDotProtoWithContext includeDir inputProto
+  (dotProto, importTypeContext) <- readDotProtoWithContext includeDir inputProto
+  modulePathPieces <- traverse rnProtoFile (toModuleComponents dotProto)
 
-    modulePathPieces <- traverse typeLikeName . components . metaModulePath . protoMeta $ dotProto
+  let relativePath = FP.concat (map fromString $ NE.toList modulePathPieces) <.> "hs"
+  let modulePath = outputDir </> relativePath
 
-    let relativePath = FP.concat (map fromString $ NE.toList modulePathPieces) <.> "hs"
-    let modulePath   = outputDir </> relativePath
+  Turtle.mktree (Turtle.directory modulePath)
 
-    Turtle.mktree (Turtle.directory modulePath)
+  extraInstances <- foldMapM getExtraInstances extraInstanceFiles
+  haskellModule <- renderHsModuleForDotProto extraInstances dotProto importTypeContext
 
-    extraInstances <- foldMapM getExtraInstances extraInstanceFiles
-
-    haskellModule <- renderHsModuleForDotProto extraInstances dotProto importTypeContext
-
-    liftIO (writeFile (FP.encodeString modulePath) haskellModule)
+  liftIO (writeFile (FP.encodeString modulePath) haskellModule)
+  where
+    toModuleComponents :: DotProto -> NonEmpty String
+    toModuleComponents = components . metaModulePath . protoMeta
 
 -- | Same as 'compileDotProtoFile', except terminates the program with an error
 -- message on failure.
@@ -104,6 +108,46 @@ compileDotProtoFileOrDie args = compileDotProtoFile args >>= \case
       ${errText}
     |]
   _ -> pure ()
+
+-- | Renaming protobuf file names to valid Haskell module names.
+--
+-- By convention, protobuf filenames are snake case. 'rnProtoFile' renames
+-- snake-cased protobuf filenames by:
+--
+-- * Replacing occurrences of one or more underscores followed by an
+-- alphabetical character with one less underscore.
+--
+-- * Capitalizing the first character following the string of underscores.
+--
+-- ==== __Examples__
+--
+-- >>> rnProtoFile @(Either CompileError) "abc_xyz"
+-- Right "AbcXyz"
+--
+-- >>> rnProtoFile @(Either CompileError) "abc_1bc"
+-- Left (InvalidModuleName "_1bc")
+--
+-- >>> rnProtoFile @(Either CompileError) "_"
+-- Left (InvalidModuleName "_")
+rnProtoFile :: MonadError CompileError m => String -> m String
+rnProtoFile str = do
+  -- @underscores@ is zero or more underscore characters prefixing the remaining
+  -- substring @rest.
+  let (underscores, rest) = span (== '_') str
+
+  unless (isValidName rest) $ do
+    throwError (InvalidModuleName str)
+
+  case break (== '_') rest of
+    (prefix, suffix)
+      | null suffix -> pure (toUpperFirst prefix)
+      | otherwise -> do
+        let renamed = drop 1 underscores ++ toUpperFirst prefix
+        suffix' <- rnProtoFile suffix
+        pure (renamed ++ suffix')
+  where
+    isValidName "" = False
+    isValidName (c : _) = isAlpha c
 
 -- | Compile a 'DotProto' AST into a 'String' representing the Haskell
 --   source of a module implementing types and instances for the .proto

--- a/src/Proto3/Suite/DotProto/Internal.hs
+++ b/src/Proto3/Suite/DotProto/Internal.hs
@@ -365,10 +365,11 @@ isMap _ = False
 -- * Name resolution
 --
 
-
-
-concatDotProtoIdentifier :: MonadError CompileError m
-                         => DotProtoIdentifier -> DotProtoIdentifier -> m DotProtoIdentifier
+concatDotProtoIdentifier ::
+  MonadError CompileError m =>
+  DotProtoIdentifier ->
+  DotProtoIdentifier ->
+  m DotProtoIdentifier
 concatDotProtoIdentifier i1 i2 = case (i1, i2) of
   (Qualified{}  ,  _           ) -> internalError "concatDotProtoIdentifier: Qualified"
   (_            , Qualified{}  ) -> internalError "concatDotProtoIdentifier Qualified"
@@ -391,17 +392,35 @@ toPascalCase xs = foldMap go (segmentBy (== '_') xs)
 
 -- | @'toCamelCase' xs@ sends a snake-case string @xs@ to a camel-cased string.
 toCamelCase :: String -> String
-toCamelCase xs = case toPascalCase xs of
-  "" -> ""
-  x : xs' -> toLower x : xs'
+toCamelCase xs =
+  case toPascalCase xs of
+    "" -> ""
+    x : xs' -> toLower x : xs'
 
--- | @'toUpperFirst' xs@ sends the first character @x@ in @xs@ to be upper case, @'toUpperFirst' "" = ""@.
+-- | Uppercases the first character of a string.
+--
+-- ==== __Examples__
+--
+-- >>> toUpperFirst "abc"
+-- "Abc"
+--
+-- >>> toUpperFirst ""
+-- ""
 toUpperFirst :: String -> String
-toUpperFirst [] = []
+toUpperFirst "" = ""
 toUpperFirst (x : xs) = toUpper x : xs
 
--- | @'segmentBy' p xs@  partitions @xs@ into segments of @'Either' [a] [a]@ where @'Right' xs'@ satisfy @p@ and
--- @'Left' xs'@ segments satisfy @'not' . p@.
+-- | @'segmentBy' p xs@  partitions @xs@ into segments of @'Either' [a] [a]@
+-- with:
+--
+-- * 'Right' sublists containing elements satisfying @p@, otherwise;
+--
+-- * 'Left' sublists containing elements that do not satisfy @p@
+--
+-- ==== __Examples__
+--
+-- >>> segmentBy (\c -> c == '_') "abc_123_xyz"
+-- [Left "abc",Right "_",Left "123",Right "_",Left "xyz"]
 segmentBy :: (a -> Bool) -> [a] -> [Either [a] [a]]
 segmentBy p xs = case span p xs of
   ([], []) -> []
@@ -454,7 +473,7 @@ typeLikeName s@(x : xs)
 
     -- Only valid as a secondary character.
     -- First character of a Haskell name can only be "isAlpha".
-    isValidNameChar x = isAlphaNum x || x == '_'
+    isValidNameChar ch = isAlphaNum ch || ch == '_'
 
 -- | @'fieldLikeName' field@ is the casing transformation used to produce record selectors from message fields. If
 -- @field@ is prefixed by a span of uppercase characters then that prefix will be lowercased while the remaining string
@@ -625,18 +644,19 @@ oneofSubDisjunctBinder = intercalate "_or_" . fmap oneofSubBinder
 --
 
 data CompileError
-  = CircularImport          FilePath
-  | CompileParseError       ParseError
-  | InternalError           String
-  | InvalidPackageName      DotProtoIdentifier
-  | InvalidMethodName       DotProtoIdentifier
-  | InvalidTypeName         String
-  | InvalidMapKeyType       String
+  = CircularImport FilePath
+  | CompileParseError ParseError
+  | InternalError String
+  | InvalidPackageName DotProtoIdentifier
+  | InvalidMethodName DotProtoIdentifier
+  | InvalidModuleName String
+  | InvalidTypeName String
+  | InvalidMapKeyType String
   | NoPackageDeclaration
-  | NoSuchType              DotProtoIdentifier
+  | NoSuchType DotProtoIdentifier
   | NonzeroFirstEnumeration String DotProtoIdentifier Int32
-  | EmptyEnumeration        String
-  | Unimplemented           String
+  | EmptyEnumeration String
+  | Unimplemented String
   deriving (Show, Eq)
 
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -34,6 +34,10 @@ import qualified TestProto                   as TP
 import           TestDhall
 #endif
 
+import qualified Test.Proto.Generate.Name
+
+-- -----------------------------------------------------------------------------
+
 main :: IO ()
 main = defaultMain tests
 
@@ -46,13 +50,14 @@ tests = testGroup "Tests"
   , parserUnitTests
   , dotProtoUnitTests
   , codeGenTests
+  , Test.Proto.Generate.Name.tests
 
 #ifdef DHALL
   , dhallTests
 #endif
   ]
 
---------------------------------------------------------------------------------
+-- -----------------------------------------------------------------------------
 -- Doctests
 
 docTests :: TestTree

--- a/tests/Test/Proto/Generate/Name.hs
+++ b/tests/Test/Proto/Generate/Name.hs
@@ -35,7 +35,7 @@ testResolution resolve nm = do
   let res = Name.Gen.nameRes nm
   let got = resolve occ
 
-  annotate ("protobuf name: " ++ res)
+  annotate ("protobuf name: " ++ occ)
   annotate ("expected name: " ++ res)
   annotate ("resolved name: " ++ show got)
 

--- a/tests/Test/Proto/Generate/Name.hs
+++ b/tests/Test/Proto/Generate/Name.hs
@@ -10,6 +10,7 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
 
 import Hedgehog (MonadTest, Property, annotate, forAll, property, (===))
+import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 
 import Test.Proto.Generate.Name.Gen (GenName)
@@ -48,5 +49,5 @@ testResolution resolve nm = do
 
 resolve'protofile :: Property
 resolve'protofile = property do
-  nm <- forAll (Name.Gen.protofile (Range.linear 1 10))
+  nm <- forAll $ Gen.sized (Name.Gen.protofile . Range.linear 1 . fromIntegral)
   testResolution (renameProtoFile @(Either CompileError)) nm

--- a/tests/Test/Proto/Generate/Name.hs
+++ b/tests/Test/Proto/Generate/Name.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+--
+module Test.Proto.Generate.Name (tests) where
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Hedgehog (MonadTest, Property, annotate, forAll, property, (===))
+import Hedgehog.Range qualified as Range
+
+import Test.Proto.Generate.Name.Gen (GenName)
+import Test.Proto.Generate.Name.Gen qualified as Name.Gen
+
+import Proto3.Suite.DotProto.Generate
+
+-- -----------------------------------------------------------------------------
+
+tests :: TestTree
+tests =
+  testGroup
+    "Test.Proto.Generate.Name"
+    [ testProperty "filenames" resolve'protofile
+    ]
+
+-- | Testing combinator for name resolution functions.
+testResolution ::
+  (MonadTest m, Applicative f, Eq (f String), Show (f String)) =>
+  (String -> f String) -> GenName -> m ()
+testResolution resolve nm = do
+  let occ = Name.Gen.nameOcc nm
+  let res = Name.Gen.nameRes nm
+  let got = resolve occ
+
+  annotate ("protobuf name: " ++ res)
+  annotate ("expected name: " ++ res)
+  annotate ("resolved name: " ++ show got)
+
+  pure res === got
+
+-- -----------------------------------------------------------------------------
+--
+-- Name Resolution Tests
+--
+
+resolve'protofile :: Property
+resolve'protofile = property do
+  nm <- forAll (Name.Gen.protofile (Range.linear 1 10))
+  testResolution (renameProtoFile @(Either CompileError)) nm

--- a/tests/Test/Proto/Generate/Name/Gen.hs
+++ b/tests/Test/Proto/Generate/Name/Gen.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- |
+module Test.Proto.Generate.Name.Gen
+  ( GenName (GenName, nameOcc, nameRes),
+    protofile,
+  )
+where
+
+import Hedgehog (MonadGen, Range)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+
+import Control.Applicative
+import Data.Char qualified as Char
+import Data.List qualified as List
+
+-- -----------------------------------------------------------------------------
+
+-- | 'GenName' is an association between generated names.
+--
+--   * 'nameOcc' is how the name occurs in the context of protocol buffers.
+--
+--   * 'nameRes' is a Haskell name that 'nameOcc' is expected to resolve as.
+--
+-- ==== __Example__
+--
+-- The *.proto filename "my_messages" should be resolved to the Haskell module
+-- "MyMessages", so we would generate a 'GenName':
+--
+-- >>> GenName "my_messages" "MyMessages"
+-- GenName {nameOcc = "my_messages", nameRes = "MyMessages"}
+--
+-- After an associated pair is generated, it can be used to test a renaming (call
+-- it @f@) by checking:
+--
+-- prop> f (nameOcc nm) == nameRes nm
+data GenName = GenName
+  { nameOcc :: String
+  , nameRes :: String
+  }
+  deriving (Eq, Show)
+
+-- | Generate the name of a Protobuf file and the Haskell module it should be
+-- resolved to.
+protofile :: MonadGen m => Range Int -> m GenName
+protofile len = do
+  parts <- Gen.list len $ Gen.sized \sz -> do
+    let rng = Range.linear 1 (fromIntegral sz)
+    liftA2 (:) Gen.alpha (alphaNum rng)
+
+  let nameOcc = List.intercalate "_" parts
+  let nameRes = concatMap upperFirst parts
+  pure GenName {nameOcc, nameRes}
+  where
+    upperFirst :: String -> String
+    upperFirst (c : cs) = Char.toUpper c : cs
+    upperFirst "" = ""
+
+-- -----------------------------------------------------------------------------
+--
+-- Primitive Name Generation Combinators
+--
+
+-- | Generate a name containing alphabetical and numeric characters
+-- @'a' .. 'z'@, @'A' .. 'Z'@, and @'0' .. '1'@.
+alphaNum :: MonadGen m => Range Int -> m String
+alphaNum rng = Gen.list rng Gen.alphaNum


### PR DESCRIPTION
This PR changes the way `compile-proto-file` handles generating valid Haskell module names from protobuf files, fixes issue #182.