### PR TITLE
build: depend from `ghc` to `ghc-lib-parser`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
         compiler:
-          - ghc902
           - ghc928
           - ghc948
           - ghc965

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 0.9.0
 * [#272](https://github.com/awakesecurity/proto3-suite/pull/272) removed support for `large-records` and `large-generics`.
 * [#274](https://github.com/awakesecurity/proto3-suite/pull/274) Support aeson-2.2.
+* [#276](https://github.com/awakesecurity/proto3-suite/pull/276)
+  * Switch dependency from `ghc` to `ghc-lib-parser`
+  * Drop support for GHC 9.0.
 
 # 0.8.3
 * Fix overlong encoding of packed "sint32" fields containing elements in

--- a/README.md
+++ b/README.md
@@ -41,11 +41,6 @@ Supported on Linux and Darwin.
 
 Supported on Linux and Darwin.
 
-#### GHC 9.0
-
-Supported only on Linux because "crypton" fails a test on Darwin,
-probably due to [this issue](https://github.com/kazu-yamamoto/crypton/issues/35).
-
 ### Nix shell + Cabal (recommended)
 
 The Nix shell provides an incremental build environment (but see below for

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -74,11 +74,6 @@ in {
           bifunctors =
             pkgsNew.haskell.lib.dontCheck haskellPackagesOld.bifunctors;
 
-          # With nixpkgs-24.11 and our overrides, cabal-install-solver does
-          # not like the version of directory when building with GHC 9.0.
-          cabal-install-solver =
-            pkgsNew.haskell.lib.doJailbreak haskellPackagesOld.cabal-install-solver;
-
           # With nixpkgs-23.11 and ghc981, conduit wants hspec for testing,
           # which causes problems.
           conduit =
@@ -287,28 +282,6 @@ in {
                 broken = false;
                 jailbreak = true;
               });
-
-          # Newer versions of "witch" do not support GHC 9.0.
-          witch =
-            if builtins.compareVersions haskellPackagesOld.ghc.version "9.2.0" < 0
-              then haskellPackagesNew.callPackage (
-                { mkDerivation, base, bytestring, containers, HUnit, lib, tagged
-                , template-haskell, text, time, transformers
-                }:
-                mkDerivation {
-                  pname = "witch";
-                  version = "1.1.6.0";
-                  sha256 = "e3f0879abbc22d7c674219317783438f28325e09e0b30cbc8890c936d870192e";
-                  libraryHaskellDepends = [
-                    base bytestring containers tagged template-haskell text time
-                  ];
-                  testHaskellDepends = [
-                    base bytestring containers HUnit tagged text time transformers
-                  ];
-                  description = "Convert values from one type into another";
-                  license = lib.licenses.mit;
-                }) {}
-              else haskellPackagesOld.witch;
 
           # With nixpkgs-23.11 and ghc962, proto3-wire thinks
           # that doctest and transformers are out of bounds.

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -374,12 +374,6 @@ in {
                   python =
                     pkgsNew.python3.withPackages (pkgs: [ pkgs.protobuf ]);
 
-                  ghc =
-                    haskellPackagesNew.ghcWithPackages
-                      (pkgs: (oldArgs.testHaskellDepends or [ ]) ++ [
-                        haskellPackagesNew.proto3-suite-boot
-                      ]);
-
                   test-files = (gitignoreSource ../../test-files);
 
                   compile-proto-flags = {
@@ -432,7 +426,6 @@ in {
 
                   testHaskellDepends =
                     (oldArgs.testHaskellDepends or [ ]) ++ [
-                      pkgsNew.ghc
                       haskellPackagesNew.proto3-suite-boot
                       python
                       protobuf
@@ -441,7 +434,7 @@ in {
                   shellHook = (oldArgs.shellHook or "") + ''
                     ${copyGeneratedCode}
 
-                    export PATH=${haskellPackagesNew.cabal-install}/bin:${ghc}/bin:${python}/bin:${protobuf}/bin''${PATH:+:}$PATH
+                    export PATH=${haskellPackagesNew.cabal-install}/bin:${python}/bin:${protobuf}/bin''${PATH:+:}$PATH
                   '';
                 }
               );

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -110,7 +110,7 @@ library
                        contravariant >=1.4 && <1.6,
                        filepath,
                        foldl,
-                       ghc-lib-parser >=9.0 && <9.11,
+                       ghc-lib-parser >=9.2.8 && <9.11,
                        hashable,
                        insert-ordered-containers,
                        lens,

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -110,7 +110,7 @@ library
                        contravariant >=1.4 && <1.6,
                        filepath,
                        foldl,
-                       ghc >=9.0 && <9.11,
+                       ghc-lib-parser >=9.0 && <9.11,
                        hashable,
                        insert-ordered-containers,
                        lens,
@@ -202,7 +202,7 @@ test-suite tests
     , deepseq >=1.4 && <1.6
     , doctest
     , generic-arbitrary
-    , ghc
+    , ghc-lib-parser
     , hedgehog
     , mtl >=2.2 && <2.4
     , parsec >= 3.1.9 && <3.2.0
@@ -229,7 +229,7 @@ executable compile-proto-file
   hs-source-dirs:      tools/compile-proto-file
   default-language:    Haskell2010
   build-depends:       base >=4.15 && <5.0
-                       , ghc
+                       , ghc-lib-parser
                        , optparse-applicative
                        , proto3-suite
                        , system-filepath

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -82,12 +82,12 @@ import qualified Turtle hiding (encodeString)
 import qualified Turtle.Compat as Turtle (encodeString)
 import           Turtle                         (FilePath, (</>), (<.>))
 
-#if !MIN_VERSION_ghc(9,6,0)
+#if !MIN_VERSION_ghc_lib_parser(9,6,0)
 import qualified GHC.Unit.Module.Name           as GHC
 import qualified GHC.Types.Basic                as GHC (PromotionFlag(..))
 #endif
 
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
 import           GHC.Hs                         (HsSigType(..))
 import           GHC.Parser.Annotation          (noLocA)
 #endif
@@ -265,7 +265,7 @@ hsModuleForDotProto ::
   -- |
   TypeContext ->
   m (GHC.HsModule
-#if MIN_VERSION_ghc(9,6,0)
+#if MIN_VERSION_ghc_lib_parser(9,6,0)
                   GHC.GhcPs
 #endif
                            )
@@ -325,7 +325,7 @@ instancesForModule m = mapMaybe go
          ( GHC.InstD clsInstX
            ( GHC.ClsInstD clsInstDeclX clsInstDecl@GHC.ClsInstDecl
              { cid_poly_ty =
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
                  GHC.L tyX
 #endif
                    (HsSig ext bndrs ty) } ) ) )
@@ -335,7 +335,7 @@ instancesForModule m = mapMaybe go
                ( GHC.InstD clsInstX
                  ( GHC.ClsInstD clsInstDeclX clsInstDecl
                    { GHC.cid_poly_ty =
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
                        GHC.L tyX
 #endif
                          (HsSig ext bndrs (tyConApply tc (typeNamed_ (noLocA (GHC.Unqual i)) : ts)))
@@ -363,7 +363,7 @@ replaceHsInstDecls overrides base = concatMap (mbReplace) base
                     { tcdLName = tyn
                     , tcdDataDefn = dd@GHC.HsDataDefn
                       { dd_derivs =
-#if !MIN_VERSION_ghc(9,2,0)
+#if !MIN_VERSION_ghc_lib_parser(9,2,0)
                           GHC.L _
 #endif
                                   clauses
@@ -375,7 +375,7 @@ replaceHsInstDecls overrides base = concatMap (mbReplace) base
              ( GHC.TyClD dataDeclX
                ( dataDecl { GHC.tcdDataDefn = dd
                             { GHC.dd_derivs =
-#if !MIN_VERSION_ghc(9,2,0)
+#if !MIN_VERSION_ghc_lib_parser(9,2,0)
                                 noLocA
 #endif
                                   uncustomized
@@ -405,7 +405,7 @@ replaceHsInstDecls overrides base = concatMap (mbReplace) base
       find (\x -> Just desired == (getSig =<< typeOfInstDecl x)) overrides
 
     getSig :: (HsOuterSigTyVarBndrs, HsType) -> Maybe SimpleTypeName
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
     getSig (GHC.HsOuterImplicit _, x) = simpleType x
     getSig _ = empty
 #else

--- a/src/Proto3/Suite/DotProto/Generate/Syntax.hs
+++ b/src/Proto3/Suite/DotProto/Generate/Syntax.hs
@@ -21,10 +21,10 @@ import GHC.Types.Name.Occurrence (NameSpace, dataName, mkOccName, tcName, tvName
 import GHC.Types.Name.Reader (mkRdrQual, mkRdrUnqual, rdrNameSpace)
 import GHC.Types.SrcLoc (GenLocated(..), SrcSpan, generatedSrcSpan)
 
-#if MIN_VERSION_ghc(9,10,0)
+#if MIN_VERSION_ghc_lib_parser(9,10,0)
 import GHC.Types.Basic (GenReason(OtherExpansion))
 #endif
-#if MIN_VERSION_ghc(9,8,0)
+#if MIN_VERSION_ghc_lib_parser(9,8,0)
 import Control.Arrow ((***))
 import Data.Bool (bool)
 import Data.Ratio ((%))
@@ -37,7 +37,7 @@ import GHC.Types.Fixity (LexicalFixity(..))
 import GHC.Types.PkgQual (RawPkgQual(..))
 import GHC.Types.SourceText
          (IntegralLit(..), FractionalExponentBase(..), FractionalLit(..), SourceText(..))
-#elif MIN_VERSION_ghc(9,6,0)
+#elif MIN_VERSION_ghc_lib_parser(9,6,0)
 import Control.Arrow ((***))
 import Data.Bool (bool)
 import Data.Ratio ((%))
@@ -50,7 +50,7 @@ import GHC.Types.Fixity (LexicalFixity(..))
 import GHC.Types.PkgQual (RawPkgQual(..))
 import GHC.Types.SourceText
          (IntegralLit(..), FractionalExponentBase(..), FractionalLit(..), SourceText(..))
-#elif MIN_VERSION_ghc(9,4,0)
+#elif MIN_VERSION_ghc_lib_parser(9,4,0)
 import Data.Ratio ((%))
 import Data.Void (Void)
 import GHC.Hs hiding (HsBind, HsDecl, HsDerivingClause, HsOuterFamEqnTyVarBndrs,
@@ -64,7 +64,7 @@ import GHC.Types.SourceText
 import GHC.Types.SrcLoc (LayoutInfo(..))
 import GHC.Unit (IsBootInterface(..))
 import GHC.Unit.Module (ModuleName, mkModuleName)
-#elif MIN_VERSION_ghc(9,2,0)
+#elif MIN_VERSION_ghc_lib_parser(9,2,0)
 import Data.Ratio ((%))
 import Data.Void (Void)
 import GHC.Hs hiding (HsBind, HsDecl, HsDerivingClause, HsOuterFamEqnTyVarBndrs,
@@ -107,13 +107,13 @@ type HsImportSpec = LIE GhcPs
 type HsMatch = LMatch GhcPs HsExp
 type HsName = LIdP GhcPs
 type HsOuterFamEqnTyVarBndrs =
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
   GHC.HsOuterFamEqnTyVarBndrs GhcPs
 #else
   ()
 #endif
 type HsOuterSigTyVarBndrs =
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
   GHC.HsOuterSigTyVarBndrs GhcPs
 #else
   ()
@@ -124,7 +124,7 @@ type HsQOp = LHsExpr GhcPs
 type HsSig = LSig GhcPs
 type HsTyVarBndrU = LHsTyVarBndr () GhcPs
 type HsTyVarBndrV = LHsTyVarBndr
-#if MIN_VERSION_ghc(9,8,0)
+#if MIN_VERSION_ghc_lib_parser(9,8,0)
                                  (HsBndrVis GhcPs)
 #else
                                  ()
@@ -133,7 +133,7 @@ type HsTyVarBndrV = LHsTyVarBndr
 type HsType = LHsType GhcPs
 type Module = ModuleName
 
-#if MIN_VERSION_ghc(9,10,0)
+#if MIN_VERSION_ghc_lib_parser(9,10,0)
 
 pattern VirtualBraces :: Int -> EpLayout
 pattern VirtualBraces indentation = EpVirtualBraces indentation
@@ -176,7 +176,7 @@ instance SyntaxDefault SrcSpan
   where
     synDef = generatedSrcSpan
 
-#if MIN_VERSION_ghc(9,10,0)
+#if MIN_VERSION_ghc_lib_parser(9,10,0)
 
 instance SyntaxDefault AnnParen
   where
@@ -220,7 +220,7 @@ instance SyntaxDefault (HsBndrVis GhcPs)
 
 #endif
 
-#if MIN_VERSION_ghc(9,8,0) && !MIN_VERSION_ghc(9,10,0)
+#if MIN_VERSION_ghc_lib_parser(9,8,0) && !MIN_VERSION_ghc_lib_parser(9,10,0)
 
 instance SyntaxDefault (HsBndrVis GhcPs)
   where
@@ -228,7 +228,7 @@ instance SyntaxDefault (HsBndrVis GhcPs)
 
 #endif
 
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_ghc_lib_parser(9,4,0)
 
 instance SyntaxDefault a => SyntaxDefault (GenLocated TokenLocation a)
   where
@@ -236,7 +236,7 @@ instance SyntaxDefault a => SyntaxDefault (GenLocated TokenLocation a)
 
 #endif
 
-#if MIN_VERSION_ghc(9,4,0) && !MIN_VERSION_ghc(9,10,0)
+#if MIN_VERSION_ghc_lib_parser(9,4,0) && !MIN_VERSION_ghc_lib_parser(9,10,0)
 
 instance SyntaxDefault (SrcAnn a)
   where
@@ -258,14 +258,14 @@ instance SyntaxDefault IsUnicodeSyntax
 
 #endif
 
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
 
 pattern PfxCon :: [arg] -> HsConDetails Void arg r
 pattern PfxCon args = PrefixCon [] args
 
 #endif
 
-#if MIN_VERSION_ghc(9,2,0) && !MIN_VERSION_ghc(9,10,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0) && !MIN_VERSION_ghc_lib_parser(9,10,0)
 
 instance SyntaxDefault e => SyntaxDefault (GenLocated (SrcAnn a) e)
   where
@@ -285,7 +285,7 @@ instance SyntaxDefault AnnSortKey
 
 #endif
 
-#if !MIN_VERSION_ghc(9,2,0)
+#if !MIN_VERSION_ghc_lib_parser(9,2,0)
 
 instance SyntaxDefault e => SyntaxDefault (GenLocated SrcSpan e)
   where
@@ -327,7 +327,7 @@ noLocA = noLoc
 
 #endif
 
-#if !MIN_VERSION_ghc(9,4,0)
+#if !MIN_VERSION_ghc_lib_parser(9,4,0)
 
 dataConCantHappen :: NoExtCon -> a
 dataConCantHappen = noExtCon
@@ -422,7 +422,7 @@ apply f xs = mkHsApps f (map paren xs)
 
 appAt :: HsExp -> HsType -> HsExp
 appAt f t = noLocA (HsAppType synDef f
-#if MIN_VERSION_ghc(9,6,0) && !MIN_VERSION_ghc(9,10,0)
+#if MIN_VERSION_ghc_lib_parser(9,6,0) && !MIN_VERSION_ghc_lib_parser(9,10,0)
                                        synDef
 #endif
                                               (HsWC NoExtField (parenTy t)))
@@ -490,12 +490,12 @@ unbangedTy_ :: HsType -> HsBangType
 unbangedTy_ = noLocA . GHC.HsBangTy synDef (HsSrcBang synDef NoSrcUnpack NoSrcStrict) . parenTy
 
 module_ :: ModuleName -> Maybe [HsExportSpec] -> [HsImportDecl] -> [HsDecl] -> GHC.HsModule
-#if MIN_VERSION_ghc(9,6,0)
+#if MIN_VERSION_ghc_lib_parser(9,6,0)
                                                                                             GhcPs
 #endif
 module_ moduleName maybeExports imports decls = GHC.HsModule
   {
-#if MIN_VERSION_ghc(9,6,0)
+#if MIN_VERSION_ghc_lib_parser(9,6,0)
     hsmodExt = XModulePs
       { hsmodAnn = synDef
       , hsmodLayout = VirtualBraces 2
@@ -503,7 +503,7 @@ module_ moduleName maybeExports imports decls = GHC.HsModule
       , hsmodHaddockModHeader = Nothing
       }
 #else
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
     hsmodAnn = synDef,
 #endif
     hsmodLayout = VirtualBraces 2
@@ -512,7 +512,7 @@ module_ moduleName maybeExports imports decls = GHC.HsModule
   , hsmodExports = noLocA <$> maybeExports
   , hsmodImports = imports
   , hsmodDecls = decls
-#if !MIN_VERSION_ghc(9,6,0)
+#if !MIN_VERSION_ghc_lib_parser(9,6,0)
   , hsmodDeprecMessage = Nothing
   , hsmodHaddockModHeader = Nothing
 #endif
@@ -526,7 +526,7 @@ importDecl_ ::
   HsImportDecl
 importDecl_ moduleName qualified maybeAs details = noLocA ImportDecl
   {
-#if MIN_VERSION_ghc(9,6,0)
+#if MIN_VERSION_ghc_lib_parser(9,6,0)
     ideclExt = XImportDeclPass
       { ideclAnn = synDef
       , ideclSourceText = synDef
@@ -538,7 +538,7 @@ importDecl_ moduleName qualified maybeAs details = noLocA ImportDecl
 #endif
   , ideclName = noLocA moduleName
   , ideclPkgQual =
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_ghc_lib_parser(9,4,0)
       NoRawPkgQual
 #else
       Nothing
@@ -546,11 +546,11 @@ importDecl_ moduleName qualified maybeAs details = noLocA ImportDecl
   , ideclSource = NotBoot
   , ideclSafe = False
   , ideclQualified = if qualified then QualifiedPre else NotQualified
-#if !MIN_VERSION_ghc(9,6,0)
+#if !MIN_VERSION_ghc_lib_parser(9,6,0)
   , ideclImplicit = False
 #endif
   , ideclAs = noLocA <$> maybeAs
-#if MIN_VERSION_ghc(9,6,0)
+#if MIN_VERSION_ghc_lib_parser(9,6,0)
   , ideclImportList = (bool Exactly EverythingBut *** noLocA) <$> details
 #else
   , ideclHiding = fmap noLocA <$> details
@@ -560,28 +560,28 @@ importDecl_ moduleName qualified maybeAs details = noLocA ImportDecl
 ieName_ :: HsName -> HsImportSpec
 ieName_ =
   noLocA .
-#if MIN_VERSION_ghc(9,10,0)
+#if MIN_VERSION_ghc_lib_parser(9,10,0)
   flip (IEVar synDef) Nothing .
 #else
   IEVar synDef .
 #endif
   noLocA .
   IEName
-#if MIN_VERSION_ghc(9,6,0)
+#if MIN_VERSION_ghc_lib_parser(9,6,0)
          synDef
 #endif
 
 ieNameAll_ :: HsName -> HsImportSpec
 ieNameAll_ =
   noLocA .
-#if MIN_VERSION_ghc(9,10,0)
+#if MIN_VERSION_ghc_lib_parser(9,10,0)
   flip (IEThingAll synDef) Nothing .
 #else
   (IEThingAll synDef) .
 #endif
   noLocA .
   IEName
-#if MIN_VERSION_ghc(9,6,0)
+#if MIN_VERSION_ghc_lib_parser(9,6,0)
          synDef
 #endif
 
@@ -593,21 +593,21 @@ dataDecl_ messageName bndrs constructors derivedInstances = noLocA $ GHC.TyClD N
     , tcdFixity = Prefix
     , tcdDataDefn = HsDataDefn
         { dd_ext = NoExtField
-#if !MIN_VERSION_ghc(9,6,0)
+#if !MIN_VERSION_ghc_lib_parser(9,6,0)
         , dd_ND = maybe DataType (const NewType) newtypeCtor
 #endif
         , dd_ctxt = synDef
         , dd_cType = Nothing
         , dd_kindSig = Nothing
         , dd_cons =
-#if MIN_VERSION_ghc(9,6,0)
+#if MIN_VERSION_ghc_lib_parser(9,6,0)
             maybe (DataTypeCons False constructors) NewTypeCon newtypeCtor
 #else
             constructors
 #endif
 
         , dd_derivs =
-#if !MIN_VERSION_ghc(9,2,0)
+#if !MIN_VERSION_ghc_lib_parser(9,2,0)
             noLoc $
 #endif
               maybeToList $ derivingClause_ Nothing $ derivedInstances <&> \className ->
@@ -618,7 +618,7 @@ dataDecl_ messageName bndrs constructors derivedInstances = noLocA $ GHC.TyClD N
     -- TO DO: Support GADT syntax, assuming we ever start to use it in generated code.
     newtypeCtor = case constructors of
       [ con@( L _ ( ConDeclH98 { con_forall =
-#if !MIN_VERSION_ghc(9,2,0)
+#if !MIN_VERSION_ghc_lib_parser(9,2,0)
                                               L _
 #endif
                                                   False
@@ -636,7 +636,7 @@ recDecl_ name fields = noLocA ConDeclH98
   { con_ext = synDef
   , con_name = name
   , con_forall =
-#if !MIN_VERSION_ghc(9,2,0)
+#if !MIN_VERSION_ghc_lib_parser(9,2,0)
                  noLoc
 #endif
                        False
@@ -645,9 +645,9 @@ recDecl_ name fields = noLocA ConDeclH98
   , con_args = RecCon $ noLocA $ fields <&> \(names, bangTy) -> noLocA ConDeclField
       { cd_fld_ext = synDef
       , cd_fld_names =
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_ghc_lib_parser(9,4,0)
           noLocA
-#elif MIN_VERSION_ghc(9,2,0)
+#elif MIN_VERSION_ghc_lib_parser(9,2,0)
           noLoc
 #else
           noLocA
@@ -664,7 +664,7 @@ conDecl_ name fields = noLocA ConDeclH98
   { con_ext = synDef
   , con_name = name
   , con_forall =
-#if !MIN_VERSION_ghc(9,2,0)
+#if !MIN_VERSION_ghc_lib_parser(9,2,0)
                  noLoc
 #endif
                        False
@@ -720,7 +720,7 @@ instDecl_ className classArgs binds = noLocA $ GHC.InstD NoExtField ClsInstD
   , cid_inst = ClsInstDecl
       { cid_ext = synDef
       , cid_poly_ty =
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
           noLocA $
 #endif
             HsSig NoExtField implicitOuterSigTyVarBinders_ (tyConApply className classArgs)
@@ -736,7 +736,7 @@ typeOfInstDecl :: HsDecl -> Maybe (HsOuterSigTyVarBndrs, HsType)
 typeOfInstDecl ( L _ ( GHC.InstD _ ClsInstD
                        { cid_inst = ClsInstDecl
                          { cid_poly_ty =
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
                              L _
 #endif
                                  (HsSig _ binders classType)
@@ -755,14 +755,14 @@ closedTyFamDecl_ tyFamName famBndrs resultKind eqns =
   noLocA $ GHC.TyClD NoExtField $ FamDecl synDef $ FamilyDecl
     { fdExt = synDef
     , fdInfo = ClosedTypeFamily (Just (map onEqn eqns))
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
     , fdTopLevel = TopLevel
 #endif
     , fdLName = tyFamName
     , fdTyVars = HsQTvs synDef famBndrs
     , fdFixity = Prefix
     , fdResultSig =
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_ghc_lib_parser(9,4,0)
         noLocA $
 #else
         noLoc $
@@ -772,21 +772,21 @@ closedTyFamDecl_ tyFamName famBndrs resultKind eqns =
     }
   where
     onEqn (eqnBndrs, pats, rhs) = noLocA $
-#if !MIN_VERSION_ghc(9,2,0)
+#if !MIN_VERSION_ghc_lib_parser(9,2,0)
       HsIB synDef
 #endif
         FamEqn
           { feqn_ext = synDef
           , feqn_tycon = tyFamName
           , feqn_bndrs =
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
               maybe (HsOuterImplicit NoExtField) (HsOuterExplicit synDef) eqnBndrs
 #else
               eqnBndrs
 #endif
           , feqn_pats = map
               (HsValArg
-#if MIN_VERSION_ghc(9,10,0)
+#if MIN_VERSION_ghc_lib_parser(9,10,0)
                         synDef
 #endif
               ) pats
@@ -799,25 +799,25 @@ tyFamInstDecl_ tyFamName bndrs pats rhs = noLocA $ GHC.InstD NoExtField TyFamIns
   { tfid_ext = NoExtField
   , tfid_inst = TyFamInstDecl
       {
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
         tfid_xtn = synDef,
 #endif
         tfid_eqn =
-#if !MIN_VERSION_ghc(9,2,0)
+#if !MIN_VERSION_ghc_lib_parser(9,2,0)
           HsIB synDef
 #endif
                       FamEqn
             { feqn_ext = synDef
             , feqn_tycon = tyFamName
             , feqn_bndrs =
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
                 maybe (HsOuterImplicit NoExtField) (HsOuterExplicit synDef) bndrs
 #else
                 bndrs
 #endif
             , feqn_pats = map
                 (HsValArg
-#if MIN_VERSION_ghc(9,10,0)
+#if MIN_VERSION_ghc_lib_parser(9,10,0)
                           synDef
 #endif
                 ) pats
@@ -844,16 +844,16 @@ patBind_ (L _ (LazyPat _ (L _ (VarPat _ nm)))) rhs =
 patBind_ pat rhs = noLocA PatBind
   { pat_ext = synDef
   , pat_lhs = pat
-#if MIN_VERSION_ghc(9,10,0)
+#if MIN_VERSION_ghc_lib_parser(9,10,0)
   , pat_mult = HsNoMultAnn synDef
 #endif
   , pat_rhs =
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
       unguardedGRHSs synDef rhs synDef
 #else
       unguardedGRHSs rhs
 #endif
-#if !MIN_VERSION_ghc(9,6,0)
+#if !MIN_VERSION_ghc_lib_parser(9,6,0)
   , pat_ticks = synDef
 #endif
   }
@@ -871,10 +871,10 @@ functionLike_ strictness name alts = noLocA $ mkFunBind generated name (map matc
   where
     generated :: Origin
     generated = Generated
-#if MIN_VERSION_ghc(9,10,0)
+#if MIN_VERSION_ghc_lib_parser(9,10,0)
                           OtherExpansion
 #endif
-#if MIN_VERSION_ghc(9,8,0)
+#if MIN_VERSION_ghc_lib_parser(9,8,0)
                                          DoPmc
 #endif
 
@@ -890,14 +890,14 @@ functionLike_ strictness name alts = noLocA $ mkFunBind generated name (map matc
 typeSig_ :: [HsName] -> HsOuterSigTyVarBndrs -> HsType -> HsDecl
 typeSig_ nms bndrs ty = noLocA $ GHC.SigD NoExtField $ TypeSig synDef nms $
   HsWC NoExtField $
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
     noLocA $
 #endif
       HsSig NoExtField bndrs ty
 
 implicitOuterFamEqnTyVarBinders_ :: HsOuterFamEqnTyVarBndrs
 implicitOuterFamEqnTyVarBinders_ =
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
   HsOuterImplicit NoExtField
 #else
   ()
@@ -905,7 +905,7 @@ implicitOuterFamEqnTyVarBinders_ =
 
 implicitOuterSigTyVarBinders_ :: HsOuterSigTyVarBndrs
 implicitOuterSigTyVarBinders_ =
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
   HsOuterImplicit NoExtField
 #else
   ()
@@ -934,14 +934,14 @@ var_ = noLocA . HsVar NoExtField
 
 fieldBind_ :: HsName -> HsExp -> LHsRecField GhcPs HsExp
 fieldBind_ nm val = noLocA
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_ghc_lib_parser(9,4,0)
   HsFieldBind
     { hfbAnn = synDef
     , hfbLHS = noLocA $ FieldOcc NoExtField nm
     , hfbRHS = val
     , hfbPun = False
     }
-#elif MIN_VERSION_ghc(9,2,0)
+#elif MIN_VERSION_ghc_lib_parser(9,2,0)
   HsRecField
     { hsRecFieldAnn = synDef
     , hsRecFieldLbl = noLoc $ FieldOcc NoExtField nm
@@ -959,7 +959,7 @@ fieldBind_ nm val = noLocA
 recordCtor_ :: HsName -> [LHsRecField GhcPs HsExp] -> HsExp
 recordCtor_ nm fields = noLocA RecordCon
   { rcon_ext = synDef
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
   , rcon_con = nm
 #else
   , rcon_con_name = nm
@@ -971,18 +971,18 @@ recordCtor_ nm fields = noLocA RecordCon
   }
 
 fieldUpd_ :: HsName -> HsExp -> LHsRecUpdField GhcPs
-#if MIN_VERSION_ghc(9,8,0)
+#if MIN_VERSION_ghc_lib_parser(9,8,0)
                                                      GhcPs
 #endif
 fieldUpd_ nm val = noLocA
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_ghc_lib_parser(9,4,0)
   HsFieldBind
     { hfbAnn = synDef
     , hfbLHS = noLocA $ Ambiguous NoExtField nm
     , hfbRHS = val
     , hfbPun = False
     }
-#elif MIN_VERSION_ghc(9,2,0)
+#elif MIN_VERSION_ghc_lib_parser(9,2,0)
   HsRecField
     { hsRecFieldAnn = synDef
     , hsRecFieldLbl = noLoc $ Ambiguous NoExtField nm
@@ -998,7 +998,7 @@ fieldUpd_ nm val = noLocA
 #endif
 
 recordUpd_ :: HsExp -> [ LHsRecUpdField GhcPs
-#if MIN_VERSION_ghc(9,8,0)
+#if MIN_VERSION_ghc_lib_parser(9,8,0)
                                               GhcPs
 #endif
                        ] -> HsExp
@@ -1006,9 +1006,9 @@ recordUpd_ r fields = noLocA RecordUpd
   { rupd_ext = synDef
   , rupd_expr = r
   , rupd_flds =
-#if MIN_VERSION_ghc(9,8,0)
+#if MIN_VERSION_ghc_lib_parser(9,8,0)
       RegularRecUpdFields synDef
-#elif MIN_VERSION_ghc(9,2,0)
+#elif MIN_VERSION_ghc_lib_parser(9,2,0)
       Left
 #endif
         fields
@@ -1061,14 +1061,14 @@ recPat ctor fields = noLocA $ ConPat synDef ctor $ RecCon $ HsRecFields
 
 fieldPunPat :: HsName -> LHsRecField GhcPs HsPat
 fieldPunPat nm = noLocA
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_ghc_lib_parser(9,4,0)
   HsFieldBind
     { hfbAnn = synDef
     , hfbLHS = noLocA $ FieldOcc NoExtField nm
     , hfbRHS = noLocA $ VarPat NoExtField nm
     , hfbPun = True
     }
-#elif MIN_VERSION_ghc(9,2,0)
+#elif MIN_VERSION_ghc_lib_parser(9,2,0)
   HsRecField
     { hsRecFieldAnn = synDef
     , hsRecFieldLbl = noLoc $ FieldOcc NoExtField nm
@@ -1088,27 +1088,27 @@ alt_ = mkHsCaseAlt
 
 case_ :: HsExp -> [HsAlt] -> HsExp
 case_ e = noLocA . HsCase synDef e . mkMatchGroup generated
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
                                                             . noLocA
 #endif
   where
     generated :: Origin
     generated = Generated
-#if MIN_VERSION_ghc(9,10,0)
+#if MIN_VERSION_ghc_lib_parser(9,10,0)
                           OtherExpansion
 #endif
-#if MIN_VERSION_ghc(9,8,0)
+#if MIN_VERSION_ghc_lib_parser(9,8,0)
                                          DoPmc
 #endif
 
 -- | Simple let expression for ordinary bindings.
 let_ :: [HsBind] -> HsExp -> HsExp
 let_ locals e =
-#if MIN_VERSION_ghc(9,10,0)
+#if MIN_VERSION_ghc_lib_parser(9,10,0)
     noLocA $ HsLet synDef binds e
-#elif MIN_VERSION_ghc(9,4,0)
+#elif MIN_VERSION_ghc_lib_parser(9,4,0)
     noLocA $ HsLet synDef synDef binds synDef e
-#elif MIN_VERSION_ghc(9,2,0)
+#elif MIN_VERSION_ghc_lib_parser(9,2,0)
     noLocA $ HsLet synDef binds e
 #else
     noLocA $ HsLet synDef (noLocA binds) e
@@ -1122,14 +1122,14 @@ lambda_ = mkHsLam
 
 if_ :: HsExp -> HsExp -> HsExp -> HsExp
 if_ c t f = noLocA $ mkHsIf c t f
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
                                   synDef
 #endif
 
 -- | A boxed tuple with all components present.
 tuple_ :: [HsExp] -> HsExp
 tuple_ xs = mkLHsTupleExpr xs
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
                               synDef
 #endif
 
@@ -1271,7 +1271,7 @@ floatE x
         overlit = mkHsFractional $ FL
           { fl_text = NoSourceText
           , fl_neg = y < 0
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
           , fl_signi = _s % 1
           , fl_exp = toInteger _e
           , fl_exp_base = case floatRadix y of
@@ -1285,13 +1285,13 @@ floatE x
 
 do_ :: [ExprLStmt GhcPs] -> HsExp
 do_ = noLocA . mkHsDo (DoExpr Nothing)
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
                                        . noLocA
 #endif
 
 letStmt_ :: [HsBind] -> ExprLStmt GhcPs
 letStmt_ locals = noLocA $ LetStmt synDef
-#if !MIN_VERSION_ghc(9,2,0)
+#if !MIN_VERSION_ghc_lib_parser(9,2,0)
                     $ noLocA
 #endif
                       binds
@@ -1300,7 +1300,7 @@ letStmt_ locals = noLocA $ LetStmt synDef
 
 bindStmt_ :: HsPat -> HsExp -> ExprLStmt GhcPs
 bindStmt_ p e = noLocA $ mkPsBindStmt
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
                                       synDef
 #endif
                                              p e

--- a/src/Proto3/Suite/DotProto/Generate/Syntax.hs
+++ b/src/Proto3/Suite/DotProto/Generate/Syntax.hs
@@ -425,32 +425,37 @@ unrestrictedArrow_ = HsUnrestrictedArrow synDef
 unbangedTy_ :: HsType -> HsBangType
 unbangedTy_ = noLocA . GHC.HsBangTy synDef (HsSrcBang synDef NoSrcUnpack NoSrcStrict) . parenTy
 
-module_ :: ModuleName -> Maybe [HsExportSpec] -> [HsImportDecl] -> [HsDecl] -> GHC.HsModule
 #if MIN_VERSION_ghc_lib_parser(9,6,0)
-                                                                                            GhcPs
-#endif
-module_ moduleName maybeExports imports decls = GHC.HsModule
-  {
-#if MIN_VERSION_ghc_lib_parser(9,6,0)
-    hsmodExt = XModulePs
-      { hsmodAnn = synDef
-      , hsmodLayout = VirtualBraces 2
-      , hsmodDeprecMessage = Nothing
-      , hsmodHaddockModHeader = Nothing
-      }
-#else
-  , hsmodAnn = synDef
-  , hsmodLayout = VirtualBraces 2
-#endif
+-- https://hackage.haskell.org/package/ghc-lib-parser-9.6.2.20231121/docs/GHC-Hs.html#t:HsModule
+module_ :: ModuleName -> Maybe [HsExportSpec] -> [HsImportDecl] -> [HsDecl] -> GHC.HsModule GhcPs
+module_ moduleName maybeExports imports decls =
+  GHC.HsModule
+  { hsmodExt = XModulePs
+    { hsmodAnn = synDef
+    , hsmodLayout = VirtualBraces 2
+    , hsmodDeprecMessage = Nothing
+    , hsmodHaddockModHeader = Nothing
+    }
   , hsmodName = Just $ noLocA moduleName
   , hsmodExports = noLocA <$> maybeExports
   , hsmodImports = imports
   , hsmodDecls = decls
-#if !MIN_VERSION_ghc_lib_parser(9,6,0)
+  }
+#else
+-- https://hackage.haskell.org/package/ghc-lib-parser-9.2.2.20220307/docs/GHC-Hs.html#t:HsModule
+module_ :: ModuleName -> Maybe [HsExportSpec] -> [HsImportDecl] -> [HsDecl] -> GHC.HsModule
+module_ moduleName maybeExports imports decls =
+  GHC.HsModule
+  { hsmodAnn = synDef
+  , hsmodLayout = VirtualBraces 2
+  , hsmodName = Just $ noLocA moduleName
+  , hsmodExports = noLocA <$> maybeExports
+  , hsmodImports = imports
+  , hsmodDecls = decls
   , hsmodDeprecMessage = Nothing
   , hsmodHaddockModHeader = Nothing
-#endif
   }
+#endif
 
 importDecl_ ::
   ModuleName ->

--- a/src/Proto3/Suite/DotProto/Generate/Syntax.hs
+++ b/src/Proto3/Suite/DotProto/Generate/Syntax.hs
@@ -64,7 +64,7 @@ import GHC.Types.SourceText
 import GHC.Types.SrcLoc (LayoutInfo(..))
 import GHC.Unit (IsBootInterface(..))
 import GHC.Unit.Module (ModuleName, mkModuleName)
-#elif MIN_VERSION_ghc_lib_parser(9,2,0)
+#else
 import Data.Ratio ((%))
 import Data.Void (Void)
 import GHC.Hs hiding (HsBind, HsDecl, HsDerivingClause, HsOuterFamEqnTyVarBndrs,
@@ -75,14 +75,6 @@ import GHC.Types.Fixity (LexicalFixity(..))
 import GHC.Types.SourceText
          (IntegralLit(..), FractionalExponentBase(..), FractionalLit(..), SourceText(..))
 import GHC.Types.SrcLoc (LayoutInfo(..), noLoc)
-import GHC.Unit (IsBootInterface(..))
-import GHC.Unit.Module (ModuleName, mkModuleName)
-#else
-import GHC.Hs hiding (HsBind, HsDecl, HsDerivingClause, HsTyVarBndr, HsType)
-import GHC.Parser.Annotation (IsUnicodeSyntax(..))
-import GHC.Types.Basic
-         (IntegralLit(..), FractionalLit(..), LexicalFixity(..), PromotionFlag(..), SourceText(..))
-import GHC.Types.SrcLoc (LayoutInfo(..), Located, noLoc)
 import GHC.Unit (IsBootInterface(..))
 import GHC.Unit.Module (ModuleName, mkModuleName)
 #endif
@@ -106,18 +98,8 @@ type HsImportDecl = LImportDecl GhcPs
 type HsImportSpec = LIE GhcPs
 type HsMatch = LMatch GhcPs HsExp
 type HsName = LIdP GhcPs
-type HsOuterFamEqnTyVarBndrs =
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-  GHC.HsOuterFamEqnTyVarBndrs GhcPs
-#else
-  ()
-#endif
-type HsOuterSigTyVarBndrs =
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-  GHC.HsOuterSigTyVarBndrs GhcPs
-#else
-  ()
-#endif
+type HsOuterFamEqnTyVarBndrs = GHC.HsOuterFamEqnTyVarBndrs GhcPs
+type HsOuterSigTyVarBndrs = GHC.HsOuterSigTyVarBndrs GhcPs
 type HsPat = LPat GhcPs
 type HsQName = LIdP GhcPs
 type HsQOp = LHsExpr GhcPs
@@ -258,14 +240,10 @@ instance SyntaxDefault IsUnicodeSyntax
 
 #endif
 
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-
 pattern PfxCon :: [arg] -> HsConDetails Void arg r
 pattern PfxCon args = PrefixCon [] args
 
-#endif
-
-#if MIN_VERSION_ghc_lib_parser(9,2,0) && !MIN_VERSION_ghc_lib_parser(9,10,0)
+#if !MIN_VERSION_ghc_lib_parser(9,10,0)
 
 instance SyntaxDefault e => SyntaxDefault (GenLocated (SrcAnn a) e)
   where
@@ -282,48 +260,6 @@ instance SyntaxDefault EpAnnComments
 instance SyntaxDefault AnnSortKey
   where
     synDef = NoAnnSortKey
-
-#endif
-
-#if !MIN_VERSION_ghc_lib_parser(9,2,0)
-
-instance SyntaxDefault e => SyntaxDefault (GenLocated SrcSpan e)
-  where
-    synDef = noLocA synDef
-
-pattern PfxCon :: [arg] -> HsConDetails arg r
-pattern PfxCon args = PrefixCon args
-
-pattern HsSig :: NoExtField -> () -> HsType -> HsImplicitBndrs GhcPs HsType
-pattern HsSig ext bndrs ty <- (((), ) -> (bndrs, HsIB ext ty))
-  where
-    HsSig ext () ty = HsIB ext ty
-
-pattern XHsSigType :: NoExtCon -> HsImplicitBndrs GhcPs HsType
-pattern XHsSigType impossible = XHsImplicitBndrs impossible
-
-{-# COMPLETE HsSig, XHsSigType #-}
-
-pattern DctSingle ::
-  NoExtField ->
-  GenLocated SrcSpan (HsImplicitBndrs GhcPs HsType) ->
-  [HsImplicitBndrs GhcPs HsType]
-pattern DctSingle ext sig <- ((NoExtField, ) -> (ext, [noLoc -> sig]))
-  where
-    DctSingle NoExtField (L _ sig) = [sig]
-
-pattern DctMulti ::
-  NoExtField ->
-  [GenLocated SrcSpan (HsImplicitBndrs GhcPs HsType)] ->
-  [HsImplicitBndrs GhcPs HsType]
-pattern DctMulti ext sigs <- ((NoExtField, ) -> (ext, map noLoc -> sigs))
-  where
-    DctMulti NoExtField sigs = sigs <&> (\(L _ sig) -> sig)
-
-{-# COMPLETE DctSingle, DctMulti #-}
-
-noLocA :: a -> Located a
-noLocA = noLoc
 
 #endif
 
@@ -503,10 +439,8 @@ module_ moduleName maybeExports imports decls = GHC.HsModule
       , hsmodHaddockModHeader = Nothing
       }
 #else
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-    hsmodAnn = synDef,
-#endif
-    hsmodLayout = VirtualBraces 2
+  , hsmodAnn = synDef
+  , hsmodLayout = VirtualBraces 2
 #endif
   , hsmodName = Just $ noLocA moduleName
   , hsmodExports = noLocA <$> maybeExports
@@ -607,9 +541,6 @@ dataDecl_ messageName bndrs constructors derivedInstances = noLocA $ GHC.TyClD N
 #endif
 
         , dd_derivs =
-#if !MIN_VERSION_ghc_lib_parser(9,2,0)
-            noLoc $
-#endif
               maybeToList $ derivingClause_ Nothing $ derivedInstances <&> \className ->
                 (implicitOuterSigTyVarBinders_, typeNamed_ className)
         }
@@ -617,11 +548,7 @@ dataDecl_ messageName bndrs constructors derivedInstances = noLocA $ GHC.TyClD N
   where
     -- TO DO: Support GADT syntax, assuming we ever start to use it in generated code.
     newtypeCtor = case constructors of
-      [ con@( L _ ( ConDeclH98 { con_forall =
-#if !MIN_VERSION_ghc_lib_parser(9,2,0)
-                                              L _
-#endif
-                                                  False
+      [ con@( L _ ( ConDeclH98 { con_forall = False
                                , con_ex_tvs = []
                                , con_mb_cxt = Nothing
                                , con_args = args
@@ -635,11 +562,7 @@ recDecl_ :: HsName -> [([HsName], HsBangType)] -> HsConDecl
 recDecl_ name fields = noLocA ConDeclH98
   { con_ext = synDef
   , con_name = name
-  , con_forall =
-#if !MIN_VERSION_ghc_lib_parser(9,2,0)
-                 noLoc
-#endif
-                       False
+  , con_forall = False
   , con_ex_tvs = []
   , con_mb_cxt = Nothing
   , con_args = RecCon $ noLocA $ fields <&> \(names, bangTy) -> noLocA ConDeclField
@@ -647,10 +570,8 @@ recDecl_ name fields = noLocA ConDeclH98
       , cd_fld_names =
 #if MIN_VERSION_ghc_lib_parser(9,4,0)
           noLocA
-#elif MIN_VERSION_ghc_lib_parser(9,2,0)
-          noLoc
 #else
-          noLocA
+          noLoc
 #endif
           . FieldOcc NoExtField <$> names
       , cd_fld_type = bangTy
@@ -663,11 +584,7 @@ conDecl_ :: HsName -> [HsBangType] -> HsConDecl
 conDecl_ name fields = noLocA ConDeclH98
   { con_ext = synDef
   , con_name = name
-  , con_forall =
-#if !MIN_VERSION_ghc_lib_parser(9,2,0)
-                 noLoc
-#endif
-                       False
+  , con_forall = False
   , con_ex_tvs = []
   , con_mb_cxt = Nothing
   , con_args = PfxCon (HsScaled unrestrictedArrow_ <$> fields)
@@ -719,11 +636,7 @@ instDecl_ className classArgs binds = noLocA $ GHC.InstD NoExtField ClsInstD
   { cid_d_ext = NoExtField
   , cid_inst = ClsInstDecl
       { cid_ext = synDef
-      , cid_poly_ty =
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-          noLocA $
-#endif
-            HsSig NoExtField implicitOuterSigTyVarBinders_ (tyConApply className classArgs)
+      , cid_poly_ty = noLocA $ HsSig NoExtField implicitOuterSigTyVarBinders_ (tyConApply className classArgs)
       , cid_binds = listToBag binds
       , cid_sigs = []
       , cid_tyfam_insts = []
@@ -735,11 +648,7 @@ instDecl_ className classArgs binds = noLocA $ GHC.InstD NoExtField ClsInstD
 typeOfInstDecl :: HsDecl -> Maybe (HsOuterSigTyVarBndrs, HsType)
 typeOfInstDecl ( L _ ( GHC.InstD _ ClsInstD
                        { cid_inst = ClsInstDecl
-                         { cid_poly_ty =
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-                             L _
-#endif
-                                 (HsSig _ binders classType)
+                         { cid_poly_ty = L _ (HsSig _ binders classType)
                          } } ) ) =
   Just (binders, classType)
 typeOfInstDecl _ =
@@ -755,9 +664,7 @@ closedTyFamDecl_ tyFamName famBndrs resultKind eqns =
   noLocA $ GHC.TyClD NoExtField $ FamDecl synDef $ FamilyDecl
     { fdExt = synDef
     , fdInfo = ClosedTypeFamily (Just (map onEqn eqns))
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
     , fdTopLevel = TopLevel
-#endif
     , fdLName = tyFamName
     , fdTyVars = HsQTvs synDef famBndrs
     , fdFixity = Prefix
@@ -772,18 +679,10 @@ closedTyFamDecl_ tyFamName famBndrs resultKind eqns =
     }
   where
     onEqn (eqnBndrs, pats, rhs) = noLocA $
-#if !MIN_VERSION_ghc_lib_parser(9,2,0)
-      HsIB synDef
-#endif
         FamEqn
           { feqn_ext = synDef
           , feqn_tycon = tyFamName
-          , feqn_bndrs =
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-              maybe (HsOuterImplicit NoExtField) (HsOuterExplicit synDef) eqnBndrs
-#else
-              eqnBndrs
-#endif
+          , feqn_bndrs = maybe (HsOuterImplicit NoExtField) (HsOuterExplicit synDef) eqnBndrs
           , feqn_pats = map
               (HsValArg
 #if MIN_VERSION_ghc_lib_parser(9,10,0)
@@ -798,23 +697,11 @@ tyFamInstDecl_ :: HsQName -> Maybe [HsTyVarBndrU] -> [HsType] -> HsType -> HsDec
 tyFamInstDecl_ tyFamName bndrs pats rhs = noLocA $ GHC.InstD NoExtField TyFamInstD
   { tfid_ext = NoExtField
   , tfid_inst = TyFamInstDecl
-      {
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-        tfid_xtn = synDef,
-#endif
-        tfid_eqn =
-#if !MIN_VERSION_ghc_lib_parser(9,2,0)
-          HsIB synDef
-#endif
-                      FamEqn
+      { tfid_xtn = synDef
+      , tfid_eqn = FamEqn
             { feqn_ext = synDef
             , feqn_tycon = tyFamName
-            , feqn_bndrs =
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-                maybe (HsOuterImplicit NoExtField) (HsOuterExplicit synDef) bndrs
-#else
-                bndrs
-#endif
+            , feqn_bndrs = maybe (HsOuterImplicit NoExtField) (HsOuterExplicit synDef) bndrs
             , feqn_pats = map
                 (HsValArg
 #if MIN_VERSION_ghc_lib_parser(9,10,0)
@@ -847,12 +734,7 @@ patBind_ pat rhs = noLocA PatBind
 #if MIN_VERSION_ghc_lib_parser(9,10,0)
   , pat_mult = HsNoMultAnn synDef
 #endif
-  , pat_rhs =
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-      unguardedGRHSs synDef rhs synDef
-#else
-      unguardedGRHSs rhs
-#endif
+  , pat_rhs = unguardedGRHSs synDef rhs synDef
 #if !MIN_VERSION_ghc_lib_parser(9,6,0)
   , pat_ticks = synDef
 #endif
@@ -890,26 +772,14 @@ functionLike_ strictness name alts = noLocA $ mkFunBind generated name (map matc
 typeSig_ :: [HsName] -> HsOuterSigTyVarBndrs -> HsType -> HsDecl
 typeSig_ nms bndrs ty = noLocA $ GHC.SigD NoExtField $ TypeSig synDef nms $
   HsWC NoExtField $
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-    noLocA $
-#endif
-      HsSig NoExtField bndrs ty
+  noLocA $
+  HsSig NoExtField bndrs ty
 
 implicitOuterFamEqnTyVarBinders_ :: HsOuterFamEqnTyVarBndrs
-implicitOuterFamEqnTyVarBinders_ =
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-  HsOuterImplicit NoExtField
-#else
-  ()
-#endif
+implicitOuterFamEqnTyVarBinders_ = HsOuterImplicit NoExtField
 
 implicitOuterSigTyVarBinders_ :: HsOuterSigTyVarBndrs
-implicitOuterSigTyVarBinders_ =
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-  HsOuterImplicit NoExtField
-#else
-  ()
-#endif
+implicitOuterSigTyVarBinders_ = HsOuterImplicit NoExtField
 
 userTyVar_ :: flag -> HsName -> LHsTyVarBndr flag GhcPs
 userTyVar_ flag nm = noLocA $ GHC.UserTyVar synDef flag nm
@@ -941,16 +811,10 @@ fieldBind_ nm val = noLocA
     , hfbRHS = val
     , hfbPun = False
     }
-#elif MIN_VERSION_ghc_lib_parser(9,2,0)
+#else
   HsRecField
     { hsRecFieldAnn = synDef
     , hsRecFieldLbl = noLoc $ FieldOcc NoExtField nm
-    , hsRecFieldArg = val
-    , hsRecPun = False
-    }
-#else
-  HsRecField
-    { hsRecFieldLbl = noLocA $ FieldOcc NoExtField nm
     , hsRecFieldArg = val
     , hsRecPun = False
     }
@@ -959,11 +823,7 @@ fieldBind_ nm val = noLocA
 recordCtor_ :: HsName -> [LHsRecField GhcPs HsExp] -> HsExp
 recordCtor_ nm fields = noLocA RecordCon
   { rcon_ext = synDef
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
   , rcon_con = nm
-#else
-  , rcon_con_name = nm
-#endif
   , rcon_flds = HsRecFields
       { rec_flds = fields
       , rec_dotdot = Nothing
@@ -982,16 +842,10 @@ fieldUpd_ nm val = noLocA
     , hfbRHS = val
     , hfbPun = False
     }
-#elif MIN_VERSION_ghc_lib_parser(9,2,0)
+#else
   HsRecField
     { hsRecFieldAnn = synDef
     , hsRecFieldLbl = noLoc $ Ambiguous NoExtField nm
-    , hsRecFieldArg = val
-    , hsRecPun = False
-    }
-#else
-  HsRecField
-    { hsRecFieldLbl = noLoc $ Ambiguous NoExtField nm
     , hsRecFieldArg = val
     , hsRecPun = False
     }
@@ -1008,7 +862,7 @@ recordUpd_ r fields = noLocA RecordUpd
   , rupd_flds =
 #if MIN_VERSION_ghc_lib_parser(9,8,0)
       RegularRecUpdFields synDef
-#elif MIN_VERSION_ghc_lib_parser(9,2,0)
+#else
       Left
 #endif
         fields
@@ -1068,16 +922,10 @@ fieldPunPat nm = noLocA
     , hfbRHS = noLocA $ VarPat NoExtField nm
     , hfbPun = True
     }
-#elif MIN_VERSION_ghc_lib_parser(9,2,0)
+#else
   HsRecField
     { hsRecFieldAnn = synDef
     , hsRecFieldLbl = noLoc $ FieldOcc NoExtField nm
-    , hsRecFieldArg = noLocA $ VarPat NoExtField nm
-    , hsRecPun = True
-    }
-#else
-  HsRecField
-    { hsRecFieldLbl = noLoc $ FieldOcc NoExtField nm
     , hsRecFieldArg = noLocA $ VarPat NoExtField nm
     , hsRecPun = True
     }
@@ -1087,10 +935,7 @@ alt_ :: HsPat -> HsExp -> HsAlt
 alt_ = mkHsCaseAlt
 
 case_ :: HsExp -> [HsAlt] -> HsExp
-case_ e = noLocA . HsCase synDef e . mkMatchGroup generated
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-                                                            . noLocA
-#endif
+case_ e = noLocA . HsCase synDef e . mkMatchGroup generated . noLocA
   where
     generated :: Origin
     generated = Generated
@@ -1108,10 +953,8 @@ let_ locals e =
     noLocA $ HsLet synDef binds e
 #elif MIN_VERSION_ghc_lib_parser(9,4,0)
     noLocA $ HsLet synDef synDef binds synDef e
-#elif MIN_VERSION_ghc_lib_parser(9,2,0)
-    noLocA $ HsLet synDef binds e
 #else
-    noLocA $ HsLet synDef (noLocA binds) e
+    noLocA $ HsLet synDef binds e
 #endif
   where
     binds = HsValBinds synDef (ValBinds synDef (listToBag locals) [])
@@ -1121,17 +964,11 @@ lambda_ :: [HsPat] -> HsExp -> HsExp
 lambda_ = mkHsLam
 
 if_ :: HsExp -> HsExp -> HsExp -> HsExp
-if_ c t f = noLocA $ mkHsIf c t f
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-                                  synDef
-#endif
+if_ c t f = noLocA $ mkHsIf c t f synDef
 
 -- | A boxed tuple with all components present.
 tuple_ :: [HsExp] -> HsExp
-tuple_ xs = mkLHsTupleExpr xs
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-                              synDef
-#endif
+tuple_ xs = mkLHsTupleExpr xs synDef
 
 -- | A promoted boxed tuple value with all components present.
 tupleT_ :: [HsType] -> HsType
@@ -1271,39 +1108,24 @@ floatE x
         overlit = mkHsFractional $ FL
           { fl_text = NoSourceText
           , fl_neg = y < 0
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
           , fl_signi = _s % 1
           , fl_exp = toInteger _e
           , fl_exp_base = case floatRadix y of
               2 -> Base2
               10 -> Base10
               b -> error $ "doubleE: unsupported floatRadix " ++ show b
-#else
-          , fl_value = toRational (abs y)
-#endif
           }
 
 do_ :: [ExprLStmt GhcPs] -> HsExp
-do_ = noLocA . mkHsDo (DoExpr Nothing)
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-                                       . noLocA
-#endif
+do_ = noLocA . mkHsDo (DoExpr Nothing) . noLocA
 
 letStmt_ :: [HsBind] -> ExprLStmt GhcPs
-letStmt_ locals = noLocA $ LetStmt synDef
-#if !MIN_VERSION_ghc_lib_parser(9,2,0)
-                    $ noLocA
-#endif
-                      binds
+letStmt_ locals = noLocA $ LetStmt synDef binds
   where
     binds = HsValBinds synDef (ValBinds synDef (listToBag locals) [])
 
 bindStmt_ :: HsPat -> HsExp -> ExprLStmt GhcPs
-bindStmt_ p e = noLocA $ mkPsBindStmt
-#if MIN_VERSION_ghc_lib_parser(9,2,0)
-                                      synDef
-#endif
-                                             p e
+bindStmt_ p e = noLocA $ mkPsBindStmt synDef p e
 
 lastStmt_ :: HsExp -> ExprLStmt GhcPs
 lastStmt_ = noLocA . mkLastStmt

--- a/src/Proto3/Suite/Form/Encode/Core.hs
+++ b/src/Proto3/Suite/Form/Encode/Core.hs
@@ -354,7 +354,7 @@ class Field name a message
     field :: forall names . a -> Prefix message names (Occupy message name names)
 
 instance forall (name :: Symbol)
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_ghc_lib_parser(9,4,0)
                 r (a :: TYPE r)
 #else
                 (a :: Type)

--- a/src/Proto3/Suite/Form/Encode/Core.hs
+++ b/src/Proto3/Suite/Form/Encode/Core.hs
@@ -355,7 +355,7 @@ class Field name a message
     field :: forall names . a -> Prefix message names (Occupy message name names)
 
 instance forall (name :: Symbol)
-#if MIN_VERSION_ghc_lib_parser(9,4,0)
+#if defined(__GLASGOW_HASKELL__) && 904 <= __GLASGOW_HASKELL__
                 r (a :: TYPE r)
 #else
                 (a :: Type)

--- a/src/Proto3/Suite/Form/Encode/Core.hs
+++ b/src/Proto3/Suite/Form/Encode/Core.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RoleAnnotations #-}
@@ -65,7 +66,7 @@ import Data.Traversable (for)
 import GHC.Exts (Constraint, Proxy#, TYPE, proxy#)
 import GHC.Generics (Generic)
 import GHC.TypeLits (ErrorMessage(..), KnownNat, Nat, Symbol, TypeError, natVal')
-import Language.Haskell.TH qualified as TH
+import "template-haskell" Language.Haskell.TH qualified as TH
 import Prelude hiding ((.), id)
 import Proto3.Suite.Class (isDefault)
 import Proto3.Suite.Form

--- a/src/Proto3/Suite/Haskell/Parser.hs
+++ b/src/Proto3/Suite/Haskell/Parser.hs
@@ -18,7 +18,7 @@ import GHC.Parser.Lexer (P(..), PState, ParseResult(..))
 import GHC.Types.SrcLoc (Located, RealSrcLoc)
 import GHC.Utils.Outputable (SDoc)
 
-#if MIN_VERSION_ghc(9,8,0)
+#if MIN_VERSION_ghc_lib_parser(9,8,0)
 import qualified GHC.Driver.Errors (printMessages)
 import GHC.Parser.Errors.Types (PsMessage)
 import GHC.Parser.Lexer (getPsMessages, initParserState, mkParserOpts)
@@ -26,7 +26,7 @@ import GHC.Types.Error (Messages, NoDiagnosticOpts(..), partitionMessages, union
 import GHC.Utils.Error (DiagOpts, emptyDiagOpts)
 import GHC.Utils.Logger (Logger, initLogger)
 import GHC.Utils.Outputable (defaultSDocContext, renderWithContext)
-#elif MIN_VERSION_ghc(9,6,0)
+#elif MIN_VERSION_ghc_lib_parser(9,6,0)
 import qualified GHC.Driver.Errors (printMessages)
 import GHC.Parser.Errors.Types (PsMessage)
 import GHC.Parser.Lexer (getPsMessages, initParserState, mkParserOpts)
@@ -34,7 +34,7 @@ import GHC.Types.Error (Messages, NoDiagnosticOpts(..), partitionMessages, union
 import GHC.Utils.Error (DiagOpts(..))
 import GHC.Utils.Logger (Logger, initLogger)
 import GHC.Utils.Outputable (defaultSDocContext, renderWithContext)
-#elif MIN_VERSION_ghc(9,4,0)
+#elif MIN_VERSION_ghc_lib_parser(9,4,0)
 import qualified GHC.Driver.Errors (printMessages)
 import GHC.Parser.Errors.Types (PsMessage)
 import GHC.Parser.Lexer (getPsMessages, initParserState, mkParserOpts)
@@ -42,7 +42,7 @@ import GHC.Types.Error (Messages, partitionMessages, unionMessages)
 import GHC.Utils.Error (DiagOpts(..))
 import GHC.Utils.Logger (Logger, initLogger)
 import GHC.Utils.Outputable (defaultSDocContext, renderWithContext)
-#elif MIN_VERSION_ghc(9,2,0)
+#elif MIN_VERSION_ghc_lib_parser(9,2,0)
 import Control.Arrow ((***))
 import Data.Foldable (traverse_)
 import GHC.ByteOrder (targetByteOrder)
@@ -86,7 +86,7 @@ parseModule ::
   RealSrcLoc ->
   StringBuffer ->
   IO (Maybe (Located (GHC.Hs.HsModule
-#if MIN_VERSION_ghc(9,6,0)
+#if MIN_VERSION_ghc_lib_parser(9,6,0)
                                       GHC.Hs.GhcPs
 #endif
                      )))
@@ -100,9 +100,9 @@ parseModule logger location input = do
         pure Nothing
   where
     exts = EnumSet.fromList (languageExtensions Nothing)
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_ghc_lib_parser(9,4,0)
     diagOpts =
-#if MIN_VERSION_ghc(9,8,0)
+#if MIN_VERSION_ghc_lib_parser(9,8,0)
       emptyDiagOpts
 #else
       DiagOpts
@@ -116,7 +116,7 @@ parseModule logger location input = do
 #endif
     parserOpts = mkParserOpts exts diagOpts [] False True True True
     initialState = initParserState parserOpts input location
-#elif MIN_VERSION_ghc(9,2,0)
+#elif MIN_VERSION_ghc_lib_parser(9,2,0)
     diagOpts = DiagOpts
     parserOpts = mkParserOpts EnumSet.empty exts False True True True
     initialState = initParserState parserOpts input location
@@ -129,10 +129,10 @@ parseModule logger location input = do
 
 printWarningsAndErrors :: Logger -> DiagOpts -> PState -> IO ()
 printWarningsAndErrors logger diagOpts state = do
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_ghc_lib_parser(9,4,0)
   let (ws, es) = getPsMessages state
   let (warnings, unionMessages es -> errors) = partitionMessages ws
-#elif MIN_VERSION_ghc(9,2,0)
+#elif MIN_VERSION_ghc_lib_parser(9,2,0)
   let (warnings, errors) = (fmap pprWarning *** fmap pprError) (getMessages state)
 #else
   let (warnings, errors) = getMessages state renderingDynFlags
@@ -140,17 +140,17 @@ printWarningsAndErrors logger diagOpts state = do
   printMessages logger diagOpts warnings
   printMessages logger diagOpts errors
 
-#if MIN_VERSION_ghc(9,6,0)
+#if MIN_VERSION_ghc_lib_parser(9,6,0)
 
 printMessages :: Logger -> DiagOpts -> Messages PsMessage -> IO ()
 printMessages logger = GHC.Driver.Errors.printMessages logger NoDiagnosticOpts
 
-#elif MIN_VERSION_ghc(9,4,0)
+#elif MIN_VERSION_ghc_lib_parser(9,4,0)
 
 printMessages :: Logger -> DiagOpts -> Messages PsMessage -> IO ()
 printMessages = GHC.Driver.Errors.printMessages
 
-#elif MIN_VERSION_ghc(9,2,0)
+#elif MIN_VERSION_ghc_lib_parser(9,2,0)
 
 printMessages :: Logger -> DiagOpts -> Bag (MsgEnvelope DecoratedSDoc) -> IO ()
 printMessages logger _ = traverse_ report . sortMsgBag Nothing
@@ -174,14 +174,14 @@ printMessages _ _ = traverse_ (putStrLn . renderSDoc) . pprErrMsgBagWithLoc
 
 renderSDoc :: SDoc -> String
 renderSDoc =
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
   renderWithContext
 #else
   renderWithStyle
 #endif
     defaultSDocContext
 
-#if !MIN_VERSION_ghc(9,2,0)
+#if !MIN_VERSION_ghc_lib_parser(9,2,0)
 
 data Logger = Logger
 
@@ -196,7 +196,7 @@ defaultSDocContext = initSDocContext renderingDynFlags defaultDumpStyle
 
 #endif
 
-#if !MIN_VERSION_ghc(9,4,0)
+#if !MIN_VERSION_ghc_lib_parser(9,4,0)
 
 data DiagOpts = DiagOpts
 
@@ -223,7 +223,7 @@ renderingDynFlags = defaultDynFlags placeholderSettings placeholderLlvmConfig
         }
       , sTargetPlatform = Platform
         {
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
           platformArchOS = ArchOS
 #else
           platformMini = PlatformMini
@@ -238,7 +238,7 @@ renderingDynFlags = defaultDynFlags placeholderSettings placeholderLlvmConfig
         , platformIsCrossCompiling = True
         , platformLeadingUnderscore = True
         , platformTablesNextToCode = False
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc_lib_parser(9,2,0)
         , platform_constants = Nothing
 #endif
         }
@@ -289,14 +289,14 @@ renderingDynFlags = defaultDynFlags placeholderSettings placeholderLlvmConfig
         , platformMisc_ghcWithSMP = False
         , platformMisc_ghcRTSWays = mempty
         , platformMisc_libFFI = False
-#if !MIN_VERSION_ghc(9,2,0)
+#if !MIN_VERSION_ghc_lib_parser(9,2,0)
         , platformMisc_ghcThreaded = False
         , platformMisc_ghcDebugged = False
 #endif
         , platformMisc_ghcRtsWithLibdw = False
         , platformMisc_llvmTarget = mempty
         }
-#if !MIN_VERSION_ghc(9,2,0)
+#if !MIN_VERSION_ghc_lib_parser(9,2,0)
       , sPlatformConstants = PlatformConstants
         { pc_CONTROL_GROUP_CONST_291 = 0
         , pc_STD_HDR_SIZE = 0

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -95,7 +95,7 @@ docTests = testCase "doctests" $ do
   Test.DocTest.doctest
     [ "--verbose"
     , "-package"
-    , "ghc"
+    , "ghc-lib-parser"
     , "-isrc"
 #ifdef SWAGGER
 #ifdef SWAGGER_WRAPPER_FORMAT


### PR DESCRIPTION
# Overview

This PR changes the dependency of `proto3-suite` from `ghc` to `ghc-lib-parser`. This resolves version conflicts with the system GHC and results in lighter dependencies.

# Background

When depending on `proto3-suite` in my project, I encountered the following issues:

- `proto3-suite` currently depends directly on the `ghc` package, which can conflict with the system GHC
- The `ghci` package issue is particularly notable - Hackage only provides GHC 8.x versions, causing problems when using GHC 9.x
- This causes `cabal build` to fail with errors like:

```
Error: [Cabal-7107]
Could not resolve dependencies:
[__0] trying: proto3-suite-0.9.0 (user goal)
[__1] next goal: ghc (dependency of proto3-suite)
[__1] rejecting: ghc-9.12.1 (conflict: proto3-suite => ghc>=9.0 && <9.11)
[__1] trying: ghc-9.10.1
[__2] next goal: ghci (dependency of ghc +/-static-libzstd +/-with-libzstd)
[__2] rejecting: ghci; 8.10.2, 8.10.1, ... (conflict: ghc +/-static-libzstd +/-with-libzstd => ghci==9.10.1)
[__2] fail (backjumping, conflict set: ghc, ghci)
```

# Changes

1. Change dependency from `ghc` to `ghc-lib-parser`
2. Update `MIN_VERSION_ghc` macros to `MIN_VERSION_ghc_lib_parser`
3. Add explicit qualified import of `Language.Haskell.TH` from the `template-haskell` package

# Benefits

1. **Lighter dependencies**: `ghc-lib-parser` is lighter than the `ghc` package and provides only the necessary functionality
2. **Improved compatibility**: Eliminates conflicts with the system GHC, enabling builds in a wider range of environments
3. **Better maintainability**: Reduces the likelihood of conflicts with future GHC versions