### PR TITLE
Add access to octets in MessageEncoding.

### DIFF
--- a/src/Proto3/Suite/Form/Encode.hs
+++ b/src/Proto3/Suite/Form/Encode.hs
@@ -29,8 +29,10 @@ module Proto3.Suite.Form.Encode
   , toLazyByteString
   , etaMessageEncoder
   , MessageEncoding
-  , cacheMessageEncoder
+  , cacheMessageEncoding
   , cachedMessageEncoding
+  , messageEncodingToByteString
+  , unsafeByteStringToMessageEncoding
   , Prefix(..)
   , etaPrefix
   , Fields
@@ -311,6 +313,6 @@ instance ( MessageFieldType repetition protoType a
 -- | Creates a message encoder by means of type class `Proto3.Suite.Class.Message`.
 --
 -- To encode a field instead of a top-level message, use 'Reflection'.
-messageReflection :: forall a . Message a => a -> MessageEncoder a
-messageReflection m = coerce (encodeMessage @a (Wire.fieldNumber 1) m)
+messageReflection :: forall message . Message message => message -> MessageEncoder message
+messageReflection m = coerce (encodeMessage @message (Wire.fieldNumber 1) m)
 {-# INLINABLE messageReflection #-}

--- a/src/Proto3/Suite/Form/Encode.hs
+++ b/src/Proto3/Suite/Form/Encode.hs
@@ -404,7 +404,9 @@ messageReflection :: forall message . Message message => message -> MessageEncod
 messageReflection m = coerce (encodeMessage @message (fieldNumber 1) m)
 {-# INLINABLE messageReflection #-}
 
--- | Equivalent to @'cacheMessageEncoding' . 'messageReflection'@.
+-- | Creates a message encoding by means of type class `Proto3.Suite.Class.Message`.
+--
+-- Equivalent to @'cacheMessageEncoding' . 'messageReflection'@.
 cacheMessage :: forall message . Message message => message -> MessageEncoding message
 cacheMessage m = cacheMessageEncoding (messageReflection m)
 {-# INLINABLE cacheMessage #-}

--- a/src/Proto3/Suite/Form/Encode.hs
+++ b/src/Proto3/Suite/Form/Encode.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -70,6 +71,7 @@ module Proto3.Suite.Form.Encode
   ) where
 
 import Control.Category (Category(..))
+import Control.DeepSeq (NFData)
 import Data.Coerce (coerce)
 import Data.Int (Int8, Int16, Int32, Int64)
 import Data.Kind (Type)
@@ -81,6 +83,7 @@ import Data.Text.Lazy qualified as TL
 import Data.Text.Short qualified as TS
 import Data.Word (Word8, Word16, Word32, Word64)
 import GHC.Exts (Proxy#, proxy#)
+import GHC.Generics (Generic)
 import GHC.TypeLits (Symbol)
 import Prelude hiding (String, (.), id)
 import Proto3.Suite.Form.Encode.Core
@@ -99,9 +102,14 @@ import Proto3.Wire.Types (fieldNumber)
 -- | The octet sequence that would be emitted by some
 -- 'MessageEncoder' having the same type parameter.
 --
+-- (This type is not a 'Semigroup' because combining encodings that both
+-- have the same non-repeated field is arguably incorrect, even though the
+-- standard asks parsers to to try to work around such improper repetition.)
+--
 -- See also: 'cacheMessageEncoding'
 newtype MessageEncoding (message :: Type) = UnsafeMessageEncoding B.ByteString
-  deriving newtype (Eq)
+  deriving stock (Generic)
+  deriving newtype (Eq, NFData, Ord)
 
 type role MessageEncoding nominal
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -373,10 +373,16 @@ encodeCachedSubmessage = testGroup "Cached Submessages"
           bogus :: FormE.MessageEncoding TP.Trivial
           bogus = FormE.unsafeByteStringToMessageEncoding badForm
       -- Test desired behavior for valid encoding:
-      show encoding @?= "Proto3.Suite.Form.Encode.messageReflection " ++ showsPrec 11 trivial ""
+      show encoding @?= "Proto3.Suite.Form.Encode.cacheMessage " ++ showsPrec 11 trivial ""
+      -- Check that when interpreting the above expected 'show' output
+      -- as Haskell source, it really does produce the shown value:
+      encoding @=? FormE.cacheMessage trivial
       -- Test fallback behavior for invalid encoding:
       show bogus @?=
         "Proto3.Suite.Form.Encode.unsafeByteStringToMessageEncoding " ++ showsPrec 11 badForm ""
+      -- Check that when interpreting the above expected 'show' output
+      -- as Haskell source, it really does produce the shown value:
+      bogus @=? FormE.unsafeByteStringToMessageEncoding badForm
 
 data TestMessage
        (num :: Nat)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -330,10 +330,11 @@ encodeCachedSubmessage = testGroup "Cached Submessages"
   [ testOptional
   , testRepeated
   , testOneof
+  , testShow
   ]
   where
     cacheReflection :: forall a . Message a => a -> FormE.MessageEncoding a
-    cacheReflection = FormE.cacheMessageEncoder . FormE.messageReflection
+    cacheReflection = FormE.cacheMessageEncoding . FormE.messageReflection
 
     testOptional :: TestTree
     testOptional = testCase "cached optional submessage" $ do
@@ -362,6 +363,20 @@ encodeCachedSubmessage = testGroup "Cached Submessages"
             FormE.field @"withOneof" (cacheReflection withOneof)
       FormE.toLazyByteString withImported @?=
         toLazyByteString (TPO.WithImported (Just (TPO.WithImportedPickOneWithOneof withOneof)))
+
+    testShow :: TestTree
+    testShow = testCase "Show MessageEncoding" $ do
+      let trivial = TP.Trivial 123
+          badForm = "abc"
+          encoding :: FormE.MessageEncoding TP.Trivial
+          encoding = cacheReflection trivial
+          bogus :: FormE.MessageEncoding TP.Trivial
+          bogus = FormE.unsafeByteStringToMessageEncoding badForm
+      -- Test desired behavior for valid encoding:
+      show encoding @?= "Proto3.Suite.Form.Encode.messageReflection " ++ showsPrec 11 trivial ""
+      -- Test fallback behavior for invalid encoding:
+      show bogus @?=
+        "Proto3.Suite.Form.Encode.unsafeByteStringToMessageEncoding " ++ showsPrec 11 badForm ""
 
 data TestMessage
        (num :: Nat)


### PR DESCRIPTION
Also add `Eq` and `Show` instances for `MessageEncoding`,
rename `cacheMessageEncoder` to `cacheMessageEncoding`,
add `cacheMessage`, and rename `cachedPrefix` to `cacheFields`.