### PR TITLE
Remove unnecessary `DotProtoEmptyField` constructor

### DIFF
--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -827,12 +827,12 @@ instance MessageField (PackedVec Double) where
 instance (MessageField e, KnownSymbol comments) => MessageField (e // comments) where
   encodeMessageField !fn = encodeMessageField fn . unCommented
   {-# INLINE encodeMessageField #-}
+
   decodeMessageField = coerce @(Parser RawField e)
                               @(Parser RawField (Commented comments e))
                               decodeMessageField
-  protoType p = case field of
-      DotProtoEmptyField -> DotProtoEmptyField
-      f -> f { dotProtoFieldComment = symbolVal (lowerProxy2 p) }
+
+  protoType p = field { dotProtoFieldComment = symbolVal (lowerProxy2 p) }
     where
       field :: DotProtoField
       field = protoType (lowerProxy1 p)
@@ -1026,8 +1026,9 @@ instance (KnownNat (GenericFieldCount f), GenericMessage f, GenericMessage g)
         adjust (genericDotProto (proxy# :: Proxy# g))
       where
         offset = fromIntegral $ natVal (Proxy @(GenericFieldCount f))
+
         adjust = map adjustPart
-        adjustPart DotProtoEmptyField = DotProtoEmptyField
+
         adjustPart part = part
           { dotProtoFieldNumber = FieldNumber . (offset +)
                                   . getFieldNumber . dotProtoFieldNumber
@@ -1047,7 +1048,6 @@ instance (Selector s, GenericMessage f) => GenericMessage (M1 S s f) where
   genericDotProto _                 = map applyName $ genericDotProto (proxy# :: Proxy# f)
     where
       applyName :: DotProtoField -> DotProtoField
-      applyName DotProtoEmptyField = DotProtoEmptyField
       applyName mp = mp { dotProtoFieldName = fromMaybe Anonymous newName}
       -- [issue] this probably doesn't match the intended name generating semantics
 

--- a/src/Proto3/Suite/DotProto/AST.hs
+++ b/src/Proto3/Suite/DotProto/AST.hs
@@ -58,7 +58,7 @@ instance Show MessageName where
 
 -- | The name of some field
 newtype FieldName = FieldName
-  { getFieldName :: String } 
+  { getFieldName :: String }
   deriving (Data, Eq, Generic, IsString, Ord)
 
 instance Show FieldName where
@@ -66,14 +66,14 @@ instance Show FieldName where
 
 -- | The name of the package
 newtype PackageName = PackageName
-  { getPackageName :: String } 
+  { getPackageName :: String }
   deriving (Data, Eq, Generic, IsString, Ord)
 
 instance Show PackageName where
   show = show . getPackageName
 
-newtype Path = Path 
-  { components :: NE.NonEmpty String } 
+newtype Path = Path
+  { components :: NE.NonEmpty String }
   deriving (Data, Eq, Generic, Ord, Show)
 
 -- Used for testing
@@ -91,7 +91,7 @@ data DotProtoIdentifier
 data DotProtoImport = DotProtoImport
   { dotProtoImportQualifier :: DotProtoImportQualifier
   , dotProtoImportPath      :: FilePath
-  } 
+  }
   deriving (Data, Eq, Generic, Ord, Show)
 
 instance Arbitrary DotProtoImport where
@@ -329,7 +329,7 @@ data RPCMethod = RPCMethod
   , rpcMethodResponseType :: DotProtoIdentifier
   , rpcMethodResponseStreaming :: Streaming
   , rpcMethodOptions :: [DotProtoOption]
-  } 
+  }
   deriving (Data, Eq, Generic, Ord, Show)
 
 instance Arbitrary RPCMethod where
@@ -386,7 +386,6 @@ data DotProtoField = DotProtoField
   , dotProtoFieldOptions :: [DotProtoOption]
   , dotProtoFieldComment :: String
   }
-  | DotProtoEmptyField
   deriving (Data, Eq, Generic, Ord, Show)
 
 instance Arbitrary DotProtoField where

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -1011,8 +1011,6 @@ dotProtoMessageD stringType recordStyle ctxt parentIdent messageIdent messagePar
        let ident = unqual_ dataName consName
        pure (conDecl_ ident [unbangedTy_ consTy], ident)
 
-    oneOfCons _ DotProtoEmptyField = internalError "field type : empty field"
-
 -- *** Generate Protobuf 'Message' instances
 
 messageInstD

--- a/src/Proto3/Suite/DotProto/Internal.hs
+++ b/src/Proto3/Suite/DotProto/Internal.hs
@@ -618,7 +618,6 @@ getQualifiedFields msgName msgParts = flip foldMapM msgParts $ \case
             s <- dpIdentUnqualName dotProtoFieldName
             c <- prefixedConName oneofTypeName s
             pure [OneofSubfield dotProtoFieldNumber c (coerce s) dotProtoFieldType dotProtoFieldOptions]
-        mkSubfield DotProtoEmptyField = pure []
 
     fieldElems <- foldMapM mkSubfield fields
 

--- a/src/Proto3/Suite/DotProto/Parsing.hs
+++ b/src/Proto3/Suite/DotProto/Parsing.hs
@@ -273,8 +273,8 @@ topLevel modulePath = do
 -- top-level statements
 
 topStatement :: ProtoParser DotProtoStatement
-topStatement = 
-  choice 
+topStatement =
+  choice
     [ DPSImport <$> import_
     , DPSPackage <$> package
     , DPSOption <$> pOptionStmt
@@ -299,8 +299,8 @@ package = do symbol "package"
              return $ DotProtoPackageSpec p
 
 definition :: ProtoParser DotProtoDefinition
-definition = 
-  choice 
+definition =
+  choice
     [ try message
     , try enum
     , service
@@ -309,7 +309,7 @@ definition =
 --------------------------------------------------------------------------------
 -- options
 
--- | Parses a protobuf option that could appear in a service, RPC, message, 
+-- | Parses a protobuf option that could appear in a service, RPC, message,
 -- enumeration, or at the top-level.
 --
 -- @since 0.5.2
@@ -321,7 +321,7 @@ pOptionStmt = token (between pOptionKw (token semi) pFieldOptionStmt)
 -- @since 0.5.2
 pFieldOptions :: ProtoParser [DotProtoOption]
 pFieldOptions = pOptions <|> pure []
-  where 
+  where
     pOptions :: ProtoParser [DotProtoOption]
     pOptions = between lbracket rbracket (commaSep1 (token pFieldOptionStmt))
 
@@ -335,8 +335,8 @@ pFieldOptions = pOptions <|> pure []
 --
 -- @since 0.5.2
 pFieldOptionStmt :: ProtoParser DotProtoOption
-pFieldOptionStmt = token $ do 
-  idt <- pOptionId 
+pFieldOptionStmt = token $ do
+  idt <- pOptionId
   token (char '=')
   val <- value
   pure (DotProtoOption idt val)
@@ -345,23 +345,23 @@ pFieldOptionStmt = token $ do
 --
 -- @since 0.5.2
 pOptionId :: ProtoParser DotProtoIdentifier
-pOptionId = 
-  choice 
+pOptionId =
+  choice
     [ try pOptionQName
     , try (parens pOptionName)
     , pOptionName
     ]
-  where 
+  where
     pOptionName :: ProtoParser DotProtoIdentifier
     pOptionName = token $ do
       nm <- identifierName
       nms <- many (char '.' *> identifierName)
-      if null nms 
+      if null nms
         then pure (Single nm)
         else pure (Dots (Path (nm :| nms)))
 
     pOptionQName :: ProtoParser DotProtoIdentifier
-    pOptionQName = token $ do 
+    pOptionQName = token $ do
       idt <- parens pOptionName
       nms <- char '.' *> pOptionName
       pure (Qualified idt nms)
@@ -419,7 +419,7 @@ message = do symbol "message"
 messageOneOf :: ProtoParser DotProtoMessagePart
 messageOneOf = do symbol "oneof"
                   name <- singleIdentifier
-                  body <- braces $ many (messageField <|> empty $> DotProtoEmptyField)
+                  body <- braces (many messageField)
                   return $ DotProtoMessageOneOf name body
 
 messagePart :: ProtoParser DotProtoMessagePart
@@ -499,7 +499,7 @@ strFieldName =
 -- Message Extensions ----------------------------------------------------------
 
 pExtendStmt :: ProtoParser (DotProtoIdentifier, [DotProtoMessagePart])
-pExtendStmt = do 
+pExtendStmt = do
   pExtendKw
   idt <- identifier
   fxs <- braces (many messagePart)
@@ -510,6 +510,6 @@ pExtendStmt = do
 -- @since 0.5.2
 pExtendKw :: ProtoParser ()
 pExtendKw = do
-  spaces 
-  token (string "extend" >> notFollowedBy alphaNum) 
+  spaces
+  token (string "extend" >> notFollowedBy alphaNum)
     <?> "keyword 'extend'"

--- a/src/Proto3/Suite/DotProto/Rendering.hs
+++ b/src/Proto3/Suite/DotProto/Rendering.hs
@@ -147,7 +147,6 @@ prettyPrintProtoDefinition opts = defn where
     <+> optionAnnotation options
     <>  PP.text ";"
     $$  PP.nest 2 (renderComment comments)
-  field _ DotProtoEmptyField = PP.empty
 
   enumPart :: DotProtoIdentifier -> DotProtoEnumPart -> PP.Doc
   enumPart msgName (DotProtoEnumField name value options)

--- a/tools/canonicalize-proto-file/Main.hs
+++ b/tools/canonicalize-proto-file/Main.hs
@@ -150,15 +150,10 @@ instance CanonicalRank [DotProtoField] (Maybe FieldNumber) where
     fmap getMin . foldMap (fmap Min . canonicalRank)
 
 instance Canonicalize [DotProtoField] where
-  canonicalize = canonicalSort . filter keep
-    where
-      keep DotProtoEmptyField = False
-      keep _ = True
+  canonicalize = canonicalSort
 
 instance CanonicalRank DotProtoField (Maybe FieldNumber) where
-  canonicalRank = \case
-    DotProtoField{..} -> Just dotProtoFieldNumber
-    DotProtoEmptyField -> Nothing
+  canonicalRank DotProtoField{..} = Just dotProtoFieldNumber
 
 instance Canonicalize DotProtoField where
   canonicalize DotProtoField{..} = DotProtoField
@@ -169,7 +164,6 @@ instance Canonicalize DotProtoField where
     , dotProtoFieldComment = ""  -- In future we might add a command-line
                                  -- option to preserve comments.
     }
-  canonicalize DotProtoEmptyField = DotProtoEmptyField
 
 instance Canonicalize DotProtoType where canonicalize = id
 


### PR DESCRIPTION
Minor change improving the AST by removing the `DotProtoEmptyField` constructor from the `DotProtoField`. This constructor complicated the AST and was needed nowhere.