### PR TITLE
Avoid requiring that Arbitrary Turtle.FilePath exist.

### DIFF
--- a/src/Proto3/Suite/DotProto/AST.hs
+++ b/src/Proto3/Suite/DotProto/AST.hs
@@ -90,7 +90,7 @@ data DotProtoImport = DotProtoImport
 instance Arbitrary DotProtoImport where
     arbitrary = do
       dotProtoImportQualifier <- arbitrary
-      dotProtoImportPath <- arbitrary
+      dotProtoImportPath <- fmap fromString arbitrary
       return (DotProtoImport {..})
 
 data DotProtoImportQualifier


### PR DESCRIPTION
This change should help us to support more versions of Turtle.