### PR TITLE
build(cabal): improve developer experience

### DIFF
--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -325,9 +325,6 @@ in {
               (oldArgs: {
                 pname = "proto3-suite-boot";
 
-                configureFlags = (oldArgs.configureFlags or [ ])
-                  ++ [ "--disable-optimization" ];
-
                 doCheck = false;
 
                 doHaddock = false;

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -49,6 +49,8 @@ source-repository head
   location: https://github.com/awakesecurity/proto3-suite
 
 common common
+  ghc-options:         -O2 -Wall
+  default-language:    Haskell2010
   default-extensions:
     BlockArguments DeriveDataTypeable DeriveGeneric ImportQualifiedPost
 
@@ -136,12 +138,9 @@ library
   if flag(attoparsec-aeson)
     build-depends:     attoparsec-aeson >= 2.2.0.0
   hs-source-dirs:      src
-  default-language:    Haskell2010
-  ghc-options:         -O2 -Wall -Werror
 
 test-suite tests
   import:           common
-  default-language: Haskell2010
   type:             exitcode-stdio-1.0
   main-is:          Main.hs
 
@@ -222,12 +221,10 @@ test-suite tests
     , turtle
     , vector >=0.11 && <0.14
 
-  ghc-options:         -O2 -Wall
-
 executable compile-proto-file
+  import: common
   main-is:             Main.hs
   hs-source-dirs:      tools/compile-proto-file
-  default-language:    Haskell2010
   build-depends:       base >=4.15 && <5.0
                        , ghc-lib-parser
                        , optparse-applicative
@@ -235,12 +232,11 @@ executable compile-proto-file
                        , system-filepath
                        , text
                        , turtle
-  ghc-options:         -O2 -Wall -Werror
 
 executable canonicalize-proto-file
+  import: common
   main-is:             Main.hs
   hs-source-dirs:      tools/canonicalize-proto-file
-  default-language:    Haskell2010
   build-depends:       base >=4.15 && <5.0
                        , containers >=0.5 && <0.8
                        , mtl >=2.2 && <2.4
@@ -250,4 +246,3 @@ executable canonicalize-proto-file
                        , range-set-list >=0.1.2 && <0.2
                        , system-filepath
                        , turtle
-  ghc-options:         -O2 -Wall -Werror

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -49,7 +49,7 @@ source-repository head
   location: https://github.com/awakesecurity/proto3-suite
 
 common common
-  ghc-options:         -Wall
+  ghc-options:         -Wall -j
   default-language:    Haskell2010
   default-extensions:
     BlockArguments DeriveDataTypeable DeriveGeneric ImportQualifiedPost

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -49,7 +49,7 @@ source-repository head
   location: https://github.com/awakesecurity/proto3-suite
 
 common common
-  ghc-options:         -O2 -Wall
+  ghc-options:         -Wall
   default-language:    Haskell2010
   default-extensions:
     BlockArguments DeriveDataTypeable DeriveGeneric ImportQualifiedPost

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -49,7 +49,15 @@ source-repository head
   location: https://github.com/awakesecurity/proto3-suite
 
 common common
-  ghc-options:         -Wall -j
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Widentities
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wpartial-fields
+    -Wredundant-constraints
+    -j
   default-language:    Haskell2010
   default-extensions:
     BlockArguments DeriveDataTypeable DeriveGeneric ImportQualifiedPost


### PR DESCRIPTION
The important change is below.

---

build: remove `-O2` from `ghc-options`

Remove the default `-O2` optimization flag.
Speeds up development cycles and iterations.
Using `shell.nix` with `fast` wasn't a complete solution since it doesn't work when running tests.
The impact on performance is minimal.
When installed via `cabal install`, optimization is automatically enabled.
For production applications, optimization can be specified at build/deploy time with `--ghc-options="-O2"`.
```
RUN stack install --ghc-options="-O2" foo-project:exe:foo-project
```

---

And cleanup cabal file.