### PR TITLE
Show MessageEncoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.9.2
+* [#282](https://github.com/awakesecurity/proto3-suite/pull/282) Show MessageEncoder
+  * [BREAKING CHANGE in experimental module: Rename `cacheMessage` to `messageCache`.]
+  * [BREAKING CHANGE in experimental module: Delete `Eq` instance for `MessageEncoding` because it is application-defined whether we should ignore field order during comparison.]
+  * Add `Show` instance for `MessageEncoder`.
+  * Add `messageEncoderToByteString` and `unsafeByteStringToMessageEncoder`.
+
 # 0.9.1
 * [#275](https://github.com/awakesecurity/proto3-suite/pull/275) the `canonicalize-proto-file` executable no longer depends on the [`range-set-list](https://github.com/phadej/range-set-list#readme) package for normalizing reserved field ranges.
 * Relocated orphaned [`Pretty`](https://hackage.haskell.org/package/pretty-1.1.3.6/docs/Text-PrettyPrint-HughesPJClass.html#t:Pretty) instances for AST types to [`Proto3.Suite.DotProto.AST`].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.9.2
 * [#282](https://github.com/awakesecurity/proto3-suite/pull/282) Show MessageEncoder
+  * [BREAKING CHANGE in experimental module: Rename `toLazyByteString` to `messageEncoderToLazyByteString`.]
   * [BREAKING CHANGE in experimental module: Rename `cacheMessage` to `messageCache`.]
   * [BREAKING CHANGE in experimental module: Delete `Eq` instance for `MessageEncoding` because it is application-defined whether we should ignore field order during comparison.]
   * Add `Show` instance for `MessageEncoder`.

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                proto3-suite
-version:             0.9.1
+version:             0.9.2
 synopsis:            A higher-level API to the proto3-wire library
 description:
   This library provides a higher-level API to <https://github.com/awakesecurity/proto3-wire the `proto3-wire` library>
@@ -50,7 +50,7 @@ source-repository head
 
 common common
   default-extensions:
-    BlockArguments ExplicitNamespaces DeriveDataTypeable DeriveGeneric 
+    BlockArguments ExplicitNamespaces DeriveDataTypeable DeriveGeneric
     ImportQualifiedPost ViewPatterns
 
 library

--- a/src/Proto3/Suite/Form/Encode.hs
+++ b/src/Proto3/Suite/Form/Encode.hs
@@ -31,9 +31,9 @@
 -- frequently than in the other modules of this package, perhaps even in patch releases.
 module Proto3.Suite.Form.Encode
   ( MessageEncoder(..)
-  , toLazyByteString
-  , etaMessageEncoder
+  , messageEncoderToLazyByteString
   , messageEncoderToByteString
+  , etaMessageEncoder
   , unsafeByteStringToMessageEncoder
   , MessageEncoding
   , messageCache
@@ -100,10 +100,6 @@ import Proto3.Wire.Encode qualified as Encode
 import Proto3.Wire.Encode.Repeated (ToRepeated, mapRepeated)
 import Proto3.Wire.Reverse qualified as RB
 import Proto3.Wire.Types (fieldNumber)
-
--- | Runs a message encoder to produce the octets of the encoding.
-messageEncoderToByteString :: MessageEncoder message -> B.ByteString
-messageEncoderToByteString = BL.toStrict . Encode.toLazyByteString . untypedMessageEncoder
 
 -- | The unsafe but fast inverse of 'messageEncoderToByteString'.
 unsafeByteStringToMessageEncoder :: B.ByteString -> MessageEncoder message

--- a/src/Proto3/Suite/Form/Encode.hs
+++ b/src/Proto3/Suite/Form/Encode.hs
@@ -33,8 +33,10 @@ module Proto3.Suite.Form.Encode
   ( MessageEncoder(..)
   , toLazyByteString
   , etaMessageEncoder
+  , messageEncoderToByteString
+  , unsafeByteStringToMessageEncoder
   , MessageEncoding
-  , cacheMessage
+  , messageCache
   , cacheMessageEncoding
   , cachedMessageEncoding
   , messageEncodingToByteString
@@ -99,6 +101,14 @@ import Proto3.Wire.Encode.Repeated (ToRepeated, mapRepeated)
 import Proto3.Wire.Reverse qualified as RB
 import Proto3.Wire.Types (fieldNumber)
 
+-- | Runs a message encoder to produce the octets of the encoding.
+messageEncoderToByteString :: MessageEncoder message -> B.ByteString
+messageEncoderToByteString = BL.toStrict . Encode.toLazyByteString . untypedMessageEncoder
+
+-- | The unsafe but fast inverse of 'messageEncoderToByteString'.
+unsafeByteStringToMessageEncoder :: B.ByteString -> MessageEncoder message
+unsafeByteStringToMessageEncoder = UnsafeMessageEncoder . Encode.unsafeFromByteString
+
 -- | The octet sequence that would be emitted by some
 -- 'MessageEncoder' having the same type parameter.
 --
@@ -109,7 +119,7 @@ import Proto3.Wire.Types (fieldNumber)
 -- See also: 'cacheMessageEncoding'
 newtype MessageEncoding (message :: Type) = UnsafeMessageEncoding B.ByteString
   deriving stock (Generic)
-  deriving newtype (Eq, NFData, Ord)
+  deriving newtype (NFData)
 
 type role MessageEncoding nominal
 
@@ -139,17 +149,14 @@ instance (omission ~ 'Alternative) =>
 --
 -- See also: 'cacheFields'.
 cacheMessageEncoding :: MessageEncoder message -> MessageEncoding message
-cacheMessageEncoding =
-  UnsafeMessageEncoding . BL.toStrict . Encode.toLazyByteString . untypedMessageEncoder
+cacheMessageEncoding = UnsafeMessageEncoding . messageEncoderToByteString
 
 -- | Encodes a precomputed 'MessageEncoder' by copying octets from a memory buffer.
 -- See 'cacheMessageEncoding'.
 --
 -- See also: 'cachedFields'
 cachedMessageEncoding :: MessageEncoding message -> MessageEncoder message
-cachedMessageEncoding =
-  UnsafeMessageEncoder . Encode.unsafeFromByteString . messageEncodingToByteString
-{-# INLINE cachedMessageEncoding #-}
+cachedMessageEncoding = unsafeByteStringToMessageEncoder . messageEncodingToByteString
 
 -- | Strips type information from the message encoding, leaving only its octets.
 messageEncodingToByteString :: MessageEncoding message -> B.ByteString
@@ -415,9 +422,9 @@ messageReflection m = coerce (encodeMessage @message (fieldNumber 1) m)
 -- | Creates a message encoding by means of type class `Proto3.Suite.Class.Message`.
 --
 -- Equivalent to @'cacheMessageEncoding' . 'messageReflection'@.
-cacheMessage :: forall message . Message message => message -> MessageEncoding message
-cacheMessage m = cacheMessageEncoding (messageReflection m)
-{-# INLINABLE cacheMessage #-}
+messageCache :: forall message . Message message => message -> MessageEncoding message
+messageCache m = cacheMessageEncoding (messageReflection m)
+{-# INLINABLE messageCache #-}
 
 instance (Message message, Show message) =>
          Show (MessageEncoding message)
@@ -425,4 +432,12 @@ instance (Message message, Show message) =>
     showsPrec d (messageEncodingToByteString -> bs) = showParen (d >= 11) $
       case fromByteString bs of
         Left _ -> shows 'unsafeByteStringToMessageEncoding . showChar ' ' . showsPrec 11 bs
-        Right (msg :: message) -> shows 'cacheMessage . showChar ' ' . showsPrec 11 msg
+        Right (msg :: message) -> shows 'messageCache . showChar ' ' . showsPrec 11 msg
+
+instance (Message message, Show message) =>
+         Show (MessageEncoder message)
+  where
+    showsPrec d (messageEncoderToByteString -> bs) = showParen (d >= 11) $
+      case fromByteString bs of
+        Left _ -> shows 'unsafeByteStringToMessageEncoder . showChar ' ' . showsPrec 11 bs
+        Right (msg :: message) -> shows 'messageReflection . showChar ' ' . showsPrec 11 msg

--- a/src/Proto3/Suite/Form/Encode/Core.hs
+++ b/src/Proto3/Suite/Form/Encode/Core.hs
@@ -29,7 +29,8 @@
 -- must be kept separate for the sake of @TemplateHaskell@.
 module Proto3.Suite.Form.Encode.Core
   ( MessageEncoder(..)
-  , toLazyByteString
+  , messageEncoderToLazyByteString
+  , messageEncoderToByteString
   , etaMessageEncoder
   , Prefix(..)
   , etaPrefix
@@ -59,6 +60,7 @@ module Proto3.Suite.Form.Encode.Core
   ) where
 
 import Control.Category (Category(..))
+import Data.ByteString qualified as B
 import Data.ByteString.Lazy qualified as BL
 import Data.Coerce (coerce)
 import Data.Kind (Type)
@@ -84,8 +86,15 @@ newtype MessageEncoder (message :: Type) = UnsafeMessageEncoder
 type role MessageEncoder nominal
 
 -- | Serialize a message (or portion thereof) as a lazy 'BL.ByteString'.
-toLazyByteString :: forall message . MessageEncoder message -> BL.ByteString
-toLazyByteString = Encode.toLazyByteString . untypedMessageEncoder
+messageEncoderToLazyByteString :: forall message . MessageEncoder message -> BL.ByteString
+messageEncoderToLazyByteString = Encode.toLazyByteString . untypedMessageEncoder
+
+-- | Serialize a message (or portion thereof) as a strict 'B.ByteString'.
+--
+-- Functionally equivalent to @'BL.toStrict' . 'messageEncoderToLazyByteString'@,
+-- and currently even the performance is the same.
+messageEncoderToByteString :: forall message . MessageEncoder message -> B.ByteString
+messageEncoderToByteString = BL.toStrict . messageEncoderToLazyByteString
 
 -- | Like 'Encode.etaMessageBuilder' but for 'MessageEncoder'.
 etaMessageEncoder :: forall a message . (a -> MessageEncoder message) -> a -> MessageEncoder message

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -213,22 +213,22 @@ encoderMatchesGoldens = testGroup "Encoder matches golden encodings"
       -- that adhere to the protobuf specification.  We check that decodability
       -- in other tests that pair a Haskell encoder with a Python decoder.
       assertEqual (show fp ++ ": direct encoding, Forward iterator, keep wrappers")
-        goldenEncoding $ FormE.toLazyByteString $
+        goldenEncoding $ FormE.messageEncoderToLazyByteString $
           let ?iterator = Forward
               ?stripping = Keep
           in toEncoder v
       assertEqual (show fp ++ ": direct encoding, Forward iterator, strip wrappers")
-        goldenEncoding $ FormE.toLazyByteString $
+        goldenEncoding $ FormE.messageEncoderToLazyByteString $
           let ?iterator = Forward
               ?stripping = Strip
           in toEncoder v
       assertEqual (show fp ++ ": direct encoding, Vector iterator, keep wrappers")
-        goldenEncoding $ FormE.toLazyByteString $
+        goldenEncoding $ FormE.messageEncoderToLazyByteString $
           let ?iterator = Vector
               ?stripping = Keep
           in toEncoder v
       assertEqual (show fp ++ ": direct encoding, Vector iterator, strip wrappers")
-        goldenEncoding $ FormE.toLazyByteString $
+        goldenEncoding $ FormE.messageEncoderToLazyByteString $
           let ?iterator = Vector
               ?stripping = Strip
           in toEncoder v
@@ -322,14 +322,14 @@ encodeBytesFromBuilder = testCase "bytes from builder" $ do
       a ->
       BL.ByteString
     enc =
-      FormE.toLazyByteString .
+      FormE.messageEncoderToLazyByteString .
       FormE.fieldsToMessage .
       FormE.field @"myBytes" @a @(MyWithBytes r)
 
 encodeMessageReflection :: TestTree
 encodeMessageReflection = testCase "messageReflection" $ do
   let msg = TP.Trivial 123
-  FormE.toLazyByteString (FormE.messageReflection msg) @?= toLazyByteString msg
+  FormE.messageEncoderToLazyByteString (FormE.messageReflection msg) @?= toLazyByteString msg
 
 encodeCachedSubmessage :: TestTree
 encodeCachedSubmessage = testGroup "Cached Submessages"
@@ -343,7 +343,7 @@ encodeCachedSubmessage = testGroup "Cached Submessages"
       let trivial = TP.Trivial 123
           wrappedTrivial = FormE.fieldsToMessage @TP.WrappedTrivial $
             FormE.field @"trivial" (Just (FormE.messageCache trivial))
-      FormE.toLazyByteString wrappedTrivial @?=
+      FormE.messageEncoderToLazyByteString wrappedTrivial @?=
         toLazyByteString (TP.WrappedTrivial (Just trivial))
 
     testRepeated :: TestTree
@@ -355,7 +355,7 @@ encodeCachedSubmessage = testGroup "Cached Submessages"
             ]
           mapTestEmulation = FormE.fieldsToMessage @TP.MapTestEmulation $
             FormE.field @"trivial" (V.map FormE.messageCache trivials)
-      FormE.toLazyByteString mapTestEmulation @?=
+      FormE.messageEncoderToLazyByteString mapTestEmulation @?=
         toLazyByteString (TP.MapTestEmulation mempty trivials mempty)
 
     testOneof :: TestTree
@@ -363,7 +363,7 @@ encodeCachedSubmessage = testGroup "Cached Submessages"
       let withOneof = TPOI.WithOneof (Just (TPOI.WithOneofPickOneB 123))
           withImported = FormE.fieldsToMessage @TPO.WithImported $
             FormE.field @"withOneof" (FormE.messageCache withOneof)
-      FormE.toLazyByteString withImported @?=
+      FormE.messageEncoderToLazyByteString withImported @?=
         toLazyByteString (TPO.WithImported (Just (TPO.WithImportedPickOneWithOneof withOneof)))
 
 testShowMessageEncoding :: TestTree
@@ -644,10 +644,10 @@ encoderPromotionsAndAuto = testGroup "Encoder promotes types correctly and Auto-
       b ->
       Property
     check1 a b =
-      FormE.toLazyByteString
+      FormE.messageEncoderToLazyByteString
         (FormE.fieldsToMessage (FormE.field @"name" @a @(TestMessage num repetition protoType) a))
       ===
-      FormE.toLazyByteString
+      FormE.messageEncoderToLazyByteString
         (FormE.fieldsToMessage (FormE.field @"name" @b @(TestMessage num repetition protoType) b))
 
     showsType :: forall a . Typeable a => ShowS

--- a/tests/SimpleEncodeDotProto.hs
+++ b/tests/SimpleEncodeDotProto.hs
@@ -21,7 +21,7 @@ import           Text.Read (readEither)
 import           System.Environment (getArgs, getProgName)
 import           System.Exit (die)
 
-import qualified Proto3.Suite.Form.Encode as Form
+import qualified Proto3.Suite.Form.Encode as FormE
 import           Test.Proto.ToEncoder (Iterator, Stripping, ToEncoder(..))
 
 data Format = Binary | Jsonpb
@@ -44,7 +44,7 @@ outputMessage msg = putStrLn (show (BL.length encoded)) >> BL.putStr encoded
     encoded = case ?format of
       Binary ->
 #if TYPE_LEVEL_FORMAT
-        Form.toLazyByteString (toEncoder msg)
+        FormE.messageEncoderToLazyByteString (toEncoder msg)
 #else
         toLazyByteString msg
 #endif


### PR DESCRIPTION
v0.9.2:
  * [BREAKING CHANGE in experimental module: Rename `toLazyByteString` to `messageEncoderToLazyByteString`.]
  * [BREAKING CHANGE in experimental module: Rename `cacheMessage` to `messageCache`.]
  * [BREAKING CHANGE in experimental module: Delete `Eq` instance for `MessageEncoding` because it is application-defined whether we should ignore field order during comparison.]
  * Add `Show` instance for `MessageEncoder`.
  * Add `messageEncoderToByteString` and `unsafeByteStringToMessageEncoder`.
