### PR TITLE
Remove use of `Data.Semigroup.Option`

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -190,7 +190,7 @@ executable canonicalize-proto-file
   main-is:             Main.hs
   hs-source-dirs:      tools/canonicalize-proto-file
   default-language:    Haskell2010
-  build-depends:       base >=4.8 && <5.0
+  build-depends:       base >=4.11.0.0 && <5.0
                        , containers >=0.5 && <0.7
                        , mtl ==2.2.*
                        , optparse-generic

--- a/tools/canonicalize-proto-file/Main.hs
+++ b/tools/canonicalize-proto-file/Main.hs
@@ -17,7 +17,7 @@ import           Control.Monad.Except
 import           Data.List                        (sort, sortOn)
 import qualified Data.List.NonEmpty              as NE
 import           Data.RangeSet.List               (fromRangeList, toRangeList)
-import           Data.Semigroup                   (Min(..), Option(..))
+import           Data.Semigroup                   (Min(..))
 import           Options.Generic
 import           Prelude                          hiding (FilePath)
 import           Proto3.Suite.DotProto.AST
@@ -147,7 +147,7 @@ instance Canonicalize DotProtoMessagePart where
 
 instance CanonicalRank [DotProtoField] (Maybe FieldNumber) where
   canonicalRank =
-    fmap getMin . getOption . foldMap (Option . fmap Min . canonicalRank)
+    fmap getMin . foldMap (fmap Min . canonicalRank)
 
 instance Canonicalize [DotProtoField] where
   canonicalize = canonicalSort . filter keep


### PR DESCRIPTION
Since `base-4.11.0.0` the `Option` `newtype` is no longer necessary
and we can use the `Maybe` type directly