### PR TITLE
Remove `Anonymous` constructor from `DotProtoIdentifier`

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -51,7 +51,7 @@ source-repository head
 common common
   default-extensions:
     BlockArguments ExplicitNamespaces DeriveDataTypeable DeriveGeneric
-    ImportQualifiedPost ViewPatterns
+    ImportQualifiedPost PatternSynonyms ViewPatterns
 
 library
   import: common
@@ -75,6 +75,7 @@ library
                        Proto3.Suite.Class
                        Proto3.Suite.DotProto
                        Proto3.Suite.DotProto.AST
+                       Proto3.Suite.DotProto.AST.Identifier
                        Proto3.Suite.DotProto.AST.Lens
                        Proto3.Suite.DotProto.Generate
                        Proto3.Suite.DotProto.Generate.Record

--- a/src/Proto3/Suite/DotProto/AST/Identifier.hs
+++ b/src/Proto3/Suite/DotProto/AST/Identifier.hs
@@ -1,0 +1,35 @@
+
+module Proto3.Suite.DotProto.AST.Identifier
+  ( -- * DotProtoIdentifier
+    DotProtoIdentifier (..),
+    fakePath,
+  )
+where
+
+import Data.Data (Data)
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty qualified as NonEmpty
+
+import GHC.Generics (Generic)
+
+import Text.PrettyPrint qualified as PP
+import Text.PrettyPrint.HughesPJClass (Pretty (..))
+
+--- DotProtoIdentifier ---------------------------------------------------------
+
+data DotProtoIdentifier
+  = Single String
+  | Dots (NonEmpty String)
+  | Qualified DotProtoIdentifier DotProtoIdentifier
+  | Anonymous -- [recheck] is there a better way to represent unnamed things
+  deriving (Data, Eq, Generic, Ord, Show)
+
+instance Pretty DotProtoIdentifier where
+  pPrint (Single name)                    = PP.text name
+  pPrint (Dots names)                     = PP.hcat . PP.punctuate (PP.text ".") $ PP.text <$> NonEmpty.toList names
+  pPrint (Qualified qualifier identifier) = PP.parens (pPrint qualifier) <> PP.text "." <> pPrint identifier
+  pPrint Anonymous                        = PP.empty
+
+-- Used for testing
+fakePath :: NonEmpty String
+fakePath = "fakePath" :| []

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -506,11 +506,19 @@ ctxtImports =
 --   field of the 'DotProtoTypeInfo' parameter, instead demanding that we have
 --   been provided with a valid module path in its 'dotProtoTypeInfoModulePath'
 --   field. The latter describes the name of the Haskell module being generated.
-msgTypeFromDpTypeInfo :: MonadError CompileError m
-                      => TypeContext -> DotProtoTypeInfo -> DotProtoIdentifier -> m HsType
+msgTypeFromDpTypeInfo :: 
+  MonadError CompileError m => 
+  TypeContext -> 
+  DotProtoTypeInfo -> 
+  DotProtoIdentifier -> 
+  m HsType
 msgTypeFromDpTypeInfo ctxt DotProtoTypeInfo{..} ident = do
+    let parIdt = case dotProtoTypeInfoParent of
+          Nothing -> Anonymous
+          Just idt -> Single idt
+
     modName   <- modulePathModName dotProtoTypeInfoModulePath
-    identName <- qualifiedMessageTypeName ctxt dotProtoTypeInfoParent ident
+    identName <- qualifiedMessageTypeName ctxt parIdt ident
     pure $ typeNamed_ $ qual_ modName tcName identName
 
 modulePathModName :: MonadError CompileError m => NonEmpty String -> m Module

--- a/src/Proto3/Suite/DotProto/Generate.hs
+++ b/src/Proto3/Suite/DotProto/Generate.hs
@@ -462,7 +462,12 @@ readImportTypeContext searchPaths toplevelFP alreadyRead (DotProtoImport _ path)
       let importPkgSpec = protoPackage import_
 
       let fixImportTyInfo tyInfo =
