### PR TITLE
Add source repository cabal stanza

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -43,8 +43,12 @@ flag large-records
   Default:       True
   Manual:        True
 
-common common 
-  default-extensions: 
+source-repository head
+  type:     git
+  location: https://github.com/awakesecurity/proto3-suite
+
+common common
+  default-extensions:
     DeriveDataTypeable DeriveGeneric
 
 library


### PR DESCRIPTION
This add a source-repository stanza to the cabal file. This will link the GitHub repository from Hackage.