### PR TITLE
Delegate to a polymorphic wrapper type for wrapped fields

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -68,6 +68,7 @@ library
                        Proto3.Suite.Types
 
                        Google.Protobuf.Timestamp
+                       Google.Protobuf.Wrappers.Polymorphic
 
                        Proto3.Suite.DotProto.Internal
                        Proto3.Suite.JSONPB.Class

--- a/src/Google/Protobuf/Wrappers/Polymorphic.hs
+++ b/src/Google/Protobuf/Wrappers/Polymorphic.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings   #-}
+
+module Google.Protobuf.Wrappers.Polymorphic
+  ( Wrapped(..)
+  , NameOfWrapperFor(..)
+  ) where
+
+import           Control.DeepSeq (NFData)
+import qualified Data.ByteString
+import qualified Data.ByteString.Lazy
+import qualified Data.HashMap.Strict.InsOrd as HsInsOrd
+import           Data.Int (Int32, Int64)
+import           Data.Proxy (Proxy(..))
+import           Data.String (IsString(..))
+import qualified Data.Text (Text)
+import qualified Data.Text.Lazy (Text)
+import           Data.Word (Word32, Word64)
+import           GHC.Exts (Proxy#, proxy#)
+import           GHC.Generics (Generic)
+import qualified Proto3.Suite.Class as HsProtobuf
+import qualified Proto3.Suite.DotProto as HsProtobuf
+import           Proto3.Suite.JSONPB ((.=), (.:))
+import qualified Proto3.Suite.JSONPB as HsJSONPB
+import qualified Proto3.Wire as HsProtobuf
+
+-- | A Haskell type representing the standard protobuf wrapper
+-- message that is associated with the given Haskell type.
+--
+-- Note that if Google ever adds wrappers for "sint..." or "..fixed..."
+-- then this newtype could still be used, provided its type parameter
+-- involves the appropriate combination of `Proto3.Suite.Types.Signed`
+-- and/or `Proto3.Suite.Types.Fixed`.  Because the latter two types
+-- are themselves newtypes, the corresponding coercions should work.
+newtype Wrapped a = Wrapped a
+  deriving (Show, Eq, Ord, Generic, NFData)
+
+instance NameOfWrapperFor a => HsProtobuf.Named (Wrapped a) where
+  nameOf _ = nameOfWrapperFor (proxy# :: Proxy# a)
+  {-# INLINE nameOf #-}
+
+instance (HsProtobuf.HasDefault a, Eq a) =>
+         HsProtobuf.HasDefault (Wrapped a)
+
+instance (HsProtobuf.MessageField a, HsProtobuf.Primitive a) =>
+         HsProtobuf.Message (Wrapped a) where
+  encodeMessage _ (Wrapped v) =
+    HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 1) v
+  {-# INLINABLE encodeMessage #-}
+  decodeMessage _ = Wrapped <$>
+    HsProtobuf.at HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 1)
+  {-# INLINABLE decodeMessage #-}
+  dotProto _ =
+    [ HsProtobuf.DotProtoField
+        (HsProtobuf.FieldNumber 1)
+        (HsProtobuf.Prim (HsProtobuf.primType (proxy# :: Proxy# a)))
+        (HsProtobuf.Single "value")
+        []
+        ""
+    ]
+
+instance (HsJSONPB.ToJSONPB a, HsProtobuf.HasDefault a) =>
+         HsJSONPB.ToJSONPB (Wrapped a) where
+  toJSONPB (Wrapped f1) = HsJSONPB.object ["value" .= f1]
+  {-# INLINABLE toJSONPB #-}
+  toEncodingPB (Wrapped f1) = HsJSONPB.pairs ["value" .= f1]
+  {-# INLINABLE toEncodingPB #-}
+
+instance (HsJSONPB.FromJSONPB a, HsProtobuf.HasDefault a, NameOfWrapperFor a) =>
+         HsJSONPB.FromJSONPB (Wrapped a) where
+  parseJSONPB = HsJSONPB.withObject
+    (nameOfWrapperFor (proxy# :: Proxy# a))
+    (\obj -> Wrapped <$> obj .: "value")
+  {-# INLINABLE parseJSONPB #-}
+
+instance (HsJSONPB.ToJSONPB a, HsProtobuf.HasDefault a) =>
+         HsJSONPB.ToJSON (Wrapped a) where
+  toJSON = HsJSONPB.toAesonValue
+  {-# INLINE toJSON #-}
+  toEncoding = HsJSONPB.toAesonEncoding
+  {-# INLINE toEncoding #-}
+
+instance (HsJSONPB.FromJSONPB a, HsProtobuf.HasDefault a, NameOfWrapperFor a) =>
+         HsJSONPB.FromJSON (Wrapped a) where
+  parseJSON = HsJSONPB.parseJSONPB
+  {-# INLINE parseJSON #-}
+
+#ifdef SWAGGER
+
+instance (HsJSONPB.ToSchema a, NameOfWrapperFor a) =>
+         HsJSONPB.ToSchema (Wrapped a) where
+  declareNamedSchema _ = do
+    let declare_value = HsJSONPB.declareSchemaRef
+    v <- declare_value Proxy
+    let _ = Wrapped <$> HsJSONPB.asProxy declare_value
+              :: Proxy (Wrapped a)
+    return HsJSONPB.NamedSchema
+      { HsJSONPB._namedSchemaName =
+          Just (nameOfWrapperFor (proxy# :: Proxy# a))
+      , HsJSONPB._namedSchemaSchema = mempty
+          { HsJSONPB._schemaParamSchema =
+              mempty{ HsJSONPB._paramSchemaType = Just HsJSONPB.SwaggerObject }
+          , HsJSONPB._schemaProperties =
+              HsInsOrd.singleton "value" v
+          }
+      }
+
+#endif
+
+-- | Defines the name to be returned by @`HsProtobuf.Named` (`Wrapped` a)@.
+class NameOfWrapperFor a where
+  nameOfWrapperFor :: IsString string => Proxy# a -> string
+
+instance NameOfWrapperFor Double where
+  nameOfWrapperFor _ = "DoubleValue"
+
+instance NameOfWrapperFor Float where
+  nameOfWrapperFor _ = "FloatValue"
+
+instance NameOfWrapperFor Int64 where
+  nameOfWrapperFor _ = "Int64Value"
+
+instance NameOfWrapperFor Word64 where
+  nameOfWrapperFor _ = "UInt64Value"
+
+instance NameOfWrapperFor Int32 where
+  nameOfWrapperFor _ = "Int32Value"
+
+instance NameOfWrapperFor Word32 where
+  nameOfWrapperFor _ = "UInt32Value"
+
+instance NameOfWrapperFor Bool where
+  nameOfWrapperFor _ = "BoolValue"
+
+instance NameOfWrapperFor Data.Text.Text where
+  nameOfWrapperFor _ = "StringValue"
+
+instance NameOfWrapperFor Data.Text.Lazy.Text where
+  nameOfWrapperFor _ = "StringValue"
+
+instance NameOfWrapperFor Data.ByteString.ByteString where
+  nameOfWrapperFor _ = "BytesValue"
+
+instance NameOfWrapperFor Data.ByteString.Lazy.ByteString where
+  nameOfWrapperFor _ = "BytesValue"

--- a/test-files/test_proto_wrappers.proto
+++ b/test-files/test_proto_wrappers.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+package TestProtoWrappers;
+import "google/protobuf/wrappers.proto";
+
+message TestDoubleValue {
+  google.protobuf.DoubleValue wrapper = 2;
+}
+
+message TestFloatValue {
+  google.protobuf.FloatValue wrapper = 2;
+}
+
+message TestInt64Value {
+  google.protobuf.Int64Value wrapper = 2;
+}
+
+message TestUInt64Value {
+  google.protobuf.UInt64Value wrapper = 2;
+}
+
+message TestInt32Value {
+  google.protobuf.Int32Value wrapper = 2;
+}
+
+message TestUInt32Value {
+  google.protobuf.UInt32Value wrapper = 2;
+}
+
+message TestBoolValue {
+  google.protobuf.BoolValue wrapper = 2;
+}
+
+message TestStringValue {
+  google.protobuf.StringValue wrapper = 2;
+}
+
+message TestBytesValue {
+  google.protobuf.BytesValue wrapper = 2;
+}

--- a/tests/SimpleDecodeDotProto.hs
+++ b/tests/SimpleDecodeDotProto.hs
@@ -10,12 +10,14 @@ import Test.Tasty.HUnit (Assertion, (@?=), (@=?), testCase)
 import qualified Data.Map as M
 import Proto3.Suite
 import qualified Data.ByteString.Char8 as BC
+import GHC.Stack (HasCallStack)
 import System.IO
 
 import TestProto
 import qualified TestProtoImport
 import qualified TestProtoOneof
 import qualified TestProtoOneofImport
+import qualified TestProtoWrappers
 
 main :: IO ()
 main = do putStr "\n"
@@ -32,6 +34,9 @@ tests = testGroup "Decode protobuf messages from Python"
           , testCase11, testCase12, testCase13, testCase14
           , testCase15, testCase16, testCase17, testCase18
           , testCase19
+          , testCase_DoubleValue, testCase_FloatValue, testCase_Int64Value
+          , testCase_UInt64Value, testCase_Int32Value, testCase_UInt32Value
+          , testCase_BoolValue, testCase_StringValue, testCase_BytesValue
           , allTestsDone -- this should always run last
           ]
 
@@ -42,7 +47,7 @@ readProto = do length <- readLn
                  Left err -> fail ("readProto: " ++ show err)
                  Right  x -> pure x
 
-expect :: (Eq a, Message a, Show a) => a -> Assertion
+expect :: (HasCallStack, Eq a, Message a, Show a) => a -> Assertion
 expect v = (v @=?) =<< readProto
 
 testCase1  = testCase "Trivial message" $
@@ -335,6 +340,62 @@ testCase19 = testCase "Maps" $ do
                         , mapTestSigned = M.fromList [(1,2),(3,4),(5,6)]
                         }
   result @?= expected
+
+testCase_DoubleValue = testCase "DoubleValue" $ do
+  let w = TestProtoWrappers.TestDoubleValue
+  expect (w Nothing)
+  expect (w (Just 3.5))
+ 
+testCase_FloatValue = testCase "FloatValue" $ do
+  let w = TestProtoWrappers.TestFloatValue
+  expect (w Nothing)
+  expect (w (Just 2.5))
+
+testCase_Int64Value = testCase "Int64Value" $ do
+  let w = TestProtoWrappers.TestInt64Value
+  expect (w Nothing)
+  expect (w (Just 0))
+  expect (w (Just maxBound))
+  expect (w (Just (-1)))
+  expect (w (Just minBound))
+
+testCase_UInt64Value = testCase "UInt64Value" $ do
+  let w = TestProtoWrappers.TestUInt64Value
+  expect (w Nothing)
+  expect (w (Just 0))
+  expect (w (Just maxBound))
+
+testCase_Int32Value = testCase "Int32Value" $ do
+  let w = TestProtoWrappers.TestInt32Value
+  expect (w Nothing)
+  expect (w (Just 0))
+  expect (w (Just maxBound))
+  expect (w (Just (-1)))
+  expect (w (Just minBound))
+
+testCase_UInt32Value = testCase "UInt32Value" $ do
+  let w = TestProtoWrappers.TestUInt32Value
+  expect (w Nothing)
+  expect (w (Just 0))
+  expect (w (Just maxBound))
+
+testCase_BoolValue = testCase "BoolValue" $ do
+  let w = TestProtoWrappers.TestBoolValue
+  expect (w Nothing)
+  expect (w (Just False))
+  expect (w (Just True))
+
+testCase_StringValue = testCase "StringValue" $ do
+  let w = TestProtoWrappers.TestStringValue
+  expect (w Nothing)
+  expect (w (Just ""))
+  expect (w (Just "abc"))
+
+testCase_BytesValue = testCase "BytesValue" $ do
+  let w = TestProtoWrappers.TestBytesValue
+  expect (w Nothing)
+  expect (w (Just ""))
+  expect (w (Just "012"))
 
 
 allTestsDone = testCase "Receive end of test suite sentinel message" $

--- a/tests/SimpleEncodeDotProto.hs
+++ b/tests/SimpleEncodeDotProto.hs
@@ -12,6 +12,7 @@ import           TestProto
 import qualified TestProtoImport
 import qualified TestProtoOneof
 import qualified TestProtoOneofImport
+import qualified TestProtoWrappers
 
 outputMessage :: Message a => a -> IO ()
 outputMessage msg =
@@ -195,6 +196,71 @@ testCase19 = do
                        , mapTestSigned = M.fromList [(1,2),(3,4),(5,6)]
                        }
 
+testCase_DoubleValue :: IO ()
+testCase_DoubleValue = do
+  let emit = outputMessage . TestProtoWrappers.TestDoubleValue
+  emit Nothing
+  emit (Just 3.5)
+
+testCase_FloatValue :: IO ()
+testCase_FloatValue = do
+  let emit = outputMessage . TestProtoWrappers.TestFloatValue
+  emit Nothing
+  emit (Just 2.5)
+
+testCase_Int64Value :: IO ()
+testCase_Int64Value = do
+  let emit = outputMessage . TestProtoWrappers.TestInt64Value
+  emit Nothing
+  emit (Just 0)
+  emit (Just maxBound)
+  emit (Just (-1))
+  emit (Just minBound)
+
+testCase_UInt64Value :: IO ()
+testCase_UInt64Value = do
+  let emit = outputMessage . TestProtoWrappers.TestUInt64Value
+  emit Nothing
+  emit (Just 0)
+  emit (Just maxBound)
+
+testCase_Int32Value :: IO ()
+testCase_Int32Value = do
+  let emit = outputMessage . TestProtoWrappers.TestInt32Value
+  emit Nothing
+  emit (Just 0)
+  emit (Just maxBound)
+  emit (Just (-1))
+  emit (Just minBound)
+
+testCase_UInt32Value :: IO ()
+testCase_UInt32Value = do
+  let emit = outputMessage . TestProtoWrappers.TestUInt32Value
+  emit Nothing
+  emit (Just 0)
+  emit (Just maxBound)
+
+testCase_BoolValue :: IO ()
+testCase_BoolValue = do
+  let emit = outputMessage . TestProtoWrappers.TestBoolValue
+  emit Nothing
+  emit (Just False)
+  emit (Just True)
+
+testCase_StringValue :: IO ()
+testCase_StringValue = do
+  let emit = outputMessage . TestProtoWrappers.TestStringValue
+  emit Nothing
+  emit (Just "")
+  emit (Just "abc")
+
+testCase_BytesValue :: IO ()
+testCase_BytesValue = do
+  let emit = outputMessage . TestProtoWrappers.TestBytesValue
+  emit Nothing
+  emit (Just "")
+  emit (Just "012")
+
 
 main :: IO ()
 main = do testCase1
@@ -223,5 +289,16 @@ main = do testCase1
 
           -- Map tests
           testCase19
+
+          -- Wrappers
+          testCase_DoubleValue
+          testCase_FloatValue
+          testCase_Int64Value
+          testCase_UInt64Value
+          testCase_Int32Value
+          testCase_UInt32Value
+          testCase_BoolValue
+          testCase_StringValue
+          testCase_BytesValue
 
           outputMessage (MultipleFields 0 0 0 0 "All tests complete" False)

--- a/tests/TestCodeGen.hs
+++ b/tests/TestCodeGen.hs
@@ -162,6 +162,7 @@ compileTestDotProtos = do
         , "test_proto_protoc_plugin.proto"
         -}
         , "test_proto_nested_message.proto"
+        , "test_proto_wrappers.proto"
         ]
 
   forM_ protoFiles $ \protoFile -> do

--- a/tests/check_simple_dot_proto.py
+++ b/tests/check_simple_dot_proto.py
@@ -5,6 +5,7 @@ from test_proto_pb2              import *
 from test_proto_import_pb2       import WithNesting as ImportedWithNesting
 from test_proto_oneof_pb2        import Something, WithImported, DUMMY0, DUMMY1
 from test_proto_oneof_import_pb2 import WithOneof
+from test_proto_wrappers_pb2     import *
 
 def read_proto(cls):
     length = int(raw_input())
@@ -368,6 +369,113 @@ assert case19.trivial[101].trivial.trivialField == 1234567
 # generated python proto types do not define structural equality.
 assert case19.trivial[79].trivial.trivialField == Trivial().trivialField
 assert case19.signed[1] == 2
+
+case_DoubleValue_A = read_proto(TestDoubleValue)
+assert not case_DoubleValue_A.HasField('wrapper')
+
+case_DoubleValue_B = read_proto(TestDoubleValue)
+assert case_DoubleValue_B.HasField('wrapper')
+assert case_DoubleValue_B.wrapper.value == 3.5
+
+case_FloatValue_A = read_proto(TestFloatValue)
+assert not case_FloatValue_A.HasField('wrapper')
+
+case_FloatValue_B = read_proto(TestFloatValue)
+assert case_FloatValue_B.HasField('wrapper')
+assert case_FloatValue_B.wrapper.value == 2.5
+
+case_Int64Value_A = read_proto(TestInt64Value)
+assert not case_Int64Value_A.HasField('wrapper')
+
+case_Int64Value_B = read_proto(TestInt64Value)
+assert case_Int64Value_B.HasField('wrapper')
+assert case_Int64Value_B.wrapper.value == 0
+
+case_Int64Value_C = read_proto(TestInt64Value)
+assert case_Int64Value_C.HasField('wrapper')
+assert case_Int64Value_C.wrapper.value == 9223372036854775807
+
+case_Int64Value_D = read_proto(TestInt64Value)
+assert case_Int64Value_D.HasField('wrapper')
+assert case_Int64Value_D.wrapper.value == -1
+
+case_Int64Value_E = read_proto(TestInt64Value)
+assert case_Int64Value_E.HasField('wrapper')
+assert case_Int64Value_E.wrapper.value == -9223372036854775808
+
+case_UInt64Value_A = read_proto(TestUInt64Value)
+assert not case_UInt64Value_A.HasField('wrapper')
+
+case_UInt64Value_B = read_proto(TestUInt64Value)
+assert case_UInt64Value_B.HasField('wrapper')
+assert case_UInt64Value_B.wrapper.value == 0
+
+case_UInt64Value_C = read_proto(TestUInt64Value)
+assert case_UInt64Value_C.HasField('wrapper')
+assert case_UInt64Value_C.wrapper.value == 18446744073709551615
+
+case_Int32Value_A = read_proto(TestInt32Value)
+assert not case_Int32Value_A.HasField('wrapper')
+
+case_Int32Value_B = read_proto(TestInt32Value)
+assert case_Int32Value_B.HasField('wrapper')
+assert case_Int32Value_B.wrapper.value == 0
+
+case_Int32Value_C = read_proto(TestInt32Value)
+assert case_Int32Value_C.HasField('wrapper')
+assert case_Int32Value_C.wrapper.value == 2147483647
+
+case_Int32Value_D = read_proto(TestInt32Value)
+assert case_Int32Value_D.HasField('wrapper')
+assert case_Int32Value_D.wrapper.value == -1
+
+case_Int32Value_E = read_proto(TestInt32Value)
+assert case_Int32Value_E.HasField('wrapper')
+assert case_Int32Value_E.wrapper.value == -2147483648
+
+case_UInt32Value_A = read_proto(TestUInt32Value)
+assert not case_UInt32Value_A.HasField('wrapper')
+
+case_UInt32Value_B = read_proto(TestUInt32Value)
+assert case_UInt32Value_B.HasField('wrapper')
+assert case_UInt32Value_B.wrapper.value == 0
+
+case_UInt32Value_C = read_proto(TestUInt32Value)
+assert case_UInt32Value_C.HasField('wrapper')
+assert case_UInt32Value_C.wrapper.value == 4294967295
+
+case_BoolValue_A = read_proto(TestBoolValue)
+assert not case_BoolValue_A.HasField('wrapper')
+
+case_BoolValue_B = read_proto(TestBoolValue)
+assert case_BoolValue_B.HasField('wrapper')
+assert case_BoolValue_B.wrapper.value == False
+
+case_BoolValue_C = read_proto(TestBoolValue)
+assert case_BoolValue_C.HasField('wrapper')
+assert case_BoolValue_C.wrapper.value == True
+
+case_StringValue_A = read_proto(TestStringValue)
+assert not case_StringValue_A.HasField('wrapper')
+
+case_StringValue_B = read_proto(TestStringValue)
+assert case_StringValue_B.HasField('wrapper')
+assert case_StringValue_B.wrapper.value == ""
+
+case_StringValue_C = read_proto(TestStringValue)
+assert case_StringValue_C.HasField('wrapper')
+assert case_StringValue_C.wrapper.value == "abc"
+
+case_BytesValue_A = read_proto(TestBytesValue)
+assert not case_BytesValue_A.HasField('wrapper')
+
+case_BytesValue_B = read_proto(TestBytesValue)
+assert case_BytesValue_B.HasField('wrapper')
+assert case_BytesValue_B.wrapper.value == ""
+
+case_BytesValue_C = read_proto(TestBytesValue)
+assert case_BytesValue_C.HasField('wrapper')
+assert case_BytesValue_C.wrapper.value == "012"
 
 # Wait for the special 'done' messsage
 done_msg = read_proto(MultipleFields)

--- a/tests/decode.sh
+++ b/tests/decode.sh
@@ -10,6 +10,7 @@ ghc                                         \
     $hsTmpDir/TestProtoImport.hs            \
     $hsTmpDir/TestProtoOneof.hs             \
     $hsTmpDir/TestProtoOneofImport.hs       \
+    $hsTmpDir/TestProtoWrappers.hs          \
     tests/SimpleDecodeDotProto.hs           \
     >/dev/null
 

--- a/tests/encode.sh
+++ b/tests/encode.sh
@@ -10,6 +10,7 @@ ghc                                         \
     $hsTmpDir/TestProtoImport.hs            \
     $hsTmpDir/TestProtoOneof.hs             \
     $hsTmpDir/TestProtoOneofImport.hs       \
+    $hsTmpDir/TestProtoWrappers.hs          \
     tests/SimpleEncodeDotProto.hs           \
     >/dev/null
 

--- a/tests/send_simple_dot_proto.py
+++ b/tests/send_simple_dot_proto.py
@@ -2,10 +2,12 @@
 import sys
 import os
 # Import protoc generated {de,}serializers (generated from test_proto{,_import}.proto)
+from google.protobuf.wrappers_pb2 import *
 from test_proto_pb2 import *
 import test_proto_import_pb2       as test_proto_import
 import test_proto_oneof_pb2        as test_proto_oneof
 import test_proto_oneof_import_pb2 as test_proto_oneof_import
+import test_proto_wrappers_pb2     as test_proto_wrappers
 
 def write_proto(msg):
     out = msg.SerializeToString()
@@ -219,6 +221,53 @@ write_proto(MapTest( prim={'foo': 1, 'bar': 42, 'baz': 1234567 },
                     signed={ 1: 2, 3: 4, 5: 6 }
                   )
           )
+
+# Test DoubleValue
+write_proto(test_proto_wrappers.TestDoubleValue())
+write_proto(test_proto_wrappers.TestDoubleValue(wrapper=DoubleValue(value=3.5)))
+
+# Test FloatValue
+write_proto(test_proto_wrappers.TestFloatValue())
+write_proto(test_proto_wrappers.TestFloatValue(wrapper=FloatValue(value=2.5)))
+
+# Test Int64Value
+write_proto(test_proto_wrappers.TestInt64Value())
+write_proto(test_proto_wrappers.TestInt64Value(wrapper=Int64Value(value=0)))
+write_proto(test_proto_wrappers.TestInt64Value(wrapper=Int64Value(value=9223372036854775807)))
+write_proto(test_proto_wrappers.TestInt64Value(wrapper=Int64Value(value=-1)))
+write_proto(test_proto_wrappers.TestInt64Value(wrapper=Int64Value(value=-9223372036854775808)))
+
+# Test UInt64Value
+write_proto(test_proto_wrappers.TestUInt64Value())
+write_proto(test_proto_wrappers.TestUInt64Value(wrapper=UInt64Value(value=0)))
+write_proto(test_proto_wrappers.TestUInt64Value(wrapper=UInt64Value(value=18446744073709551615)))
+
+# Test Int32Value
+write_proto(test_proto_wrappers.TestInt32Value())
+write_proto(test_proto_wrappers.TestInt32Value(wrapper=Int32Value(value=0)))
+write_proto(test_proto_wrappers.TestInt32Value(wrapper=Int32Value(value=2147483647)))
+write_proto(test_proto_wrappers.TestInt32Value(wrapper=Int32Value(value=-1)))
+write_proto(test_proto_wrappers.TestInt32Value(wrapper=Int32Value(value=-2147483648)))
+
+# Test UInt32Value
+write_proto(test_proto_wrappers.TestUInt32Value())
+write_proto(test_proto_wrappers.TestUInt32Value(wrapper=UInt32Value(value=0)))
+write_proto(test_proto_wrappers.TestUInt32Value(wrapper=UInt32Value(value=4294967295)))
+
+# Test BoolValue
+write_proto(test_proto_wrappers.TestBoolValue())
+write_proto(test_proto_wrappers.TestBoolValue(wrapper=BoolValue(value=False)))
+write_proto(test_proto_wrappers.TestBoolValue(wrapper=BoolValue(value=True)))
+
+# Test StringValue
+write_proto(test_proto_wrappers.TestStringValue())
+write_proto(test_proto_wrappers.TestStringValue(wrapper=StringValue(value="")))
+write_proto(test_proto_wrappers.TestStringValue(wrapper=StringValue(value="abc")))
+
+# Test BytesValue
+write_proto(test_proto_wrappers.TestBytesValue())
+write_proto(test_proto_wrappers.TestBytesValue(wrapper=BytesValue(value="")))
+write_proto(test_proto_wrappers.TestBytesValue(wrapper=BytesValue(value="012")))
 
 # Send the special 'done' message
 write_proto(MultipleFields(multiFieldString = "All tests complete"))


### PR DESCRIPTION
...instead of delegating to code generated from the .proto
definitions of the standard Google protobuf wrapper types.

By avoiding delegation to wrapper implementations generated
from .proto definitions we avoid the need to generate such
implementations and link against them.

More importantly, by coercing between "Maybe Text" and
a polymorphic wrapper instead of a single fixed Haskell
representation of "StringValue", we enable a future
per-module choice between strict and lazy "Text" types,
rather than restricting ourselves to a uniform decision.
In fact, "Text" could be replaced by any string type that
provides the required type class instances for protobuf
serialization.  The same could be done for BytesValue.