### PR TITLE
Fix bugs in interval merging.

### DIFF
--- a/src/Proto3/Suite/DotProto/Internal.hs
+++ b/src/Proto3/Suite/DotProto/Internal.hs
@@ -204,11 +204,12 @@ joinIntervals (a, b) (c, d)
 --
 -- = Conclusions
 --
--- In conclusion, the behavior of this function is well defined
--- by the first paragraph in this comment block, and the second
--- paragraph provides an equivalent characterization.
+-- In conclusion, the desired behavior of this function is well defined
+-- by the first paragraph in this comment block, and the second paragraph
+-- (once combined with a requirement to preserve the union) provides
+-- an equivalent definition.
 --
--- To check that the implementation actually fulfills these comments,
+-- To check that the implementation actually fulfills these requirements,
 -- note that it filters out empty intervals, sorts those that remain,
 -- and then merges intervals until the resulting list becomes /normal/.
 --

--- a/src/Proto3/Suite/DotProto/Internal.hs
+++ b/src/Proto3/Suite/DotProto/Internal.hs
@@ -211,10 +211,10 @@ joinIntervals (a, b) (c, d)
 --
 -- To check that the implementation actually fulfills these requirements,
 -- note that it filters out empty intervals, sorts those that remain,
--- and then merges intervals until the resulting list becomes /normal/.
+-- and then merges intervals until the resulting list becomes normal.
 --
 -- There are also unit tests checking that the result is
