### PR TITLE
Bug fix in Turtle compatibility module.

### DIFF
--- a/src/Turtle/Compat.hs
+++ b/src/Turtle/Compat.hs
@@ -15,7 +15,7 @@ import qualified Data.Text
 import qualified System.FilePath
 import qualified Turtle
 
-absolute :: FilePath -> Bool
+absolute :: Turtle.FilePath -> Bool
 collapse :: Turtle.FilePath -> Turtle.FilePath
 encodeString :: Turtle.FilePath -> String
 fromText :: Turtle.Text -> Turtle.FilePath


### PR DESCRIPTION
Missing "Turtle." qualification caused build failure on versions
of turtle before 1.6.