### PR TITLE
Fix remove `cabal-install` from Nix shell `buildInputs`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -27,7 +27,6 @@ let
 
 in proto3-suite.env.overrideAttrs (old: {
   buildInputs = (old.buildInputs or []) ++ [
-    pkgs.cabal-install
     pkgs.protobuf
     pkgs.python3Packages.virtualenv
   ];


### PR DESCRIPTION
This is only a temporary fix for an issue we've been encountering with provisioning a Nix shell on `aarch64-darwin` with the `semaphore-compat` and `unix` packages. This is known issue and is documented here: https://github.com/NixOS/nixpkgs/issues/333921