### PR TITLE
build: relax QuickCheck upper bound to <2.17

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -122,7 +122,7 @@ library
                        pretty ==1.1.*,
                        pretty-show >= 1.6.12 && < 2.0,
                        proto3-wire >= 1.4.5 && < 1.5,
-                       QuickCheck >=2.10 && <2.15,
+                       QuickCheck >=2.10 && <2.17,
                        quickcheck-instances >=0.3.26 && < 0.4,
                        safe ==0.3.*,
                        split,
@@ -212,7 +212,7 @@ test-suite tests
     , pretty-show >= 1.6.12 && < 2.0
     , proto3-suite
     , proto3-wire >= 1.4.5 && < 1.5
-    , QuickCheck >=2.10 && <2.15
+    , QuickCheck >=2.10 && <2.17
     , record-hasfield
     , tasty >= 0.11 && <1.5
     , tasty-hedgehog


### PR DESCRIPTION
For allow QuickCheck 2.15 and 2.16.
