### PR TITLE
Support proto3-wire 1.4

### DIFF
--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -38,8 +38,8 @@ in {
               source = pkgsNew.fetchFromGitHub {
                 owner = "awakesecurity";
                 repo = "proto3-wire";
-                rev = "e5e0158ceaaa50d258bb86dbf2e6c42d5e16c3c5";
-                sha256 = "14r2qm6x4bcaywbi3cypriz4hr8i2v3j4qm61lal6x21p0z9i9ak";
+                rev = "ae24c00c83cbce29750005b1fa6506c1e62e4822";
+                sha256 = "1pr078k7j5yvsixh7g76bfb3w5a5nxsjl9lgvc5ji4nm0ngx5i61";
               };
             in haskellPackagesNew.callCabal2nix "proto3-wire" source { };
 

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -95,7 +95,7 @@ library
                        parsers >= 0.12 && <0.13,
                        pretty ==1.1.*,
                        pretty-show >= 1.6.12 && < 2.0,
-                       proto3-wire >= 1.2.2 && < 1.4,
+                       proto3-wire >= 1.2.2 && < 1.5,
                        QuickCheck >=2.10 && <2.15,
                        quickcheck-instances < 0.4,
                        safe ==0.3.*,
@@ -159,7 +159,7 @@ test-suite tests
     , mtl ==2.2.*
     , pretty-show >= 1.6.12 && < 2.0
     , proto3-suite
-    , proto3-wire == 1.2.*
+    , proto3-wire >= 1.2 && < 1.5
     , QuickCheck >=2.10 && <2.15
     , tasty >= 0.11 && <1.5
     , tasty-hedgehog
@@ -195,7 +195,7 @@ executable canonicalize-proto-file
                        , mtl ==2.2.*
                        , optparse-generic
                        , proto3-suite
-                       , proto3-wire == 1.2.*
+                       , proto3-wire >= 1.2 && <1.5
                        , range-set-list >=0.1.2 && <0.2
                        , system-filepath
                        , turtle


### PR DESCRIPTION
While I'd like to update more before releasing this would be worthwhile to try to squeeze in.

This is a minor version since proto3-suite does not export the signatures affected by the breakage (although usually major implies major)