### PR TITLE
Upgrade macOS version used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
           - ghc8104
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.0.2
         name: Checkout
-      - uses: cachix/install-nix-action@v13
+      - uses: cachix/install-nix-action@v17
         name: Install Nix
       - uses: cachix/cachix-action@v10
         name: Set up Cachix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-10.15
+          - macos-12
         compiler:
           - ghc8104
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-11
+          - macos-latest
         compiler:
           - ghc8104
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-12
+          - macos-11
         compiler:
           - ghc8104
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
… because GitHub is browning out macOS 10.15 builds:

https://github.com/awakesecurity/proto3-suite/actions/runs/2747559977