### PR TITLE
Fix tests of the Swagger schema of Google protobuf wrapper fields.

### DIFF
--- a/tests/TestCodeGen.hs
+++ b/tests/TestCodeGen.hs
@@ -51,31 +51,31 @@ codeGenTests = testGroup "Code generator unit tests"
 
 swaggerWrapperFormat :: TestTree
 swaggerWrapperFormat = testGroup "Swagger Wrapper Format"
-    [ prop @TestProtoWrappers.TestDoubleValue
+    [ expectSchema @TestProtoWrappers.TestDoubleValue
            "{\"properties\":{\"wrapper\":{\"format\":\"DoubleValue\",\"type\":\"number\"}},\"type\":\"object\"}"
            "{\"properties\":{\"wrapper\":{\"format\":\"double\",\"type\":\"number\"}},\"type\":\"object\"}"
-    , prop @TestProtoWrappers.TestFloatValue
+    , expectSchema @TestProtoWrappers.TestFloatValue
            "{\"properties\":{\"wrapper\":{\"format\":\"FloatValue\",\"type\":\"number\"}},\"type\":\"object\"}"
            "{\"properties\":{\"wrapper\":{\"format\":\"float\",\"type\":\"number\"}},\"type\":\"object\"}"
-    , prop @TestProtoWrappers.TestInt64Value
+    , expectSchema @TestProtoWrappers.TestInt64Value
            "{\"properties\":{\"wrapper\":{\"maximum\":9223372036854775807,\"format\":\"Int64Value\",\"minimum\":-9223372036854775808,\"type\":\"integer\"}},\"type\":\"object\"}"
            "{\"properties\":{\"wrapper\":{\"maximum\":9223372036854775807,\"format\":\"int64\",\"minimum\":-9223372036854775808,\"type\":\"integer\"}},\"type\":\"object\"}"
-    , prop @TestProtoWrappers.TestUInt64Value
+    , expectSchema @TestProtoWrappers.TestUInt64Value
            "{\"properties\":{\"wrapper\":{\"maximum\":18446744073709551615,\"format\":\"UInt64Value\",\"minimum\":0,\"type\":\"integer\"}},\"type\":\"object\"}"
            "{\"properties\":{\"wrapper\":{\"maximum\":18446744073709551615,\"minimum\":0,\"type\":\"integer\"}},\"type\":\"object\"}"
-    , prop @TestProtoWrappers.TestInt32Value
+    , expectSchema @TestProtoWrappers.TestInt32Value
            "{\"properties\":{\"wrapper\":{\"maximum\":2147483647,\"format\":\"Int32Value\",\"minimum\":-2147483648,\"type\":\"integer\"}},\"type\":\"object\"}"
            "{\"properties\":{\"wrapper\":{\"maximum\":2147483647,\"format\":\"int32\",\"minimum\":-2147483648,\"type\":\"integer\"}},\"type\":\"object\"}"
-    , prop @TestProtoWrappers.TestUInt32Value
+    , expectSchema @TestProtoWrappers.TestUInt32Value
            "{\"properties\":{\"wrapper\":{\"maximum\":4294967295,\"format\":\"UInt32Value\",\"minimum\":0,\"type\":\"integer\"}},\"type\":\"object\"}"
            "{\"properties\":{\"wrapper\":{\"maximum\":4294967295,\"minimum\":0,\"type\":\"integer\"}},\"type\":\"object\"}"
-    , prop @TestProtoWrappers.TestBoolValue
+    , expectSchema @TestProtoWrappers.TestBoolValue
            "{\"properties\":{\"wrapper\":{\"format\":\"BoolValue\",\"type\":\"boolean\"}},\"type\":\"object\"}"
            "{\"properties\":{\"wrapper\":{\"type\":\"boolean\"}},\"type\":\"object\"}"
-    , prop @TestProtoWrappers.TestStringValue
+    , expectSchema @TestProtoWrappers.TestStringValue
            "{\"properties\":{\"wrapper\":{\"format\":\"StringValue\",\"type\":\"string\"}},\"type\":\"object\"}"
            "{\"properties\":{\"wrapper\":{\"type\":\"string\"}},\"type\":\"object\"}"
-    , prop @TestProtoWrappers.TestBytesValue
+    , expectSchema @TestProtoWrappers.TestBytesValue
            "{\"properties\":{\"wrapper\":{\"format\":\"BytesValue\",\"type\":\"string\"}},\"type\":\"object\"}"
            "{\"properties\":{\"wrapper\":{\"format\":\"byte\",\"type\":\"string\"}},\"type\":\"object\"}"
     ]

--- a/tests/TestCodeGen.hs
+++ b/tests/TestCodeGen.hs
@@ -80,13 +80,13 @@ swaggerWrapperFormat = testGroup "Swagger Wrapper Format"
            "{\"properties\":{\"wrapper\":{\"format\":\"byte\",\"type\":\"string\"}},\"type\":\"object\"}"
     ]
   where
