### PR TITLE
Improve doctests

### DIFF
--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -72,6 +72,9 @@ import qualified Turtle hiding (encodeString)
 import qualified Turtle.Compat as Turtle (encodeString)
 import           Turtle                         (FilePath, (</>), (<.>))
 
+-- $setup
+-- >>> :set -XTypeApplications
+
 --------------------------------------------------------------------------------
 
 --

--- a/src/Proto3/Suite/JSONPB/Class.hs
+++ b/src/Proto3/Suite/JSONPB/Class.hs
@@ -223,13 +223,13 @@ parseField :: FromJSONPB a
            => A.Object -> Key -> A.Parser a
 parseField = A.explicitParseField parseJSONPB
 
--- | >>> isDefault (def @E.Encoding)
+-- | >>> isDefault (def :: E.Encoding)
 -- True
 instance HasDefault E.Encoding where
   def       = E.empty
   isDefault = E.nullEncoding
 
--- | >>> isDefault (def @A.Value)
+-- | >>> isDefault (def :: A.Value)
 -- True
 instance HasDefault A.Value where
   def       = A.Null

--- a/src/Proto3/Suite/Tutorial.hs
+++ b/src/Proto3/Suite/Tutorial.hs
@@ -1,8 +1,6 @@
 -- |
 -- = Tutorial
 --
--- >>> :set -XOverloadedStrings
---
 -- This module contains a worked example of encoding and decoding messages,
 -- and exporting a corresponding .proto file from Haskell types.
 --
@@ -41,6 +39,9 @@ import Proto3.Suite (Enumerated, Nested, NestedVec, PackedVec,
                      enum, message, packageFromDefs, toProtoFileDef)
 import Proto3.Wire.Class (ProtoEnum)
 
+-- $setup
+-- >>> :set -XOverloadedStrings
+
 -- |
 -- == Defining Message Types
 --
@@ -65,7 +66,7 @@ import Proto3.Wire.Class (ProtoEnum)
 --
 -- We can also decode messages using `fromByteString`:
 --
--- >>> Proto3.Suite.fromByteString "\b*\DC2\SOH{" :: Either [Proto3.Suite..Decode.Parser.ParseError] Foo
+-- >>> Proto3.Suite.fromByteString "\b*\DC2\SOH{" :: Either Proto3.Wire.Decode.ParseError Foo
 -- Right (Foo {fooX = 42, fooY = PackedVec {packedvec = [123]}})
 data Foo = Foo
   { fooX :: Word32
@@ -125,12 +126,12 @@ data Shape
 -- }
 -- message Foo {
 --   uint32 fooX = 1;
---   repeated int32 fooY = 2 [packed=true];
+--   repeated int32 fooY = 2 [packed = true];
 -- }
 -- message Bar {
 --   Shape barShape = 1;
 --   Foo barFoo = 2;
---   repeated Foo foos = 3 [packed=false];
+--   repeated Foo foos = 3;
 -- }
 
 protoFile :: String

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -66,9 +66,8 @@ docTests :: TestTree
 docTests = testCase "doctests" $ do
   putStrLn "Running all doctests..."
   Test.DocTest.doctest
-    [ "-isrc"
-    , "-itests"
-    , "-igen"
+    [ "--verbose"
+    , "-isrc"
 #ifdef SWAGGER
 #ifdef SWAGGER_WRAPPER_FORMAT
     , "-isrc/swagger-wrapper-format"
@@ -85,8 +84,9 @@ docTests = testCase "doctests" $ do
     , "-DLARGE_RECORDS"
 #endif
     , "src/Proto3/Suite/DotProto/Internal.hs"
+    , "src/Proto3/Suite/DotProto/Generate.hs"
     , "src/Proto3/Suite/JSONPB/Class.hs"
-    , "tests/TestCodeGen.hs"
+    , "src/Proto3/Suite/Tutorial.hs"
     ]
 
 --------------------------------------------------------------------------------
@@ -327,11 +327,11 @@ qcDotProtoRoundtrip = testProperty
                                   ++ "\n\nInitial AST:\n\n"
 
 dotProtoRoundtripExtend :: TestTree
-dotProtoRoundtripExtend = 
+dotProtoRoundtripExtend =
   let expected :: DotProto
       expected = DotProto [] [] DotProtoNoPackage [] (DotProtoMeta (Path ("test-files" NE.:| ["test_proto_extend"])))
    in testCase
-        "Round-trip for a message extension" 
+        "Round-trip for a message extension"
         (testDotProtoRoundtrip expected)
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
1. Actually run the doctests in "Tutorial.hs". This commit also updates those doctests to match current expected types and behavior.

2. Convert doctests in test-only code to ordinary unit tests because:

  a. Because they are in test-only code they do not actually provide
     any documentation despite being expressed as doctests, and

  b. It seems that doctests tend to be fragile when upgrading GHC or
     dependencies, especially the ones found in "TestCodeGen.hs".