-             tyInfo { dotProtoTypeInfoPackage    = importPkgSpec
+             tyInfo { dotProtoTypeInfoPackage    = case importPkgSpec of 
+                        Nothing -> []
+                        Just Anonymous -> []
+                        Just (Single p) -> [p]
+                        Just (Dots ps) -> NE.toList ps
+                        Just Qualified {} -> error "fixImportTyInfo: Qualified"
                     , dotProtoTypeInfoModulePath = metaModulePath . protoMeta $ import_
                     }
       importTypeContext <- fmap fixImportTyInfo <$> dotProtoTypeContext import_

--- a/src/Proto3/Suite/DotProto/Generate/Syntax.hs
+++ b/src/Proto3/Suite/DotProto/Generate/Syntax.hs
@@ -998,7 +998,7 @@ symT = noLocA . HsTyLit synDef . HsStrTy NoSourceText . mkFastString
 nothingN, justN :: HsQName
 
 dotProtoFieldC, primC, optionalC, repeatedC, nestedRepeatedC, namedC, mapC,
-  fieldNumberC, singleC, dotsC, pathC, qualifiedC, anonymousC, dotProtoOptionC,
+  fieldNumberC, singleC, dotsC, qualifiedC, anonymousC, dotProtoOptionC,
   identifierC, stringLitC, intLitC, floatLitC, boolLitC, trueC, falseC, nothingC,
   justC, forceEmitC, encodeMessageFieldE, fromStringE, decodeMessageFieldE,
   pureE, returnE, mappendE, memptyE, msumE, atE, oneofE, fmapE :: HsExp
@@ -1014,7 +1014,6 @@ namedC               = var_ (protobufASTName tcName "Named")
 mapC                 = var_ (protobufASTName dataName  "Map")
 fieldNumberC         = var_ (protobufName dataName "FieldNumber")
 singleC              = var_ (protobufASTName dataName "Single")
-pathC                = var_ (protobufASTName dataName "Path")
 dotsC                = var_ (protobufASTName dataName "Dots")
 qualifiedC           = var_ (protobufASTName dataName "Qualified")
 anonymousC           = var_ (protobufASTName dataName "Anonymous")

--- a/src/Proto3/Suite/DotProto/Rendering.hs
+++ b/src/Proto3/Suite/DotProto/Rendering.hs
@@ -54,10 +54,14 @@ defEnumMemberName = const pPrint
 renderDotProto :: RenderingOptions -> DotProto -> PP.Doc
 renderDotProto opts DotProto{..}
   = PP.text "syntax = \"proto3\";"
- $$ pPrint protoPackage
+ $$ packageDoc 
  $$ (PP.vcat $ pPrint    <$> protoImports)
  $$ (PP.vcat $ topOption <$> protoOptions)
  $$ (PP.vcat $ prettyPrintProtoDefinition opts <$> protoDefinitions)
+  where 
+    packageDoc = case protoPackage of
+      Nothing -> PP.empty
+      Just p  -> PP.text "package" <+> pPrint p PP.<> PP.text ";"
 
 optionAnnotation :: [DotProtoOption] -> PP.Doc
 optionAnnotation [] = PP.empty
@@ -140,4 +144,4 @@ toProtoFileDef = toProtoFile defRenderingOptions
 
 packageFromDefs :: String -> [DotProtoDefinition] -> DotProto
 packageFromDefs package defs =
-  DotProto [] [] (DotProtoPackageSpec $ Single package) defs (DotProtoMeta fakePath)
+  DotProto [] [] (Just (Single package)) defs (DotProtoMeta fakePath)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -102,6 +102,8 @@ docTests = testCase "doctests" $ do
     , "ghc-lib-parser"
     , "-isrc"
     , "-XBlockArguments"
+    , "-XExplicitNamespaces"
+    , "-XPatternSynonyms"
 #ifdef SWAGGER
 #ifdef SWAGGER_WRAPPER_FORMAT
     , "-isrc/swagger-wrapper-format"
@@ -838,7 +840,7 @@ dotProtoUnitTests = testGroup ".proto parsing tests"
   ]
 
 trivialDotProto :: DotProto
-trivialDotProto = DotProto [] [] DotProtoNoPackage [] (DotProtoMeta (Path $ "test-files" NE.:| ["test_trivial"]))
+trivialDotProto = DotProto [] [] Nothing [] (DotProtoMeta ("test-files" NE.:| ["test_trivial"]))
 
 dotProtoParseTrivial :: TestTree
 dotProtoParseTrivial = testCase
@@ -860,7 +862,7 @@ dotProtoParseEmptyStatement =
     dotProtoAST :: DotProto
     dotProtoAST =
       DotProto [] []
