### PR TITLE
Fix bug in instance "Eq (Enumerated a)".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-* Support GHC 9.2
+# 0.7.0
+* Support GHC 9.2.
+* Support proto files without a package declaration.
+* Modify "Eq (Enumerated a)" to identify "Enumerated (Right e)"
+  with "Enumerated (Left (fromProtoEnum e))" because those two
+  values encode to the same octet sequence.  They are already
+  equivalent as arguments to "isDefault @(Enumerated e)".
+* Derive Data and Generic instances for Protobuf AST types.
 
 # 0.6.0
 * Support use of ShortText as the Haskell type of a protobuf string.

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                proto3-suite
-version:             0.6.0
+version:             0.7.0
 synopsis:            A higher-level API to the proto3-wire library
 description:
   This library provides a higher-level API to <https://github.com/awakesecurity/proto3-wire the `proto3-wire` library>

--- a/src/Proto3/Suite/Types.hs
+++ b/src/Proto3/Suite/Types.hs
@@ -66,7 +66,7 @@ instance ProtoEnum a => Eq (Enumerated a) where
 -- | We compare two enumerated values by comparing the code to which they serialize.
 instance ProtoEnum a => Ord (Enumerated a) where
   compare = compare `on` either id fromProtoEnum . enumerated
-  {-# INLINABLE (==) #-}
+  {-# INLINABLE compare #-}
 
 instance ProtoEnum a => Arbitrary (Enumerated a) where
   arbitrary = do

--- a/src/Proto3/Suite/Types.hs
+++ b/src/Proto3/Suite/Types.hs
@@ -35,6 +35,7 @@ import           Control.Applicative
 import           Control.DeepSeq (NFData)
 import           GHC.Exts (IsList(..))
 import           GHC.Generics
+import           Data.Function (on)
 import           Data.Int (Int32)
 import qualified Data.Vector as V
 import           GHC.TypeLits (Symbol)
@@ -55,8 +56,13 @@ newtype Signed a = Signed { signed :: a }
 -- | 'Enumerated' lifts any type with an 'IsEnum' instance so that it can be encoded
 -- with 'HasEncoding'.
 newtype Enumerated a = Enumerated { enumerated :: Either Int32 a }
-  deriving (Show, Eq, Ord, Generic, NFData
+  deriving (Show, Ord, Generic, NFData
            , Functor, Foldable, Traversable)
+
+-- | We consider two enumerated values to be equal if they serialize to the same code.
+instance ProtoEnum a => Eq (Enumerated a) where
+  (==) = (==) `on` either id fromProtoEnum . enumerated
+  {-# INLINABLE (==) #-}
 
 instance ProtoEnum a => Arbitrary (Enumerated a) where
   arbitrary = do

--- a/src/Proto3/Suite/Types.hs
+++ b/src/Proto3/Suite/Types.hs
@@ -56,8 +56,7 @@ newtype Signed a = Signed { signed :: a }
 -- | 'Enumerated' lifts any type with an 'IsEnum' instance so that it can be encoded
 -- with 'HasEncoding'.
 newtype Enumerated a = Enumerated { enumerated :: Either Int32 a }
-  deriving (Show, Ord, Generic, NFData
-           , Functor, Foldable, Traversable)
+  deriving (Show, Ord, Generic, NFData, Functor, Foldable, Traversable)
 
 -- | We consider two enumerated values to be equal if they serialize to the same code.
 instance ProtoEnum a => Eq (Enumerated a) where

--- a/src/Proto3/Suite/Types.hs
+++ b/src/Proto3/Suite/Types.hs
@@ -56,11 +56,16 @@ newtype Signed a = Signed { signed :: a }
 -- | 'Enumerated' lifts any type with an 'IsEnum' instance so that it can be encoded
 -- with 'HasEncoding'.
 newtype Enumerated a = Enumerated { enumerated :: Either Int32 a }
-  deriving (Show, Ord, Generic, NFData, Functor, Foldable, Traversable)
+  deriving (Show, Generic, NFData, Functor, Foldable, Traversable)
 
 -- | We consider two enumerated values to be equal if they serialize to the same code.
 instance ProtoEnum a => Eq (Enumerated a) where
   (==) = (==) `on` either id fromProtoEnum . enumerated
+  {-# INLINABLE (==) #-}
+
+-- | We compare two enumerated values by comparing the code to which they serialize.
+instance ProtoEnum a => Ord (Enumerated a) where
+  compare = compare `on` either id fromProtoEnum . enumerated
   {-# INLINABLE (==) #-}
 
 instance ProtoEnum a => Arbitrary (Enumerated a) where


### PR DESCRIPTION
Modify "Eq (Enumerated a)" and "Ord (Enumerated a)" to identify "Enumerated (Right e)" with "Enumerated (Left (fromProtoEnum e))" because those two values encode to the same octet sequence.  They are already equivalent as arguments to "isDefault @(Enumerated e)".

Also increase the major version because this bug fix might break existing applications or test suites.