### PR TITLE
specify autogen-modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ test-files/test_files/
 # Ignore Emacs backup files
 *~
 # Ignore code generation artifacts
-gen/
+gen/*.hs

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -21,7 +21,7 @@ copyright:           2017-2020 Awake Security, 2021 Arista Networks
 category:            Codec
 build-type:          Simple
 data-files:          test-files/*.bin tests/encode.sh tests/decode.sh
-extra-source-files:  CHANGELOG.md
+extra-source-files:  CHANGELOG.md, gen/.gitignore
 
 flag dhall
   Description:   Turn on Dhall interpret and inject codegen

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -131,6 +131,12 @@ test-suite tests
     if flag(swagger-wrapper-format)
       cpp-options:       -DSWAGGER_WRAPPER_FORMAT
 
+  autogen-modules:
+    TestProto
+    TestProtoImport
+    TestProtoOneof
+    TestProtoOneofImport
+    TestProtoNestedMessage
   other-modules:
     ArbitraryGeneratedTestTypes
     TestCodeGen


### PR DESCRIPTION
Otherwise cabal build fails when used in source-repository-package