-        (DotProtoPackageSpec (Single "TestProtoEmptyField"))
+        (Just (Single "TestProtoEmptyField"))
         [ DotProtoEnum
             ""
             (Single "EnumWithEmptyField")
@@ -886,7 +888,7 @@ dotProtoParseEmptyStatement =
                 })
             ]
         ]
-        (DotProtoMeta (Path (testFilesPfx NE.:| ["test_proto_empty_field.proto"])))
+        (DotProtoMeta (testFilesPfx NE.:| ["test_proto_empty_field.proto"]))
 
 dotProtoRoundtripTrivial :: TestTree
 dotProtoRoundtripTrivial = testCase
@@ -894,13 +896,13 @@ dotProtoRoundtripTrivial = testCase
   testDotProtoRoundtrip trivialDotProto
 
 dotProtoSimpleMessage :: DotProto
-dotProtoSimpleMessage = DotProto [] [] DotProtoNoPackage
+dotProtoSimpleMessage = DotProto [] [] Nothing
   [ DotProtoMessage "" (Single "MessageTest")
       [ DotProtoMessageField $
           DotProtoField (fieldNumber 1) (Prim Int32) (Single "testfield") [] ""
       ]
   ]
-  (DotProtoMeta (Path ("test-files" NE.:| ["simple"])))
+  (DotProtoMeta ("test-files" NE.:| ["simple"]))
 
 dotProtoRoundtripSimpleMessage :: TestTree
 dotProtoRoundtripSimpleMessage = testCase
@@ -934,7 +936,7 @@ qcDotProtoRoundtrip = testProperty
 dotProtoRoundtripExtend :: TestTree
 dotProtoRoundtripExtend =
   let expected :: DotProto
-      expected = DotProto [] [] DotProtoNoPackage [] (DotProtoMeta (Path ("test-files" NE.:| ["test_proto_extend"])))
+      expected = DotProto [] [] Nothing [] (DotProtoMeta ("test-files" NE.:| ["test_proto_extend"]))
    in testCase
         "Round-trip for a message extension"
         (testDotProtoRoundtrip expected)
@@ -943,11 +945,11 @@ dotProtoRoundtripExtend =
 -- Helpers
 
 dotProtoFor :: (Named a, Message a) => Proxy# a -> DotProto
-dotProtoFor proxy = DotProto [] [] DotProtoNoPackage
+dotProtoFor proxy = DotProto [] [] Nothing
   [ DotProtoMessage
       "" (Single (nameOf proxy)) (DotProtoMessageField <$> dotProto proxy)
   ]
-  (DotProtoMeta (Path $ "mypath" NE.:| []))
+  (DotProtoMeta ("mypath" NE.:| []))
 
 showDotProtoFor :: (Named a, Message a) => Proxy# a -> IO ()
 showDotProtoFor proxy = putStrLn . toProtoFileDef $ dotProtoFor proxy

--- a/tests/Test/Proto/Generate/Name.hs
+++ b/tests/Test/Proto/Generate/Name.hs
@@ -24,30 +24,30 @@ testTree :: TestTree
 testTree =
   testGroup
     "Test.Proto.Generate.Name"
