### PR TITLE
Support proto files without a package declaration

### DIFF
--- a/src/Proto3/Suite/DotProto/Internal.hs
+++ b/src/Proto3/Suite/DotProto/Internal.hs
@@ -680,7 +680,3 @@ invalidMethodNameError = throwError . InvalidMethodName
 
 noSuchTypeError :: MonadError CompileError m => DotProtoIdentifier -> m a
 noSuchTypeError = throwError . NoSuchType
-
-protoPackageName :: MonadError CompileError m => DotProtoPackageSpec -> m DotProtoIdentifier
-protoPackageName (DotProtoPackageSpec name) = pure name
-protoPackageName DotProtoNoPackage = throwError NoPackageDeclaration


### PR DESCRIPTION
The proto compilation currently requires a package declaration. This PR allows compilation without package declarations thus making this implementation compatible with other language implementations.