### PR TITLE
Nix: if enableLargeRecords is false use -f-large-records

### DIFF
--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -50,7 +50,7 @@ in {
                 (if enableDhall then "-fdhall" else "")
                 (if enableSwagger then "" else "-f-swagger")
                 (if swaggerWrapperFormat then "-fswagger-wrapper-format" else "")
-                (if enableLargeRecords then "-flarge-records" else "")
+                (if enableLargeRecords then "" else "-f-large-records")
               ];
             in
             (haskellPackagesNew.callCabal2nixWithOptions
@@ -65,7 +65,7 @@ in {
                 ++ (if enableDhall then [ "-fdhall" ] else [ ])
                 ++ (if enableSwagger then [ "" ] else [ "-f-swagger" ])
                 ++ (if swaggerWrapperFormat then [ "-fswagger-wrapper-format" ] else [ "" ])
-                ++ (if enableLargeRecords then [ "-flarge-records" ] else [ ]);
+                ++ (if enableLargeRecords then [ ] else [ "-f-large-records" ]);
             });
 
           proto3-suite-boot =


### PR DESCRIPTION
The absence of "-flarge-records" is not enough because the "large-records" cabal flag is enabled by default.

This fix should improve the coverage of continuous integration tests for the proto3-suite repository.