### PR TITLE
Eliminate a number of compiler warnings.

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -74,6 +74,8 @@ library
                        Proto3.Suite.DotProto.Internal
                        Proto3.Suite.JSONPB.Class
 
+  other-modules:       Turtle.Compat
+
   build-depends:       aeson >= 1.1.1.0 && < 2.1,
                        aeson-pretty,
                        attoparsec >= 0.13.0.1,

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -62,7 +62,8 @@ import           Proto3.Suite.DotProto.Internal
 import           Proto3.Wire.Types              (FieldNumber (..))
 import Text.Parsec (Parsec, alphaNum, eof, parse, satisfy, try)
 import qualified Text.Parsec as Parsec
-import qualified Turtle
+import qualified Turtle hiding (encodeString)
+import qualified Turtle.Compat as Turtle (encodeString)
 import           Turtle                         (FilePath, (</>), (<.>))
 
 --------------------------------------------------------------------------------

--- a/src/Proto3/Suite/DotProto/Internal.hs
+++ b/src/Proto3/Suite/DotProto/Internal.hs
@@ -42,7 +42,8 @@ import           Proto3.Suite.DotProto.Parsing
 import           Proto3.Wire.Types         (FieldNumber (..))
 import           System.FilePath           (isPathSeparator)
 import           Text.Parsec               (ParseError)
-import qualified Turtle
+import qualified Turtle hiding (absolute, collapse)
+import qualified Turtle.Compat as Turtle (absolute, collapse)
 import           Turtle                    (ExitCode (..), FilePath, Text,
                                             (</>))
 import           Turtle.Format             ((%))

--- a/src/Proto3/Suite/DotProto/Parsing.hs
+++ b/src/Proto3/Suite/DotProto/Parsing.hs
@@ -36,7 +36,8 @@ import Text.Parser.Combinators
 import Text.Parser.LookAhead
 import Text.Parser.Token
 import qualified Text.Parser.Token.Style as TokenStyle
-import qualified Turtle
+import qualified Turtle hiding (encodeString, fromText)
+import qualified Turtle.Compat as Turtle (encodeString, fromText)
 
 ----------------------------------------
 -- interfaces

--- a/src/Proto3/Suite/DotProto/Rendering.hs
+++ b/src/Proto3/Suite/DotProto/Rendering.hs
@@ -30,7 +30,7 @@ import           Proto3.Wire.Types               (FieldNumber (..))
 import           Text.PrettyPrint                (($$), (<+>), (<>))
 import qualified Text.PrettyPrint                as PP
 import           Text.PrettyPrint.HughesPJClass  (Pretty(..))
-import           Turtle                          (toText)
+import           Turtle.Compat                   (toText)
 
 -- | Options for rendering a @.proto@ file.
 data RenderingOptions = RenderingOptions

--- a/src/Turtle/Compat.hs
+++ b/src/Turtle/Compat.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE CPP #-}
+
+-- | Compatibility module to avoid compiler warnings about deprecation
+-- of obsolete Turtle functionality related to FilePath.  Once we
+-- no longer support pre-1.6 Turtle we can eliminate this module.
+module Turtle.Compat
+  ( absolute
+  , collapse
+  , encodeString
+  , fromText
+  , toText
+  ) where
+
+import qualified Data.Text
+import qualified System.FilePath
+import qualified Turtle
+
+absolute :: FilePath -> Bool
+collapse :: Turtle.FilePath -> Turtle.FilePath
+encodeString :: Turtle.FilePath -> String
+fromText :: Turtle.Text -> Turtle.FilePath
+toText :: Turtle.FilePath -> Either Turtle.Text Turtle.Text
+
+#if MIN_VERSION_turtle(1,6,0)
+
+absolute = System.FilePath.isAbsolute
+collapse = System.FilePath.normalise
+encodeString = id
+fromText = Data.Text.unpack
+toText = Right . Data.Text.pack
+
+#else
+
+absolute = Turtle.absolute
+collapse = Turtle.collapse
+encodeString = Turtle.encodeString
+fromText = Turtle.fromText
+toText = Turtle.toText
+
+#endif


### PR DESCRIPTION
These all relate to Turtle functions deprecated by turtle-1.6.

Eliminating the warnings seems to make doctest behave more predictably.

We could use -Wno-deprecations, but this change is more selective.