### PR TITLE
Support parsing qualified option names.

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -154,6 +154,8 @@ test-suite tests
     --TestProtoProtocPlugin
     Test.Proto.Generate.Name
     Test.Proto.Generate.Name.Gen
+    Test.Proto.Parse.Gen
+    Test.Proto.Parse.Option
 
   build-depends:
       aeson >= 1.1.1.0 && < 2.1
@@ -168,6 +170,8 @@ test-suite tests
     , generic-arbitrary
     , hedgehog
     , mtl ==2.2.*
+    , parsec >= 3.1.9 && <3.2.0
+    , pretty ==1.1.*
     , pretty-show >= 1.6.12 && < 2.0
     , proto3-suite
     , proto3-wire >= 1.2 && < 1.5

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -35,6 +35,7 @@ import           TestDhall
 #endif
 
 import qualified Test.Proto.Generate.Name
+import qualified Test.Proto.Parse.Option
 
 -- -----------------------------------------------------------------------------
 
@@ -51,6 +52,7 @@ tests = testGroup "Tests"
   , dotProtoUnitTests
   , codeGenTests
   , Test.Proto.Generate.Name.tests
+  , Test.Proto.Parse.Option.tests
 
 #ifdef DHALL
   , dhallTests

--- a/tests/Test/Proto/Parse/Gen.hs
+++ b/tests/Test/Proto/Parse/Gen.hs
@@ -1,0 +1,52 @@
+
+module Test.Proto.Parse.Gen
+  ( optionId,
+    optionName,
+    optionQName,
+    optionKw,
+  )
+where
+
+import Hedgehog (Gen)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import Control.Applicative (liftA2)
+import qualified Data.List.NonEmpty as NonEmpty
+
+import Proto3.Suite.DotProto.AST
+
+optionId :: Gen DotProtoIdentifier
+optionId = Gen.choice [optionName, optionQName]
+
+optionQName :: Gen DotProtoIdentifier
+optionQName = liftA2 Qualified optionName optionName
+
+optionName :: Gen DotProtoIdentifier
+optionName = 
+  Gen.sized $ \s -> do
+    let range = Range.linear 1 (fromIntegral s)
+    nms <- Gen.nonEmpty range gNameString
+    pure $ if null (NonEmpty.tail nms)
+      then Single (NonEmpty.head nms)
+      else Dots (Path nms)
+  where
+    gNameString :: Gen String
+    gNameString = 
+      Gen.sized $ \s -> do
+        let range = Range.linear 1 (fromIntegral s)
+        chr <- Gen.alpha
+        chrs <- Gen.list range Gen.alphaNum
+        pure (chr : chrs)
+
+optionKw :: Gen String
+optionKw = do
+  lspace <- whitespace
+  rspace <- whitespace
+  pure (lspace ++ "option" ++ rspace)
+
+whitespace :: Gen String
+whitespace = 
+  Gen.sized $ \s -> do
+    len <- Gen.int (Range.linear 0 (fromIntegral s))
+    pure (replicate len ' ')

--- a/tests/Test/Proto/Parse/Option.hs
+++ b/tests/Test/Proto/Parse/Option.hs
@@ -1,0 +1,75 @@
+
+module Test.Proto.Parse.Option (tests) where
+
+import Hedgehog (Property, PropertyT, forAll, property, (===))
+import qualified Hedgehog as Hedgehog
+import qualified Hedgehog.Gen as Gen
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import qualified Test.Proto.Parse.Gen as Gen
+
+import qualified Data.Char as Char
+import Data.Either (isLeft)
+import Text.Parsec (ParseError)
+import qualified Text.Parsec as Parsec
+import Text.PrettyPrint (render)
+import Text.PrettyPrint.HughesPJClass (Pretty, pPrint)
+
+import Proto3.Suite.DotProto.Parsing (ProtoParser)
+import qualified Proto3.Suite.DotProto.Parsing as Proto3
+import Proto3.Suite.DotProto.Rendering () -- orphan Pretty DotProtoIdentifier
+
+tests :: TestTree
+tests = 
+  testGroup 
+    "Test.Proto.Parse.Option"
+    [ testProperty "Unqualified Option Identifier" propParseName
+    , testProperty "Qualified Option Identifier" propParseQName
+    , testProperty "Keyword 'Option'" propParseOptionKw
+    , testsOptionKw
+    ]
+
+runParseTest :: ProtoParser a -> String -> Either ParseError a
+runParseTest p = Parsec.parse (Proto3.runProtoParser p) ""
+
+parseTrip :: (Eq a, Pretty a, Show a) => a -> ProtoParser a -> PropertyT IO ()
+parseTrip x p = Hedgehog.tripping x (render . pPrint) (runParseTest p)
+
+propParseName :: Property
+propParseName = property $ do
+  idt <- forAll Gen.optionName
+  parseTrip idt Proto3.pOptionId
+
+propParseQName :: Property
+propParseQName = property $ do
+  idt <- forAll Gen.optionQName
+  parseTrip idt Proto3.pOptionId
+
+--------------------------------------------------------------------------------
+
+testsOptionKw :: TestTree 
+testsOptionKw = 
+  testGroup
+    "Test.Proto.Parse.Option.Keyword"
+    [ testProperty "Keyword 'Option'" propParseOptionKw
+    , testProperty "Keyword Malformed" propParseOptionKwMalformed
+    ]
+
+propParseOptionKw :: Property 
+propParseOptionKw = property $ do 
+  str <- forAll Gen.optionKw
+  case runParseTest Proto3.pOptionKw str of 
+    Left err -> Hedgehog.footnoteShow err >> Hedgehog.failure
+    Right () -> Hedgehog.success
+
+-- | Ensure the parser handling the keyword "option" must be followed by a 
+-- non-alphanumeric, otherwise the parser should fail.
+propParseOptionKwMalformed :: Property
+propParseOptionKwMalformed = property $ do 
+  chr <- forAll Gen.ascii
+  let result :: Either ParseError ()
+      result = runParseTest Proto3.pOptionKw ("option" ++ [chr])
+   in if Char.isAlphaNum chr 
+        then Hedgehog.assert (isLeft result)
+        else result === Right ()


### PR DESCRIPTION
Fixes the parser for protobuf option identifiers to support qualified option names such as:

```protobuf
syntax = "proto3";
import "foo";
option (foo.boolean_option_name_file) = true;
```