### PR TITLE
0.5.1 Release, with feeling

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.0
 name:                proto3-suite
-version:             0.5.0
+version:             0.5.1
 synopsis:            A higher-level API to the proto3-wire library
 description:
   This library provides a higher-level API to <https://github.com/awakesecurity/proto3-wire the `proto3-wire` library>

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -80,7 +80,9 @@ compileDotProtoFile CompileArgs{..} = runExceptT $ do
   (dotProto, importTypeContext) <- readDotProtoWithContext includeDir inputProto
   modulePathPieces <- traverse renameProtoFile (toModuleComponents dotProto)
 
-  let relativePath = foldr (</>) mempty (map fromString $ NE.toList modulePathPieces) <.> "hs"
+  let relativePath = foldr combine mempty (map fromString $ NE.toList modulePathPieces) <.> "hs"
+      combine p1 p2 | p2 == mempty = p1
+      combine p1 p2 = p1 </> p2
   let modulePath = outputDir </> relativePath
 
   Turtle.mktree (Turtle.directory modulePath)

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -57,10 +57,10 @@ import           Proto3.Suite.DotProto
 import           Proto3.Suite.DotProto.AST.Lens
 import           Proto3.Suite.DotProto.Internal
 import           Proto3.Wire.Types              (FieldNumber (..))
-import           System.FilePath                (FilePath, (</>), (<.>), joinPath)
 import Text.Parsec (Parsec, alphaNum, eof, parse, satisfy, try)
 import qualified Text.Parsec as Parsec
 import qualified Turtle
+import           Turtle                         (FilePath, (</>), (<.>))
 
 --------------------------------------------------------------------------------
 
@@ -80,7 +80,7 @@ compileDotProtoFile CompileArgs{..} = runExceptT $ do
   (dotProto, importTypeContext) <- readDotProtoWithContext includeDir inputProto
   modulePathPieces <- traverse renameProtoFile (toModuleComponents dotProto)
 
-  let relativePath = joinPath (map fromString $ NE.toList modulePathPieces) <.> "hs"
+  let relativePath = foldr (</>) mempty (map fromString $ NE.toList modulePathPieces) <.> "hs"
   let modulePath = outputDir </> relativePath
 
   Turtle.mktree (Turtle.directory modulePath)


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/awakesecurity/proto3-suite/pull/200, and bumps the version in proto3-suite.cabal (which I thought I had inadvertently already done in another PR)