### PR TITLE
Remove `large-records` from `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,27 +23,15 @@ for more details.
 
 #### GHC 9.10
 
-We do not support features making use of the "large-records"
-library because it does not currently build on GHC 9.10, and
-therefore we cannot test our support.
-
-Otherwise we support GHC 9.10 on Linux and Darwin.
+Supported on Linux and Darwin.
 
 #### GHC 9.8
 
-We do not support features making use of the "large-records"
-library because it does not currently build on GHC 9.8, and
-therefore we cannot test our support.
-
-Otherwise we support GHC 9.8 on Linux and Darwin.
+Supported on Linux and Darwin.
 
 #### GHC 9.6
 
-We do not support features making use of the "large-records"
-library because it does not currently build on GHC 9.6, and
-therefore we cannot test our support.
-
-Otherwise we support GHC 9.6 on Linux and Darwin.
+Supported on Linux and Darwin.
 
 #### GHC 9.4
 

--- a/src/Proto3/Suite/DotProto/Generate/Record.hs
+++ b/src/Proto3/Suite/DotProto/Generate/Record.hs
@@ -1,6 +1,4 @@
-{- | This module provides functions to generate regular Haskell records
-   without using the large-records library.
--}
+-- | This module provides functions to generate Haskell records
 module Proto3.Suite.DotProto.Generate.Record where
 
 import GHC.Types.Name.Occurrence (tcName)


### PR DESCRIPTION
Now that support for `large-records` has been dropped we don't need to mention it in the `README.md` or in Haskell modules.