### PR TITLE
Bring MonadIO into scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3.0.2
         name: Checkout
-      - uses: cachix/install-nix-action@v17
+      - uses: cachix/install-nix-action@v20
         name: Install Nix
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         name: Set up Cachix
         with:
           name: awakesecurity

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -39,6 +39,7 @@ module Proto3.Suite.DotProto.Generate
 import           Control.Applicative
 import           Control.Lens                   ((&), ix, over, has, filtered)
 import           Control.Monad.Except
+import           Control.Monad.IO.Class
 import           Data.Char
 import           Data.Coerce
 import           Data.Either                    (partitionEithers)

--- a/src/Proto3/Suite/DotProto/Internal.hs
+++ b/src/Proto3/Suite/DotProto/Internal.hs
@@ -20,6 +20,7 @@ import qualified Control.Foldl             as FL
 import           Control.Lens              (Lens', lens, over)
 import           Control.Lens.Cons         (_head)
 import           Control.Monad
+import           Control.Monad.IO.Class
 import           Control.Monad.Except
 import           Data.Bifunctor            (first)
 import           Data.Char


### PR DESCRIPTION
This change fixes the following failure with ghc-9.6.1:

```
proto3-suite> src/Proto3/Suite/DotProto/Internal.hs:83:13: error: [GHC-76037]
proto3-suite>     Not in scope: type constructor or class ‘MonadIO’
proto3-suite>     Suggested fixes:
proto3-suite>       • Perhaps use one of these:
proto3-suite>           ‘Turtle.MonadIO’ (imported from Turtle),
proto3-suite>           ‘Monad’ (imported from Prelude)
proto3-suite>       • Perhaps you want to add ‘MonadIO’ to the import list
proto3-suite>         in the import of ‘Turtle’
proto3-suite>         (src/Proto3/Suite/DotProto/Internal.hs:(46,1)-(47,50)).
proto3-suite>    |
proto3-suite> 83 | dieLines :: MonadIO m => Text -> m a
proto3-suite>    |             ^^^^^^^
```