### PR TITLE
Fix Import Render

### DIFF
--- a/src/Proto3/Suite/DotProto/Rendering.hs
+++ b/src/Proto3/Suite/DotProto/Rendering.hs
@@ -74,7 +74,7 @@ instance Pretty DotProtoPackageSpec where
 
 instance Pretty DotProtoImport where
   pPrint (DotProtoImport q i) =
-    PP.text "import" <+> pPrint q <+> PP.text "\"" <+> PP.text fp <+> PP.text "\"" <> PP.text ";"
+    PP.text "import" <+> pPrint q <+> PP.text "\"" <> PP.text fp <> PP.text "\"" <> PP.text ";"
     where
       fp = case T.unpack . either id id . toText $ i of
              [] -> show ("" :: String)

--- a/src/Proto3/Suite/DotProto/Rendering.hs
+++ b/src/Proto3/Suite/DotProto/Rendering.hs
@@ -74,7 +74,7 @@ instance Pretty DotProtoPackageSpec where
 
 instance Pretty DotProtoImport where
   pPrint (DotProtoImport q i) =
-    PP.text "import" <+> pPrint q <+> PP.text fp <> PP.text ";"
+    PP.text "import" <+> pPrint q <+> PP.text "\"" <+> PP.text fp <+> PP.text "\"" <> PP.text ";"
     where
       fp = case T.unpack . either id id . toText $ i of
              [] -> show ("" :: String)


### PR DESCRIPTION
It looks like if you parse and then render a proto file, it strips the double quotes from the imports accidentally. This fixed it for me, so just wanted to contribute it back.