-    prop ::
+    expectSchema ::
       forall a .
       (ToSchema a, Typeable a) =>
       LBS.ByteString ->
       LBS.ByteString ->
       TestTree
-    prop wrapperFormat noWrapperFormat =
+    expectSchema wrapperFormat noWrapperFormat =
         testCase (tyConName (fst (splitTyConApp (typeRep (Proxy @a))))) $ do
           lbsSchemaOf @a @?= (if wf then wrapperFormat else noWrapperFormat)
       where

--- a/tests/TestCodeGen.hs
+++ b/tests/TestCodeGen.hs
@@ -19,6 +19,8 @@ import           Data.String                    (IsString)
 import           Data.Swagger                   (ToSchema)
 import qualified Data.Swagger
 import qualified Data.Text                      as T
+import           Data.Typeable                  (Typeable, splitTyConApp,
+                                                 tyConName, typeRep)
 import           Google.Protobuf.Timestamp      (Timestamp(..))
 import           Prelude                        hiding (FilePath)
 import           Proto3.Suite.DotProto.Generate
@@ -32,11 +34,12 @@ import           Test.Tasty.HUnit               (testCase, (@?=))
 import           Turtle                         (FilePath)
 import qualified Turtle
 import qualified Turtle.Format                  as F
-import qualified TestProtoWrappers              ()
+import qualified TestProtoWrappers
 
 codeGenTests :: TestTree
 codeGenTests = testGroup "Code generator unit tests"
