### PR TITLE
Build against `turtle-1.6.0`

### DIFF
--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -20,9 +20,11 @@ let
 in {
   haskellPackages = pkgsOld.haskell.packages."${compiler}".override (old: {
     overrides =
-      pkgsNew.lib.composeExtensions
+      pkgsNew.lib.fold pkgsNew.lib.composeExtensions
         (old.overrides or (_: _: { }))
-        (haskellPackagesNew: haskellPackagesOld: {
+        [ (pkgsNew.haskell.lib.packagesFromDirectory { directory = ../packages; })
+
+          (haskellPackagesNew: haskellPackagesOld: {
           range-set-list =
             pkgsNew.haskell.lib.overrideCabal
               haskellPackagesOld.range-set-list
@@ -152,6 +154,7 @@ in {
                   '';
                 }
               );
-        });
+          })
+        ];
   });
 }

--- a/nix/packages/turtle.nix
+++ b/nix/packages/turtle.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, ansi-wl-pprint, async, base, bytestring, clock
+, containers, directory, doctest, exceptions, filepath, foldl
+, hostname, lib, managed, optional-args, optparse-applicative
+, process, stm, streaming-commons, tasty, tasty-bench, tasty-hunit
+, temporary, text, time, transformers, unix, unix-compat
+}:
+mkDerivation {
+  pname = "turtle";
+  version = "1.6.0";
+  sha256 = "8551a72f62ece4e53a51209b184a555dc5f8af5155da09698e35ea3f58a265bc";
+  libraryHaskellDepends = [
+    ansi-wl-pprint async base bytestring clock containers directory
+    exceptions filepath foldl hostname managed optional-args
+    optparse-applicative process stm streaming-commons temporary text
+    time transformers unix unix-compat
+  ];
+  testHaskellDepends = [
+    base doctest filepath tasty tasty-hunit temporary
+  ];
+  benchmarkHaskellDepends = [ base tasty-bench text ];
+  description = "Shell programming, Haskell-style";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/turtle.nix
+++ b/nix/packages/turtle.nix
@@ -6,8 +6,8 @@
 }:
 mkDerivation {
   pname = "turtle";
-  version = "1.6.0";
-  sha256 = "8551a72f62ece4e53a51209b184a555dc5f8af5155da09698e35ea3f58a265bc";
+  version = "1.6.1";
+  sha256 = "2795445c93a4b646dd02b68ebf4006f8ec3588c85ccfe9d47810597e638e3b9c";
   libraryHaskellDepends = [
     ansi-wl-pprint async base bytestring clock containers directory
     exceptions filepath foldl hostname managed optional-args

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -103,7 +103,7 @@ library
                        time,
                        text >= 0.2 && <1.3,
                        transformers >=0.4 && <0.6,
-                       turtle < 1.7.0,
+                       turtle < 1.6.0 || >= 1.6.1 && < 1.7.0,
                        vector >=0.11 && < 0.13
   if !impl(ghc >= 8.0)
     build-depends:     semigroups >= 0.18 && < 0.20

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -103,7 +103,7 @@ library
                        time,
                        text >= 0.2 && <1.3,
                        transformers >=0.4 && <0.6,
-                       turtle,
+                       turtle < 1.7.0,
                        vector >=0.11 && < 0.13
   if !impl(ghc >= 8.0)
     build-depends:     semigroups >= 0.18 && < 0.20

--- a/src/Proto3/Suite/DotProto/AST.hs
+++ b/src/Proto3/Suite/DotProto/AST.hs
@@ -37,7 +37,6 @@ import           Control.Monad
 import           Data.Int                  (Int32)
 import qualified Data.List.NonEmpty        as NE
 import           Data.String               (IsString)
-import qualified Filesystem.Path.CurrentOS as FP
 import           Numeric.Natural
 import           Prelude                   hiding (FilePath)
 import           Proto3.Wire.Types         (FieldNumber (..))
@@ -91,7 +90,7 @@ data DotProtoImport = DotProtoImport
 instance Arbitrary DotProtoImport where
     arbitrary = do
       dotProtoImportQualifier <- arbitrary
-      let dotProtoImportPath = FP.empty
+      let dotProtoImportPath = mempty
       return (DotProtoImport {..})
 
 data DotProtoImportQualifier

--- a/src/Proto3/Suite/DotProto/Internal.hs
+++ b/src/Proto3/Suite/DotProto/Internal.hs
@@ -129,8 +129,13 @@ dieLines (Turtle.textToLines -> msg) = do
 -- >>> toModulePath "foo/FiLeName_underscore.and.then.some.dots.proto"
 -- Right (Path {components = "Foo" :| ["FiLeName_underscore","And","Then","Some","Dots"]})
 --
+#if MIN_VERSION_turtle(1,6,0)
+-- >>> toModulePath "foo/bar/././baz/../boggle.proto"
+-- Left "path contained unexpected .. after canonicalization, please use form x.y.z.proto"
+#else
 -- >>> toModulePath "foo/bar/././baz/../boggle.proto"
 -- Right (Path {components = "Foo" :| ["Bar","Boggle"]})
+#endif
 --
 -- >>> toModulePath "./foo.proto"
 -- Right (Path {components = "Foo" :| []})

--- a/src/Proto3/Suite/DotProto/Internal.hs
+++ b/src/Proto3/Suite/DotProto/Internal.hs
@@ -34,8 +34,6 @@ import qualified Data.Map                  as M
 import           Data.Maybe                (fromMaybe)
 import qualified Data.Text                 as T
 import           Data.Tuple                (swap)
-import           Filesystem.Path.CurrentOS ((</>))
-import qualified Filesystem.Path.CurrentOS as FP
 import qualified NeatInterpolation         as Neat
 import           Prelude                   hiding (FilePath)
 import           Proto3.Suite.DotProto.AST
@@ -45,7 +43,8 @@ import           Proto3.Wire.Types         (FieldNumber (..))
 import           System.FilePath           (isPathSeparator)
 import           Text.Parsec               (ParseError)
 import qualified Turtle
-import           Turtle                    (ExitCode (..), FilePath, Text)
+import           Turtle                    (ExitCode (..), FilePath, Text,
+                                            (</>))
 import           Turtle.Format             ((%))
 import qualified Turtle.Format             as F
 
@@ -140,16 +139,16 @@ dieLines (Turtle.textToLines -> msg) = do
 -- >>> toModulePath ".foo.proto"
 -- Right (Path {components = "Foo" :| []})
 toModulePath :: FilePath -> Either String Path
-toModulePath fp0@(fromMaybe fp0 . FP.stripPrefix "./" -> fp)
+toModulePath fp0@(fromMaybe fp0 . Turtle.stripPrefix "./" -> fp)
   | Turtle.absolute fp
     = Left "expected include-relative path"
   | Turtle.extension fp /= Just "proto"
     = Left "expected .proto suffix"
   | otherwise
-    = case FP.stripPrefix "../" fp of
+    = case Turtle.stripPrefix "../" fp of
         Just{}  -> Left "expected include-relative path, but the path started with ../"
         Nothing
-          | T.isInfixOf ".." . Turtle.format F.fp . FP.collapse $ fp
+          | T.isInfixOf ".." . Turtle.format F.fp . Turtle.collapse $ fp
             -> Left "path contained unexpected .. after canonicalization, please use form x.y.z.proto"
           | otherwise
             -> maybe (Left "empty path after canonicalization") (Right . Path)
@@ -161,7 +160,7 @@ toModulePath fp0@(fromMaybe fp0 . FP.stripPrefix "./" -> fp)
              . concatMap (T.splitOn ".")
              . T.split isPathSeparator
              . Turtle.format F.fp
-             . FP.collapse
+             . Turtle.collapse
              . Turtle.dropExtension
              $ fp
 

--- a/src/Proto3/Suite/DotProto/Parsing.hs
+++ b/src/Proto3/Suite/DotProto/Parsing.hs
@@ -27,7 +27,6 @@ import Control.Monad.Fail
 import qualified Data.List.NonEmpty as NE
 import Data.Functor
 import qualified Data.Text as T
-import qualified Filesystem.Path.CurrentOS as FP
 import Proto3.Suite.DotProto.AST
 import Proto3.Wire.Types (FieldNumber(..))
 import Text.Parsec (parse, ParseError)
@@ -57,7 +56,7 @@ parseProtoWithFile modulePath filePath = parse (runProtoParser (topLevel moduleP
 -- relative to some @--includeDir@.
 parseProtoFile :: Turtle.MonadIO m
                => Path -> Turtle.FilePath -> m (Either ParseError DotProto)
-parseProtoFile modulePath (FP.encodeString -> fp) =
+parseProtoFile modulePath (Turtle.encodeString -> fp) =
   parseProtoWithFile modulePath fp <$> Turtle.liftIO (readFile fp)
 
 ----------------------------------------
@@ -212,7 +211,7 @@ import_ = do symbol "import"
              qualifier <- option DotProtoImportDefault $
                                  symbol "weak" $> DotProtoImportWeak
                              <|> symbol "public" $> DotProtoImportPublic
-             target <- FP.fromText . T.pack <$> stringLit
+             target <- Turtle.fromText . T.pack <$> stringLit
              semi
              return $ DotProtoImport qualifier target
 

--- a/src/Proto3/Suite/DotProto/Rendering.hs
+++ b/src/Proto3/Suite/DotProto/Rendering.hs
@@ -22,7 +22,6 @@ module Proto3.Suite.DotProto.Rendering
 import           Data.Char
 import qualified Data.List.NonEmpty              as NE
 import qualified Data.Text                       as T
-import           Filesystem.Path.CurrentOS       (toText)
 #if (MIN_VERSION_base(4,11,0))
 import           Prelude                         hiding ((<>))
 #endif
@@ -31,6 +30,7 @@ import           Proto3.Wire.Types               (FieldNumber (..))
 import           Text.PrettyPrint                (($$), (<+>), (<>))
 import qualified Text.PrettyPrint                as PP
 import           Text.PrettyPrint.HughesPJClass  (Pretty(..))
+import           Turtle                          (toText)
 
 -- | Options for rendering a @.proto@ file.
 data RenderingOptions = RenderingOptions


### PR DESCRIPTION
This builds against the older versions of `turtle`, too, albeit
at the expense of several deprecation warnings.  Once we cut a
release with this fix we can do a second pass to fix all the
warnings, that way end users have a smooth migration path.