### PR TITLE
compile-proto-file: add --text-type option to generate code using strict Text

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -101,6 +101,7 @@ library
                        QuickCheck >=2.10 && <2.15,
                        quickcheck-instances < 0.4,
                        safe ==0.3.*,
+                       split,
                        system-filepath,
                        time,
                        text >= 0.2 && <1.3,

--- a/src/Proto3/Suite/JSONPB/Class.hs
+++ b/src/Proto3/Suite/JSONPB/Class.hs
@@ -437,6 +437,12 @@ instance FromJSONPB Double where
 -- Stringly types (string and bytes)
 
 -- string
+instance ToJSONPB T.Text where
+  toJSONPB     = const . A.toJSON
+  toEncodingPB = const . A.toEncoding
+instance FromJSONPB T.Text where
+  parseJSONPB = A.parseJSON
+
 instance ToJSONPB TL.Text where
   toJSONPB     = const . A.toJSON
   toEncodingPB = const . A.toEncoding

--- a/tests/TestCodeGen.hs
+++ b/tests/TestCodeGen.hs
@@ -144,11 +144,14 @@ simpleDecodeDotProto format =
 dumpAST :: [FilePath] -> FilePath -> IO ()
 dumpAST incs fp = either (error . show) putStrLn <=< runExceptT $ do
   (dp, tc) <- readDotProtoWithContext incs fp
-  renderHsModuleForDotProto mempty dp tc
+  renderHsModuleForDotProto theStringType mempty dp tc
 
 hsTmpDir, pyTmpDir :: IsString a => a
 hsTmpDir = "test-files/hs-tmp"
 pyTmpDir = "test-files/py-tmp"
+
+theStringType :: StringType
+theStringType = StringType "Data.Text.Lazy" "Text"
 
 compileTestDotProtos :: IO ()
 compileTestDotProtos = do
@@ -173,6 +176,7 @@ compileTestDotProtos = do
                    , extraInstanceFiles = []
                    , outputDir = hsTmpDir
                    , inputProto = protoFile
+                   , stringType = theStringType
                    }
 
     let cmd = T.concat [ "protoc --python_out="

--- a/tools/compile-proto-file/Main.hs
+++ b/tools/compile-proto-file/Main.hs
@@ -15,7 +15,7 @@ import           Proto3.Suite.DotProto.Generate
 parseArgs :: ParserInfo CompileArgs
 parseArgs = info (helper <*> parser) (fullDesc <> progDesc "Compiles a .proto file to a Haskell module")
   where
-    parser = CompileArgs <$> includes <*> extraInstances <*> proto <*> out
+    parser = CompileArgs <$> includes <*> extraInstances <*> proto <*> out <*> stringType
 
     includes = many $ strOption $
       long "includeDir"
@@ -36,6 +36,12 @@ parseArgs = info (helper <*> parser) (fullDesc <> progDesc "Compiles a .proto fi
       long "out"
         <> metavar "DIR"
         <> help "Output directory path where generated Haskell modules will be written (directory is created if it does not exist; note that files in the output directory may be overwritten!)"
+
+    stringType = option (eitherReader parseStringType)
+      $ long "string-type"
+      <> metavar "Data.Text.Lazy.Text"
+      <> help "Haskell representation of strings"
+      <> value (StringType "Data.Text.Lazy" "Text")
 
 main :: IO ()
 main = execParser parseArgs >>= compileDotProtoFileOrDie


### PR DESCRIPTION
Context: https://github.com/awakesecurity/proto3-suite/pull/19

AFAIK, the use of Data.Text.Lazy is infrequent in the current ecosystem.
Adding an ability to toggle between strict and lazy texts releases us from tedious impedance matching