### PR TITLE
Avoid allocating intermediate field builder list.

### DIFF
--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -930,8 +930,8 @@ messageInstD stringType ctxt parentIdent msgIdent messageParts = do
 
          encodeMessageE = case encodedFields of
            [] -> memptyE
-           (field : fields) -> foldl op field fields
-             where op fs f = apply (apply mappendE [fs]) [f]
+           (field : fields) -> foldl op (paren field) fields
+             where op fs f = apply (apply mappendE [fs]) [paren f]
              -- NOTE: We use a left fold because this way the leftmost field
              -- is the most nested and the rightmost field--the one to be written
              -- first by the right-to-left builder--is the one that is least nested.

--- a/src/Proto3/Suite/DotProto/Generate/Syntax.hs
+++ b/src/Proto3/Suite/DotProto/Generate/Syntax.hs
@@ -107,10 +107,9 @@ defaultSrcLoc = SrcLoc "<generated>" 0 0
 
 dotProtoFieldC, primC, repeatedC, nestedRepeatedC, namedC, mapC,
   fieldNumberC, singleC, dotsC, pathC, qualifiedC, anonymousC, dotProtoOptionC,
-  identifierC, stringLitC, intLitC, floatLitC, boolLitC, trueC, falseC,
-  nothingC, justC, forceEmitC, mconcatE, encodeMessageFieldE,
-  fromStringE, decodeMessageFieldE, pureE, returnE, memptyE, msumE, atE, oneofE,
-  fmapE :: HsExp
+  identifierC, stringLitC, intLitC, floatLitC, boolLitC, trueC, falseC, nothingC,
+  justC, forceEmitC,  encodeMessageFieldE, fromStringE, decodeMessageFieldE,
+  pureE, returnE, mappendE, memptyE, msumE, atE, oneofE, fmapE :: HsExp
 
 dotProtoFieldC       = HsVar (protobufASTName "DotProtoField")
 primC                = HsVar (protobufASTName "Prim")
@@ -140,10 +139,10 @@ trueC                = HsVar (haskellName "True")
 falseC               = HsVar (haskellName "False")
 nothingC             = HsVar (haskellName "Nothing")
 justC                = HsVar (haskellName "Just")
-mconcatE             = HsVar (haskellName "mconcat")
 fromStringE          = HsVar (haskellName "fromString")
 pureE                = HsVar (haskellName "pure")
 returnE              = HsVar (haskellName "return")
+mappendE             = HsVar (haskellName "mappend")
 memptyE              = HsVar (haskellName "mempty")
 msumE                = HsVar (haskellName "msum")
 fmapE                = HsVar (haskellName "fmap")


### PR DESCRIPTION
During encoding, we used to create a list of builders for the fields of a protobuf message and then make a call to mconcat on the message builder type.  But mconcat is recursive and therefore cannot be inlined as such, and GHC seems reluctant to perform beta reduction on known constructors such as (:) across module boundaries.

Therefore this commit switches from "mconcat [x, y, z]" to "mappend (mappend x y) z" (for example).  These appends are left associativity because the builder writes in reverse, starting with the rightmost field.