### PR TITLE
Update pinning of proto3-wire to < 1.4.0

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -95,7 +95,7 @@ library
                        parsers >= 0.12 && <0.13,
                        pretty ==1.1.*,
                        pretty-show >= 1.6.12 && < 2.0,
-                       proto3-wire >= 1.2.2 && < 1.3,
+                       proto3-wire >= 1.2.2 && < 1.4,
                        QuickCheck >=2.10 && <2.15,
                        quickcheck-instances < 0.4,
                        safe ==0.3.*,


### PR DESCRIPTION
proto3-wire has been released recently and is available on hackage.