### PR TITLE
JSON encoding of MessageEncoder, MessageEncoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.9.3
+* [#284](https://github.com/awakesecurity/proto3-suite/pull/283) Delete Repeated.hs
+  * [BREAKING CHANGE in experimental module: Rename `Prefix` to `FieldsEncoder`, along with related functions.]
+  * [BREAKING CHANGE in experimental module: Rename `Fields` to `FieldsEncoding`, along with related functions.]
+  * Add instances of `FromJSON`, `FromJSONPB`, `ToJSON`, `ToJSONPB`
+    for `MessageEncoding` and `MessageEncoder`.
+
 # 0.9.2
 * [#282](https://github.com/awakesecurity/proto3-suite/pull/282) Show MessageEncoder
   * [BREAKING CHANGE in experimental module: Rename `toLazyByteString` to `messageEncoderToLazyByteString`.]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.9.3
-* [#284](https://github.com/awakesecurity/proto3-suite/pull/283) Delete Repeated.hs
+* [#284](https://github.com/awakesecurity/proto3-suite/pull/284) Delete Repeated.hs
   * [BREAKING CHANGE in experimental module: Rename `Prefix` to `FieldsEncoder`, along with related functions.]
   * [BREAKING CHANGE in experimental module: Rename `Fields` to `FieldsEncoding`, along with related functions.]
   * Add instances of `FromJSON`, `FromJSONPB`, `ToJSON`, `ToJSONPB`

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                proto3-suite
-version:             0.9.2
+version:             0.9.3
 synopsis:            A higher-level API to the proto3-wire library
 description:
   This library provides a higher-level API to <https://github.com/awakesecurity/proto3-wire the `proto3-wire` library>
@@ -17,7 +17,7 @@ description:
 license:             Apache-2.0
 author:              Arista Networks <opensource@awakesecurity.com>
 maintainer:          Arista Networks <opensource@awakesecurity.com>
-copyright:           2017-2020 Awake Security, 2021-2022 Arista Networks
+copyright:           2017-2020 Awake Security, 2021-2025 Arista Networks
 category:            Codec
 build-type:          Simple
 data-files:          test-files/*.bin tests/encode.sh tests/decode.sh

--- a/src/Proto3/Suite/Form/Encode.hs
+++ b/src/Proto3/Suite/Form/Encode.hs
@@ -145,7 +145,7 @@ instance (omission ~ 'Alternative) =>
 -- Do this only if you expect to reuse that specific octet sequence repeatedly.
 --
 -- @'cachedMessageEncoding' . 'cacheMessageEncoding'@ is functionally equivalent
--- to @id@ but has different performance characteristics.
+-- to 'id' but has different performance characteristics.
 --
 -- See also: 'cacheFieldsEncoding'.
 cacheMessageEncoding :: MessageEncoder message -> MessageEncoding message
@@ -178,7 +178,7 @@ type role FieldsEncoding nominal nominal nominal
 -- Do this only if you expect to reuse that specific octet sequence repeatedly.
 --
 -- @'cachedFieldsEncoding' . 'cacheFieldsEncoding'@ is functionally equivalent
--- to @id@ but has different performance characteristics.
+-- to 'id' but has different performance characteristics.
 --
 -- See also: 'cacheMessageEncoding'
 cacheFieldsEncoding ::

--- a/src/Proto3/Suite/Form/Encode/Core.hs
+++ b/src/Proto3/Suite/Form/Encode/Core.hs
@@ -32,8 +32,8 @@ module Proto3.Suite.Form.Encode.Core
   , messageEncoderToLazyByteString
   , messageEncoderToByteString
   , etaMessageEncoder
-  , Prefix(..)
-  , etaPrefix
+  , FieldsEncoder(..)
+  , etaFieldsEncoder
   , Distinct
   , DistinctCheck
   , RepeatedNames
@@ -121,28 +121,28 @@ etaMessageEncoder = coerce (Encode.etaMessageBuilder @a)
 -- packed repeated field.  Though that would be less compact than
 -- a single block, it is allowed by the protobuf standard.
 --
--- See also: 'cachePrefix'
-newtype Prefix (message :: Type) (possible :: [Symbol]) (following :: [Symbol]) =
-  UnsafePrefix { untypedPrefix :: Encode.MessageBuilder }
+-- See also: 'cacheFieldsEncoder'
+newtype FieldsEncoder (message :: Type) (possible :: [Symbol]) (following :: [Symbol]) =
+  UnsafeFieldsEncoder { untypedFieldsEncoder :: Encode.MessageBuilder }
 
-type role Prefix nominal nominal nominal
+type role FieldsEncoder nominal nominal nominal
 
--- | The 'Category' on prefixes of a particular type of
--- message whose '.' is '<>' on the contained builders.
+-- | The 'Category' on encoders of zero or more fields of a particular
+-- type of message whose '.' is '<>' on the contained builders.
 --
 -- Note that '.' preserves the requirements
--- on the type parameters of 'Prefix'.
-instance Category (Prefix message)
+-- on the type parameters of 'FieldsEncoder'.
+instance Category (FieldsEncoder message)
   where
-    id = UnsafePrefix mempty
-    f . g = UnsafePrefix (untypedPrefix f <> untypedPrefix g)
+    id = UnsafeFieldsEncoder mempty
+    f . g = UnsafeFieldsEncoder (untypedFieldsEncoder f <> untypedFieldsEncoder g)
 
--- | Like 'Encode.etaMessageBuilder' but for 'Prefix'.
-etaPrefix ::
+-- | Like 'Encode.etaMessageBuilder' but for 'FieldsEncoder'.
+etaFieldsEncoder ::
   forall a message possible following .
-  (a -> Prefix message possible following) ->
-  a -> Prefix message possible following
-etaPrefix = coerce (Encode.etaMessageBuilder @a)
+  (a -> FieldsEncoder message possible following) ->
+  a -> FieldsEncoder message possible following
+etaFieldsEncoder = coerce (Encode.etaMessageBuilder @a)
 
 -- | Yields a satisfied constraint if the given list of names contains
 -- no duplicates after first filtering out the names of repeated fields
@@ -244,9 +244,9 @@ type family OccupiedOnly1 (message :: Type) (name :: Symbol) (names :: [Symbol])
 fieldsToMessage ::
   forall (message :: Type) (names :: [Symbol]) .
   Distinct message names =>
-  Prefix message '[] names ->
+  FieldsEncoder message '[] names ->
   MessageEncoder message
-fieldsToMessage = UnsafeMessageEncoder . untypedPrefix
+fieldsToMessage = UnsafeMessageEncoder . untypedFieldsEncoder
 
 -- | Among the names of the given message, prefixes
 -- the given name with the following exceptions:
@@ -285,8 +285,8 @@ type family NameSublist (names :: [Symbol]) (moreNames :: [Symbol]) :: Constrain
       ( 'Text "NameSublist: name disappeared: " ':<>: 'ShowType n )
 
 -- | Uses an empty encoding for the @oneof@s and non-@oneof@ message fields
--- that appear in the final type parameter of 'Prefix' but not the previous
--- type parameter, thereby implicitly emitting their default values.
+-- that appear in the final type parameter of 'FieldsEncoder' but not the
+-- previous type parameter, thereby implicitly emitting their default values.
 --
 -- This function is not always required, but becomes necessary when
 -- there are two code paths, one of which may write non-repeatable
@@ -301,8 +301,8 @@ type family NameSublist (names :: [Symbol]) (moreNames :: [Symbol]) :: Constrain
 omitted ::
   forall (message :: Type) (names :: [Symbol]) (moreNames :: [Symbol]) .
   NameSublist names moreNames =>
-  Prefix message names moreNames
-omitted = UnsafePrefix mempty
+  FieldsEncoder message names moreNames
+omitted = UnsafeFieldsEncoder mempty
 
 -- | Singleton field number type.
 newtype SFieldNumber (fieldNumber :: Nat)
@@ -361,7 +361,7 @@ class Field name a message
     -- `Proto3.Suite.Form.Encode.associations`.
     --
     -- See also 'fieldForm'.
-    field :: forall names . a -> Prefix message names (Occupy message name names)
+    field :: forall names . a -> FieldsEncoder message names (Occupy message name names)
 
 instance forall (name :: Symbol)
 #if defined(__GLASGOW_HASKELL__) && 904 <= __GLASGOW_HASKELL__
@@ -378,10 +378,10 @@ instance forall (name :: Symbol)
          ) =>
          Field name a message
   where
-    field :: forall names . a -> Prefix message names (Occupy message name names)
+    field :: forall names . a -> FieldsEncoder message names (Occupy message name names)
     field = coerce
       @(a -> Encode.MessageBuilder)
-      @(a -> Prefix message names (Occupy message name names))
+      @(a -> FieldsEncoder message names (Occupy message name names))
       (fieldForm @(RepetitionOf message name) @(ProtoTypeOf message name) @a
                  proxy# proxy# (fieldNumberVal @message @name))
       -- Implementation Note: Using the newtype constructor would require us


### PR DESCRIPTION
v0.9.3:
* [#284](https://github.com/awakesecurity/proto3-suite/pull/284) Delete Repeated.hs
  * [BREAKING CHANGE in experimental module: Rename `Prefix` to `FieldsEncoder`, along with related functions.]
  * [BREAKING CHANGE in experimental module: Rename `Fields` to `FieldsEncoding`, along with related functions.]
  * Add instances of `FromJSON`, `FromJSONPB`, `ToJSON`, `ToJSONPB` for `MessageEncoding` and `MessageEncoder`.