### PR TITLE
Bump Checkout Action from `v3.5.3` to `v4`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4
         name: Checkout
       - uses: cachix/install-nix-action@v22
         name: Install Nix


### PR DESCRIPTION
Changes the github checkout action version from `3.5.3` to `4.0` in `ci.yml`.