-    [ testProperty "filenames" resolve'protofile
+    [ testProperty "filenames" resolveProtofile
     ]
 
 -- | Testing combinator for name resolution functions.
 testResolution ::
   (MonadTest m, Applicative f, Eq (f String), Show (f String)) =>
-  (String -> f String) -> GenName -> m ()
+  (String -> f String) -> 
+  GenName -> 
+  m ()
 testResolution resolve nm = do
-  let occ = Name.Gen.nameOcc nm
-  let res = Name.Gen.nameRes nm
-  let got = resolve occ
-
   annotate ("protobuf name: " ++ occ)
   annotate ("expected name: " ++ res)
   annotate ("resolved name: " ++ show got)
-
   pure res === got
+  where
+    occ :: String
+    occ = Name.Gen.nameOcc nm
 
--- -----------------------------------------------------------------------------
---
--- Name Resolution Tests
---
+    res :: String
+    res = Name.Gen.nameRes nm
 
-resolve'protofile :: Property
-resolve'protofile = property do
+    got = resolve occ
+
+resolveProtofile :: Property
+resolveProtofile = property do
   nm <- forAll $ Gen.sized (Name.Gen.protofile . Range.linear 1 . fromIntegral)
   testResolution (renameProtoFile @(Either CompileError)) nm

--- a/tests/Test/Proto/Generate/Name/Gen.hs
+++ b/tests/Test/Proto/Generate/Name/Gen.hs
@@ -8,19 +8,21 @@
 
 -- |
 module Test.Proto.Generate.Name.Gen
-  ( GenName (GenName, nameOcc, nameRes),
+  ( -- * GenName 
+    GenName (..),
     protofile,
   )
 where
+
+import Control.Applicative
+
+import Data.Char qualified as Char
 
 import Hedgehog (MonadGen, Range)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 
-import Control.Applicative
-import Data.Char qualified as Char
-
--- -----------------------------------------------------------------------------
+--- GenName --------------------------------------------------------------------
 
 -- | 'GenName' is an association between generated names.
 --

--- a/tests/Test/Proto/Parse/Gen.hs
+++ b/tests/Test/Proto/Parse/Gen.hs
@@ -11,7 +11,6 @@ import Hedgehog (Gen)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
-import Control.Applicative (liftA2)
 import qualified Data.List.NonEmpty as NonEmpty
 
 import Proto3.Suite.DotProto.AST

--- a/tests/Test/Proto/Parse/Gen.hs
+++ b/tests/Test/Proto/Parse/Gen.hs
@@ -11,6 +11,7 @@ import Hedgehog (Gen)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
+import Control.Applicative (liftA2)
 import qualified Data.List.NonEmpty as NonEmpty
 
 import Proto3.Suite.DotProto.AST
@@ -28,7 +29,7 @@ optionName =
     nms <- Gen.nonEmpty range gNameString
     pure $ if null (NonEmpty.tail nms)
       then Single (NonEmpty.head nms)
-      else Dots (Path nms)
+      else Dots nms
   where
     gNameString :: Gen String
     gNameString =

--- a/tools/canonicalize-proto-file/Main.hs
+++ b/tools/canonicalize-proto-file/Main.hs
@@ -41,12 +41,10 @@ import Proto3.Suite.DotProto.AST
   , DotProtoImport (..)
   , DotProtoMessagePart (..)
   , DotProtoOption (..)
-  , DotProtoPackageSpec (..)
   , DotProtoServicePart (..)
   , DotProtoReservedField (..)
   , DotProtoType (..)
   , DotProtoValue (..)
-  , Path (..)
   , RPCMethod (..)
   )
 import Proto3.Suite.DotProto.Generate (readDotProtoWithContext)
@@ -95,7 +93,7 @@ instance Canonicalize DotProto where
   canonicalize DotProto{..} = DotProto
     { protoImports     = canonicalize protoImports
     , protoOptions     = canonicalize protoOptions
-    , protoPackage     = canonicalize protoPackage
+    , protoPackage     = fmap canonicalize protoPackage 
     , protoDefinitions = canonicalize protoDefinitions
     , protoMeta        = protoMeta
     }
@@ -115,11 +113,6 @@ instance Canonicalize DotProtoOption where
     { dotProtoOptionIdentifier = canonicalize dotProtoOptionIdentifier
     , dotProtoOptionValue      = canonicalize dotProtoOptionValue
     }
-
-instance Canonicalize DotProtoPackageSpec where
-  canonicalize = \case
-    DotProtoPackageSpec name -> DotProtoPackageSpec (canonicalize name)
-    DotProtoNoPackage -> DotProtoNoPackage
 
 instance Canonicalize [DotProtoDefinition] where canonicalize = canonicalSort
 
@@ -273,7 +266,7 @@ instance Canonicalize DotProtoValue where
 instance Canonicalize DotProtoIdentifier where
   canonicalize = \case
     Single part -> Single part
-    Dots (Path (part NE.:| [])) -> Single part
+    Dots (part NE.:| []) -> Single part
     Dots path -> Dots path
     Qualified x y -> Qualified (canonicalize x) (canonicalize y)
     Anonymous -> Anonymous


### PR DESCRIPTION
This PR makes changes to the protobuf AST in order to remove some constructions which don't map to any meaningful protobuf syntax. Additionally, this PR will attempt to refactor how `DotProtoIdentifier` is defined so that it is no longer a recursive type, but a record with fields for enclosing file path, qualifiers, and the identifier symbol.