-  [ pascalCaseMessageNames
+  [ swaggerWrapperFormat
+  , pascalCaseMessageNames
   , camelCaseMessageFieldNames
   , don'tAlterEnumFieldNames
   , knownTypeMessages
@@ -45,6 +48,60 @@ codeGenTests = testGroup "Code generator unit tests"
   , simpleEncodeDotProto "Jsonpb"
   , simpleDecodeDotProto "Jsonpb"
   ]
+
+swaggerWrapperFormat :: TestTree
+swaggerWrapperFormat = testGroup "Swagger Wrapper Format"
+    [ prop @TestProtoWrappers.TestDoubleValue
+           "{\"properties\":{\"wrapper\":{\"format\":\"DoubleValue\",\"type\":\"number\"}},\"type\":\"object\"}"
+           "{\"properties\":{\"wrapper\":{\"format\":\"double\",\"type\":\"number\"}},\"type\":\"object\"}"
+    , prop @TestProtoWrappers.TestFloatValue
+           "{\"properties\":{\"wrapper\":{\"format\":\"FloatValue\",\"type\":\"number\"}},\"type\":\"object\"}"
+           "{\"properties\":{\"wrapper\":{\"format\":\"float\",\"type\":\"number\"}},\"type\":\"object\"}"
+    , prop @TestProtoWrappers.TestInt64Value
+           "{\"properties\":{\"wrapper\":{\"maximum\":9223372036854775807,\"format\":\"Int64Value\",\"minimum\":-9223372036854775808,\"type\":\"integer\"}},\"type\":\"object\"}"
+           "{\"properties\":{\"wrapper\":{\"maximum\":9223372036854775807,\"format\":\"int64\",\"minimum\":-9223372036854775808,\"type\":\"integer\"}},\"type\":\"object\"}"
+    , prop @TestProtoWrappers.TestUInt64Value
+           "{\"properties\":{\"wrapper\":{\"maximum\":18446744073709551615,\"format\":\"UInt64Value\",\"minimum\":0,\"type\":\"integer\"}},\"type\":\"object\"}"
+           "{\"properties\":{\"wrapper\":{\"maximum\":18446744073709551615,\"minimum\":0,\"type\":\"integer\"}},\"type\":\"object\"}"
+    , prop @TestProtoWrappers.TestInt32Value
+           "{\"properties\":{\"wrapper\":{\"maximum\":2147483647,\"format\":\"Int32Value\",\"minimum\":-2147483648,\"type\":\"integer\"}},\"type\":\"object\"}"
+           "{\"properties\":{\"wrapper\":{\"maximum\":2147483647,\"format\":\"int32\",\"minimum\":-2147483648,\"type\":\"integer\"}},\"type\":\"object\"}"
+    , prop @TestProtoWrappers.TestUInt32Value
+           "{\"properties\":{\"wrapper\":{\"maximum\":4294967295,\"format\":\"UInt32Value\",\"minimum\":0,\"type\":\"integer\"}},\"type\":\"object\"}"
+           "{\"properties\":{\"wrapper\":{\"maximum\":4294967295,\"minimum\":0,\"type\":\"integer\"}},\"type\":\"object\"}"
+    , prop @TestProtoWrappers.TestBoolValue
+           "{\"properties\":{\"wrapper\":{\"format\":\"BoolValue\",\"type\":\"boolean\"}},\"type\":\"object\"}"
+           "{\"properties\":{\"wrapper\":{\"type\":\"boolean\"}},\"type\":\"object\"}"
+    , prop @TestProtoWrappers.TestStringValue
+           "{\"properties\":{\"wrapper\":{\"format\":\"StringValue\",\"type\":\"string\"}},\"type\":\"object\"}"
+           "{\"properties\":{\"wrapper\":{\"type\":\"string\"}},\"type\":\"object\"}"
+    , prop @TestProtoWrappers.TestBytesValue
+           "{\"properties\":{\"wrapper\":{\"format\":\"BytesValue\",\"type\":\"string\"}},\"type\":\"object\"}"
+           "{\"properties\":{\"wrapper\":{\"format\":\"byte\",\"type\":\"string\"}},\"type\":\"object\"}"
+    ]
+  where
+    prop ::
+      forall a .
+      (ToSchema a, Typeable a) =>
+      LBS.ByteString ->
+      LBS.ByteString ->
+      TestTree
+    prop wrapperFormat noWrapperFormat =
+        testCase (tyConName (fst (splitTyConApp (typeRep (Proxy @a))))) $ do
+          lbsSchemaOf @a @?= (if wf then wrapperFormat else noWrapperFormat)
+      where
+        wf :: Bool
+#ifdef SWAGGER_WRAPPER_FORMAT
+        wf = True
+#else
+        wf = False
+#endif
+
+-- >>> schemaOf @TestStringValue
+-- {"properties":{"wrapper":{"type":"string"}},"type":"object"}
+-- >>> schemaOf @TestBytesValue
+-- {"properties":{"wrapper":{"format":"byte","type":"string"}},"type":"object"}
+--
 
 knownTypeMessages :: TestTree
 knownTypeMessages =
@@ -282,18 +339,6 @@ compileTestDotProtos = do
 -- >>> schemaOf @(Enumerated DummyEnum)
 -- {"type":"string","enum":["DUMMY0","DUMMY1"]}
 --
-#ifdef SWAGGER_WRAPPER_FORMAT
--- >>> schemaOf @TestInt32Value
--- {"properties":{"wrapper":{"maximum":2147483647,"format":"Int32Value","minimum":-2147483648,"type":"integer"}},"type":"object"}
-#else
--- >>> schemaOf @TestInt32Value
--- {"properties":{"wrapper":{"maximum":2147483647,"format":"int32","minimum":-2147483648,"type":"integer"}},"type":"object"}
-#endif
--- >>> schemaOf @TestStringValue
--- {"properties":{"wrapper":{"type":"string"}},"type":"object"}
--- >>> schemaOf @TestBytesValue
--- {"properties":{"wrapper":{"format":"byte","type":"string"}},"type":"object"}
---
 -- Generic HasDefault
 --
 -- >>> def :: MultipleFields
@@ -325,4 +370,7 @@ decodesAs :: (Eq a, FromJSONPB a)
 decodesAs bs x = eitherDecode bs == Right x
 
 schemaOf :: forall a . ToSchema a => IO ()
-schemaOf = LBS8.putStrLn (Data.Aeson.encode (Data.Swagger.toSchema (Proxy @a)))
+schemaOf = LBS8.putStrLn (lbsSchemaOf @a)
+
+lbsSchemaOf :: forall a . ToSchema a => LBS.ByteString
+lbsSchemaOf = Data.Aeson.encode (Data.Swagger.toSchema (Proxy @a))


### PR DESCRIPTION
It seems that attempting to use conditional compilation on doctests
of the Swagger format for fields of Google protobuf wrapper type
silently suppresses those tests.

This commit replaces such doctests with HUnit tests.