### PR TITLE
Upgrade CI to `install-nix-action@v22`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.0.2
         name: Checkout
-      - uses: cachix/install-nix-action@v20
+      - uses: cachix/install-nix-action@v22
         name: Install Nix
       - uses: cachix/cachix-action@v12
         name: Set up Cachix


### PR DESCRIPTION
This PR upgrades to install-nix-action@v22 in CI. This fixes an environment issue that occurs during the "install Nix` step, see:

- The same fix for `proto3-wire`: https://github.com/awakesecurity/proto3-wire/pull/98
- The same fix for `gRPC-haskell`: https://github.com/awakesecurity/gRPC-haskell/pull/154