- -- /normal/ and has the same union as the given list.
+-- normal and has the same union as the given list.
 normalizeIntervals :: (Enum a, Ord a) => [(a, a)] -> [(a, a)]
 normalizeIntervals = mergeIntervals . filter \(x, y) -> x <= y
 {-# INLINABLE normalizeIntervals #-}  -- To allow specialization to particular type class instances.

--- a/src/Proto3/Suite/DotProto/Internal.hs
+++ b/src/Proto3/Suite/DotProto/Internal.hs
@@ -88,52 +88,157 @@ dieLines (Turtle.textToLines -> msg) = do
   mapM_ Turtle.err msg
   Turtle.exit (ExitFailure 1)
 
--- | Check if the given values is some given bounds (inclusive).
-between :: (Ord a, Enum a) => a -> (a, a) -> Bool
-between x (a, b) = a <= x && x <= b
+-- | The proposition that some third value comes strictly after
+-- the first argument but strictly before the second argument.
+nonconsecutive :: (Enum a, Ord a) => a -> a -> Bool
+nonconsecutive x y = x < y && succ x < y
+  -- The check that @x < y@ avoids the potential for arithmetic overflow in @succ x@.
+{-# INLINABLE nonconsecutive #-}  -- To allow specialization to particular type class instances.
 
--- | @('isOverlappingIntervals' a b :: 'Bool')@ is a relation between two 
--- interval-like terms @a@ and @b@ that is 'True' when the two intervals are 
--- overlapping or touching over a subinterval of @a@ and @b@.
-isOverlappingIntervals :: (Ord a, Enum a) => (a, a) -> (a, a) -> Bool
-isOverlappingIntervals i1@(x, y) i2@(u, v) = x `between` i2 || y `between` i2 || u `between` i1 || v `between` i1
+-- | This function yields 'Just' of the union of its arguments if that union
+-- can be expressed as a single interval, and otherwise yields 'Nothing'.
+joinIntervals :: (Enum a, Ord a) => (a, a) -> (a, a) -> Maybe (a, a)
+joinIntervals (a, b) (c, d)
+  | b < a = Just (c, d)  -- (a, b) is empty; we can just drop it
+  | d < c = Just (a, b)  -- (c, d) is empty; we can just drop it
+  | a <= c = if
+      | nonconsecutive b c -> Nothing   -- (a, b), then something strictly between, then (c, d)
+      | otherwise -> Just (a, max b d)  -- no value lies strictly between b and c
+  | otherwise = if
+      | nonconsecutive d a -> Nothing   -- (c, d), then something strictly between, then (a, b)
+      | otherwise -> Just (c, max b d)  -- no value lies strictly between d and a
+{-# INLINABLE joinIntervals #-}  -- To allow specialization to particular type class instances.
 
--- | @('joinIntervals' a b :: 'Maybe' (a, a))@ will join the two given intervals 
--- @a@ and @b@ into a larger interval if 
+-- | Finds the unique shortest list of intervals having the same
+-- set union as the given list and nondecreasing low endpoints.
 --
--- @
--- ('isOverlappingIntervals' a b '==' 'True')
--- @
+-- The result also satisfies the definition of /normal/ given below.
 --
--- Otherwise, returns 'Nothing'.
-joinIntervals :: (Ord a, Enum a) => (a, a) -> (a, a) -> Maybe (a, a)
-joinIntervals a b = do 
-  guard (isOverlappingIntervals a b)
-  pure (min (fst a) (fst b), max (snd a) (snd b))
-
--- | Normalizes a list of intervals. 
+-- Each interval is specified by pairing its low and high endpoints,
+-- which are included in the interval, except when the first component
+-- of the pair exceeds the second, in which case the interval is empty.
 --
--- 1. Filters out any "invalid" intervals from the resulting list, i.e. any 
---    intervals @(x, y) :: (a, a)@ with @x > y@. 
+-- = Supporting Theory
 --
--- 2. Additionally, the resulting list will have all overlapping intervals 
---    merged into a larger interval that covers each overlapping interval.
-normalizeIntervals :: (Ord a, Enum a) => [(a, a)] -> [(a, a)]
+-- == Definition of /normal/
+--
+-- Call a list of intervals /normal/ when it excludes empty intervals
+-- and for any two consecutive intervals /[a .. b]/ and /[c .. d]/,
+-- there exists an /x/ such that /b < x < c/.
+--
+-- We claim that, among those interval lists having any given union,
+-- normality is equivalent to having minimal length and nondecreasing
+-- low endpoints.
+--
+-- == Normal implies minimal length
+--
+-- To see why, first consider any normal interval list /N/.  Clearly its
+-- low endpoints are nondecreasing--and in fact are strictly increasing
+-- with gaps inbetween.  Therefore any interval intersecting at least two
+-- intervals of /N/ necessarily includes at least one point in such a gap,
+-- and that point is outside the union of /N/.  Hence every interval list
+-- with the same union as /N/ consists of (possibly empty) subintervals of
+-- intervals listed by /N/.  Hence /N/ has minimal length among such lists.
+--
+-- == Minimal length implies normal
+--
+-- To establish the converse, consider any interval list /N/ having
+-- nondecreasing endpoints and minimal length.  Deleting empty intervals
+-- from /N/ would only decrease its length, so /N/ must not include any.
+-- Next note that if /[a .. b]/ and /[c .. d]/ are consecutive intervals
+-- within /N/, then either there exists an /x/ such that /b < x < c/, or
+-- else we may shorten /N/ without changing its union by replacing both
+-- /[a .. b]/ and /[c .. d]/ by the single interval /[a .. max b d]/,
+-- which would contradict the minimality of the length of /N/.  Thus
+-- /N/ fulfills all the requirements of being a normal interval list.
+--
+-- == Existence
+--
+-- Having proved the desired equivalence, we turn to the question of
+-- the existence of the shortest interval list having the same union
+-- as any given interval list and nondecreasing low endpoints.
+--
+-- Consider the set /S/ of interval lists having the same union as
+-- the given interval list and nondecreasing low endpoints.  Note
+-- that by performing a stable sort on the given interval list we
+-- immediately find that /S/ is nonempty.  Being nonempty, it must
+-- contain at least one element of minimal length.
+--
+-- == Uniqueness
+--
+-- But could there be two different interval lists of minimal length
+-- for their common union, both with nondecreasing low endpoints?
+--
+-- We claim the answer is no, and proceed by induction on that shared
+-- minimal length.  The base case is trivial: if both lists are empty,
+-- then they cannot differ.
+--
+-- For the induction step, suppose that there are two interval lists
+-- that share the same positive minimal length among those that
+-- have nondecreasing low endpoints and a given same union.
+-- Call them /L/ and /N/.  We will prove that /L = N/.
+--
+-- Let /(a, b) = head L/ and /(e, f) = head N/.
+--
+-- If /a < e/ then /a/ is in /union L/ but not in /union N/,
+-- contradicting our assumpion that /union L = union N/.  Likewise
+-- we may exclude /e < a/, leaving /a = e/ and /(a, f) = head N/.
+--
+-- Next suppose that /b < f/.  If /tail L == []/ then clearly /f/
+-- is outside of /union L/ and yet inside of /union N/, which is
+-- once again beyond our scenario.  Let /(c, d) = head (tail L)/.
+-- By the equivalence we established earlier, /L/ is normal and
+-- hence there exists an /x/ such that /b < x < c/.  If /x <= f/,
+-- then /x/ is in /[a .. f]/ and yet outside of /union L/, once
+-- again contradicting our hypotheses.  Otherwise /f < x < c/, and
+-- hence /f/ is outside of /union L/, a similar contradiction.
+-- Therefore our supposition that /b < f/ must be impossible,
+-- and we can likewise exclude /f < b/.  Hence /b = f/.
+--
+-- Having establishing both /a = e/ and /b = f/, we conclude that
+-- /head L = head N/.  It follows that /tail L/ and /tail N/ have
+-- the same union as each other.  Both tails must be minimal in
+-- length, because otherwise there would also be a way to shorten
+-- /L/ or /N/ in a union-preserving way.  Invoking our induction
+-- hypothesis we find that /tail L = tail N/; therefore /L = N/.
+--
+-- = Conclusions
+--
+-- In conclusion, the behavior of this function is well defined
+-- by the first paragraph in this comment block, and the second
+-- paragraph provides an equivalent characterization.
+--
+-- To check that the implementation actually fulfills these comments,
+-- note that it filters out empty intervals, sorts those that remain,
+-- and then merges intervals until the resulting list becomes /normal/.
+--
+-- There are also unit tests checking that the result is
+ -- /normal/ and has the same union as the given list.
+normalizeIntervals :: (Enum a, Ord a) => [(a, a)] -> [(a, a)]
 normalizeIntervals = mergeIntervals . filter \(x, y) -> x <= y
+{-# INLINABLE normalizeIntervals #-}  -- To allow specialization to particular type class instances.
 
--- | Returns a sorted list that contains all intervals from the minimal set of 
--- intervals to represent the given list of intervals. 
+-- | Returns a sorted list that contains all intervals from the minimal set of
+-- intervals to represent the given list of intervals.
 --
--- "Merges" overlapping intervals in a list of intervals. Think disjunctive 
+-- "Merges" overlapping intervals in a list of intervals. Think disjunctive
 -- normal form.
-mergeIntervals :: (Ord a, Enum a) => [(a, a)] -> [(a, a)]
+mergeIntervals :: forall a . (Enum a, Ord a) => [(a, a)] -> [(a, a)]
 mergeIntervals = foldr step [] . sort
-  where 
-    step :: (Ord a, Enum a) => (a, a) -> [(a, a)] -> [(a, a)]
+  where
+    step :: (a, a) -> [(a, a)] -> [(a, a)]
     step x [] = [x]
-    step x (y : ys) = case joinIntervals x y of 
-      Nothing -> x : y : ys 
-      Just xy -> xy : ys
+    step x (y : ys) = case joinIntervals x y of
+      Nothing -> x : y : ys
+        -- In this case @x@ and @y@ could not be merged, and therefore there is
+        -- some value strictly inbetween the end of @x@ and the start of @y@.
+        -- Compare this property to the definition of /normal/ (above).
+      Just xy -> step xy ys
+        -- Recursion is necessary here because @x@ may end later than did @y@,
+        -- possibly making @xy@ mergable with some prefix of @ys@, unlike @y@.
+        -- By merging @x@ and @y@ into @xy@ we have shortened the overall
+        -- length of the list, and therefore this recursion must terminate.
+{-# INLINABLE mergeIntervals #-}  -- To allow specialization to particular type class instances.
 
 --------------------------------------------------------------------------------
 --

--- a/tests/Test/Proto/Interval.hs
+++ b/tests/Test/Proto/Interval.hs
@@ -1,12 +1,14 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NegativeLiterals #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Proto.Interval (testTree) where
 
-import Control.Monad (unless)
+import Data.Foldable (for_)
 
-import Data.Int (Int8)
-
-import Proto3.Suite.DotProto.Internal (isOverlappingIntervals, joinIntervals)
+import Proto3.Suite.DotProto.Internal (joinIntervals, normalizeIntervals)
 
 import Hedgehog (Gen, forAll, property, (===))
 import Hedgehog qualified
@@ -18,15 +20,74 @@ import Test.Tasty.Hedgehog (testProperty)
 
 --------------------------------------------------------------------------------
 
-overlappingIntervals :: (Bounded a, Integral a) => Gen ((a, a), (a, a))
-overlappingIntervals = do 
-  x <- Gen.integral Range.constantBounded
-  y <- Gen.integral (Range.constant x maxBound)
+-- | Check if the given value is some given bounds (inclusive).
+isIn :: (Ord a) => a -> (a, a) -> Bool
+isIn x (a, b) = a <= x && x <= b
 
-  u <- Gen.integral (Range.constant x y) 
-  v <- Gen.integral (Range.constant y maxBound)
+-- | Check if the given value is any of the given bounds (inclusive).
+isInAnyOf :: (Ord a) => a -> [(a, a)] -> Bool
+isInAnyOf = any . isIn
 
-  pure ((x, y), (u, v))
+-- | Generates an arbitrary interval.  May generate
+-- empty intervals, though at about 10% probability.
+genInterval :: (Bounded a, Integral a) => Gen (a, a)
+genInterval = Gen.frequency [(4, alwaysNonempty), (1, halfEmpty)]
+  where
+    alwaysNonempty = do
+      x <- Gen.integral Range.constantBounded
+      y <- Gen.integral Range.constantBounded
+      pure (min x y, max x y)
+
+    halfEmpty = do
+      x <- Gen.integral Range.constantBounded
+      y <- Gen.integral Range.constantBounded
+      pure (x, y)
+
+-- | A value in the range [-8 .. 7].  We intentionally limit this type to
+-- just a few values in order to increase the chance of overlapping intervals
+-- in some tests, while still retaining enough distinct values to allow many
+-- different relationships between intervals.  We also want to check for
+-- arithmetic overflow in the code under test by throwing an exception,
+-- which should cause the test to fail.
+newtype Nybble = UnsafeNybble Int
+  deriving newtype (Eq, Ord, Real, Show)
+
+{-# COMPLETE Nybble #-}
+
+pattern Nybble :: Int -> Nybble
+pattern Nybble x <- UnsafeNybble x
+  where
+    Nybble x
+      | -8 <= x && x <= 7 = UnsafeNybble x
+      | otherwise = error $ "Nybble out of bounds: " ++ show x
+
+instance Bounded Nybble
+  where
+    minBound = Nybble -8
+    maxBound = Nybble 7
+
+-- | Manual implementation to ensure an exception is thrown for out-of-bounds values.
+instance Enum Nybble
+  where
+    toEnum x = Nybble x
+    fromEnum (Nybble x) = x
+
+-- | Manual implementation to ensure an exception is thrown for arithmetic overflow.
+instance Num Nybble
+  where
+    Nybble x + Nybble y = Nybble (x + y)
+    Nybble x - Nybble y = Nybble (x - y)
+    Nybble x * Nybble y = Nybble (x * y)
+    negate (Nybble x) = Nybble (negate x)
+    abs (Nybble x) = Nybble (abs x)
+    signum (Nybble x) = Nybble (signum x)
+    fromInteger x = Nybble (fromInteger x)
+
+-- | Manual implementation to ensure an exception is thrown for arithmetic overflow.
+instance Integral Nybble
+  where
+    quotRem (Nybble n) (Nybble d) = let (q, r) = quotRem n d in (Nybble q, Nybble r)
+    toInteger (Nybble x) = toInteger x
 
 --------------------------------------------------------------------------------
 
@@ -34,61 +95,87 @@ testTree :: TestTree
 testTree =
   testGroup
     "Test.Proto.Interval"
-    [ testIntervalMerge
-    , testIntervalMeasure
+    [ testJoinIntervals
+    , testNormalizeIntervals
     ]
 
--- testNormaliseIntervalsOrder :: TestTree
--- testNormaliseIntervalsOrder = testProperty "Order" $ property do
+-- This test verifies the documented behavior of 'joinIntervals'.
+testJoinIntervals :: TestTree
+testJoinIntervals = testProperty "joinIntervals" $ property do
+  (a, b) <- forAll $ genInterval @Nybble
+  (c, d) <- forAll $ genInterval @Nybble
+  case joinIntervals (a, b) (c, d) of
+    Nothing -> do
+      -- The code under test says that one cannot merge the two intervals into
+      -- a single interval.  For that to be true, both intervals must be nonempty/valid:
+      Hedgehog.assert (a <= b)
+      Hedgehog.assert (c <= d)
+      -- And in addition, the least interval containing both of the given intervals
+      -- must /not/ be their union.  Namely, it must include some extra element:
+      let extra x = not (x `isIn` (a, b) || x `isIn` (c, d))
+      Hedgehog.assert (any extra [min a c .. max b d])
+      -- That suffices to verify that the intervals cannot be combined, but because
+      -- the code under test currently considers similar issues, we note that there
+      -- must be at least one value strictly between the two given intervals;
+      -- otherwise we could merge them because there would be nothing between them:
+      let between x = (b < x && x < c) || (d < x && x < a)
+      Hedgehog.assert (any between [minBound .. maxBound])
+    Just combined -> do
+      -- The code under test claims that 'combined' equals the union of the given
+      -- intervals.  We check that conclusion by testing every possible element:
+      Hedgehog.annotateShow combined
+      for_ [minBound .. maxBound] \x -> do
+        x `isIn` combined === (x `isIn` (a, b) || x `isIn` (c, d))
 
+-- This test verifies the documented behavior of 'normalizeIntervals'.
+-- (Note the correspondence between the various documented properties
+-- and the specific checks included here.)
+--
+-- This test also checks an additional property: that 'normalizeIntervals'
+-- never increases the sum of the sizes of the listed intervals, where by
+-- "size" we mean the count of elements within the interval.  That is, we
+-- are only eliminating redundancy in the
+testNormalizeIntervals :: TestTree
+testNormalizeIntervals = testProperty "normalizeIntervals" $ property do
+  messy <- forAll $ Gen.list (Range.linear 0 20) $ genInterval @Nybble
 
-testIntervalMerge :: TestTree 
-testIntervalMerge = testProperty "Overlap" $ property do
-  (i1@(x, y), i2@(u, v)) <- forAll (overlappingIntervals @Int8)
+  let clean :: [(Nybble, Nybble)]
+      clean = normalizeIntervals messy
+  Hedgehog.annotateShow clean
 
-  Hedgehog.assert (isOverlappingIntervals i1 i2)
+  -- The result must not contain any empty intervals.
+  for_ clean \(a, b) ->
+    Hedgehog.assert (a <= b)
 
-  -- This test is invalid for intervals (x, y) and (u, v) when any of the
-  -- following conditions are true: x == y, u == v, x == v or y == u. This 
-  -- is because 'Gen.int8' can produce the boundary values of the given
-  -- range which can lead to situations where splitting @i1@ and @i2@ at 
-  -- the subinterval covered by @i1@ and @i2@ are still "touching" along
-  -- the upper boundary of @i1@ and the lower boundary of @i2@, e.g.
+  -- The union of the result must be the same as the union of the input.
+  for_ [minBound .. maxBound] \x -> do
+    (x, isInAnyOf x clean) === (x, isInAnyOf x messy)
+
+  -- Check that the listed intervals do not overlap, and moreover,
+  -- cannot be merged because there are no values between them.
   --
-  -- @
-  -- i1  = (0, 5)
-  -- i2  = (5, 10)
-  -- i1' = (0, 5) 
-  -- i2' = (5, 10) 
-  -- @
+  -- Note that here we rely upon the accuracy of 'joinIntervals',
+  -- which is checked in isolation by the test 'testJoinIntervals'.
+  for_ (zip [1 ..] clean) \(d, i1) ->
+    for_ (drop d clean) \i2 -> do
+      (i1, i2, joinIntervals i1 i2) === (i1, i2, Nothing)
+
+  -- The code under test should have ensured that for any two consecutive intervals,
+  -- there is at least one value strictly inbetween those two intervals.  This check
+  -- should subsume the previous one, but we run both checks just to be sure.
   --
-  -- In all other cases we are gauranteed to have disjoint @i1'@ and 
-  -- @i2'@, thus @'not' . 'isOverlappingIntervals'@ should be implied.
-  unless (x == y || u == v || x == u || y == v) do
-    Hedgehog.assert (not (isOverlappingIntervals (x, v) (u, y)))
+  -- The nonempty gaps between intervals prevent further merging, making 'clean'
+  -- at least locally minimal.  But a simple exhaustive search would be extremely
+  -- expensive, and hence we rely upon the mathematical argument in the comments for
+  -- 'normalizeIntervals' to completely rule out the possibility of shorter lists.
+  for_ (zip clean (drop 1 clean)) \((_, b), (c, _)) ->
+    Hedgehog.assert (b < c && succ b < c)  -- The first check is to sure that 'succ' is safe.
 
--- Verify interval merging by checking that the size of the merged interval is 
--- bounded below the sum of the sizes of each individual interval that was 
--- merged. 
-testIntervalMeasure :: TestTree
-testIntervalMeasure = testProperty "Measure" $ property do
-  (i1, i2) <- forAll (overlappingIntervals @Int8)
-
-  let d1 :: Integer 
-      d1 = magnitude i1
-
-  let d2 :: Integer 
-      d2 = magnitude i2
-
-  Hedgehog.annotateShow d1
-  Hedgehog.annotateShow d2
-
-  case joinIntervals i1 i2 of 
-    Nothing -> Hedgehog.failure
-    Just i3 -> do 
-      fst i3 === min (fst i1) (fst i2)
-      snd i3 === max (snd i1) (snd i2)
-      Hedgehog.diff (magnitude i3) (<=) (magnitude i1 + magnitude i2)
-  where 
-    magnitude :: (Int8, Int8) -> Integer
-    magnitude i = toInteger (snd i) - toInteger (fst i)
+  -- Verify interval merging by checking that the size of the merged intervals is
+  -- bounded below the sum of the sizes of each individual interval that was merged.
+  let intervalSize :: (Nybble, Nybble) -> Integer
+      intervalSize (a, b) = if a <= b then toInteger b + 1 - toInteger a else 0
+      overallSize :: [(Nybble, Nybble)] -> Integer
+      overallSize = sum . map intervalSize
+  Hedgehog.annotateShow (overallSize clean, overallSize messy)
+  Hedgehog.assert (overallSize clean <= overallSize messy)


### PR DESCRIPTION
`Proto3.Suite.DotProto.Internal.joinIntervals (0, 1) (2, 3 :: Int)` now correctly reduces to `Just (0, 3)` instead of to `Nothing`.

`Proto3.Suite.DotProto.Internal.normalizeIntervals [(0, 5), (1, 1), (3, 3 :: Int), (5, 5 :: Int)]` now correctly reduces to `[(0,5)]` instead of `[(0, 5), (3, 3), (5, 5)]`.