### PR TITLE
Update default `ghc8107` to `ghc948`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ compiler ? "ghc8107"
+{ compiler ? "ghc948"
 , enableDhall ? false
 , enableSwagger ? true
 , swaggerWrapperFormat ? false


### PR DESCRIPTION
This PR updates the default GHC version used in the `nix-shell.nix` and `default.nix` file from `ghc8107` to `ghc948`.