### PR TITLE
Fix compilation error when swagger is disabled

### DIFF
--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -788,10 +788,12 @@ dotProtoMessageD stringType recordStyle ctxt parentIdent messageIdent messagePar
             [ recDecl_ (HsIdent messageName) flds ]
             defaultMessageDeriving
 
+#ifdef SWAGGER
     let getName = \case
           DotProtoMessageField fld -> (: []) <$> getFieldNameForSchemaInstanceDeclaration fld
           DotProtoMessageOneOf ident _ -> (: []) . (Nothing, ) <$> dpIdentUnqualName ident
           _ -> pure []
+#endif
 
     messageDataDecl <- mkDataDecl <$> foldMapM (messagePartFieldD messageName) messageParts
 


### PR DESCRIPTION
When building without the swagger flag, this change fixes the following error:

  src/Proto3/Suite/DotProto/Generate.hs:792:46: error: [GHC-39999]
      • Could not deduce ‘Functor f0’ arising from a use of ‘<$>’
        from the context: MonadError CompileError m