### PR TITLE
Fix casing for `True` in cabal file

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -47,7 +47,7 @@ flag attoparsec-aeson
 flag development
   description: Enable development-specific options.
   default: False 
-  manual: true
+  manual: True
 
 source-repository head
   type:     git

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -20,8 +20,15 @@ maintainer:          Arista Networks <opensource@awakesecurity.com>
 copyright:           2017-2020 Awake Security, 2021-2025 Arista Networks
 category:            Codec
 build-type:          Simple
-data-files:          test-files/*.bin tests/encode.sh tests/decode.sh
-extra-source-files:  CHANGELOG.md, gen/.gitignore
+
+data-files:
+  test-files/*.bin 
+  tests/encode.sh 
+  tests/decode.sh
+
+extra-source-files:
+  CHANGELOG.md, 
+  gen/.gitignore
 
 flag dhall
   Description:   Turn on Dhall interpret and inject codegen
@@ -45,15 +52,16 @@ flag attoparsec-aeson
     -- "Manual: False" to automatically skip "attoparsec-aeson" if it is not available
 
 flag development
-  description: Enable development-specific options.
-  default: False 
-  manual: True
+  Description: Enable development-specific options.
+  Default:     False 
+  Manual:      True
 
 source-repository head
   type:     git
   location: https://github.com/awakesecurity/proto3-suite
 
 common common
+  default-language: Haskell2010
   default-extensions:
     BlockArguments ExplicitNamespaces DeriveDataTypeable DeriveGeneric
     ImportQualifiedPost ViewPatterns
@@ -62,8 +70,17 @@ common common
     ghc-options:
       -Werror
 
+  build-depends:
+      base >=4.15 && <5.0
+    , proto3-wire >= 1.4.6 && < 1.5
+
+  ghc-options:
+    -O2 
+    -Wall
+
 library
-  import: common
+  import:           common
+  hs-source-dirs:   src
 
   if flag(dhall)
     exposed-modules:   Proto3.Suite.DhallPB
@@ -71,87 +88,91 @@ library
     cpp-options:       -DDHALL
 
   if flag(swagger)
-    exposed-modules:   Proto3.Suite.DotProto.Generate.Swagger
-                       Proto3.Suite.DotProto.Generate.Swagger.Wrappers
-    build-depends:     swagger2 >=2.1.6 && <2.9
-    cpp-options:       -DSWAGGER
+    build-depends:
+      swagger2 >=2.1.6 && <2.9
+
+    cpp-options:       
+      -DSWAGGER
+
+    exposed-modules:
+      Proto3.Suite.DotProto.Generate.Swagger
+      Proto3.Suite.DotProto.Generate.Swagger.Wrappers
+
     if flag(swagger-wrapper-format)
-      hs-source-dirs:  src/swagger-wrapper-format
+      hs-source-dirs: src/swagger-wrapper-format
     else
-      hs-source-dirs:  src/no-swagger-wrapper-format
+      hs-source-dirs: src/no-swagger-wrapper-format
 
-  exposed-modules:     Proto3.Suite
-                       Proto3.Suite.Class
-                       Proto3.Suite.DotProto
-                       Proto3.Suite.DotProto.AST
-                       Proto3.Suite.DotProto.AST.Lens
-                       Proto3.Suite.DotProto.Generate
-                       Proto3.Suite.DotProto.Generate.Record
-                       Proto3.Suite.DotProto.Generate.Syntax
-                       Proto3.Suite.DotProto.Parsing
-                       Proto3.Suite.DotProto.Rendering
-                       Proto3.Suite.Form
-                       Proto3.Suite.Form.Encode
-                       Proto3.Suite.JSONPB
-                       Proto3.Suite.Tutorial
-                       Proto3.Suite.Types
+  exposed-modules:     
+    Proto3.Suite
+    Proto3.Suite.Class
+    Proto3.Suite.DotProto
+    Proto3.Suite.DotProto.AST
+    Proto3.Suite.DotProto.AST.Lens
+    Proto3.Suite.DotProto.Generate
+    Proto3.Suite.DotProto.Generate.Record
+    Proto3.Suite.DotProto.Generate.Syntax
+    Proto3.Suite.DotProto.Parsing
+    Proto3.Suite.DotProto.Rendering
+    Proto3.Suite.Form
+    Proto3.Suite.Form.Encode
+    Proto3.Suite.JSONPB
+    Proto3.Suite.Tutorial
+    Proto3.Suite.Types
 
-                       Google.Protobuf.Timestamp
-                       Google.Protobuf.Wrappers.Polymorphic
+    Google.Protobuf.Timestamp
+    Google.Protobuf.Wrappers.Polymorphic
 
-                       Proto3.Suite.DotProto.Internal
-                       Proto3.Suite.Haskell.Parser
-                       Proto3.Suite.JSONPB.Class
+    Proto3.Suite.DotProto.Internal
+    Proto3.Suite.Haskell.Parser
+    Proto3.Suite.JSONPB.Class
 
   other-modules:
-                       Proto3.Suite.Form.Encode.Core
-                       Turtle.Compat
+    Proto3.Suite.Form.Encode.Core
+    Turtle.Compat
 
-  build-depends:       aeson >= 1.1.1.0 && < 2.3,
-                       aeson-pretty,
-                       attoparsec >= 0.13.0.1,
-                       base >=4.15 && <5.0,
-                       base64-bytestring >= 1.0.0.1 && < 1.3,
-                       binary >=0.8.3,
-                       bytestring >=0.10.6.0 && <0.13,
-                       deepseq >=1.4 && <1.6,
-                       cereal >= 0.5.1 && <0.6,
-                       containers >=0.5 && <0.8,
-                       contravariant >=1.4 && <1.6,
-                       filepath,
-                       foldl,
-                       ghc-lib-parser >=9.2.8 && <9.13,
-                       hashable,
-                       insert-ordered-containers,
-                       lens,
-                       mtl >=2.2 && <2.4,
-                       neat-interpolation,
-                       parsec >= 3.1.9 && <3.2.0,
-                       parsers >= 0.12 && <0.13,
-                       pretty ==1.1.*,
-                       pretty-show >= 1.6.12 && < 2.0,
-                       proto3-wire >= 1.4.6 && < 1.5,
-                       QuickCheck >=2.10 && <2.17,
-                       quickcheck-instances >=0.3.26 && < 0.4,
-                       safe ==0.3.*,
-                       split,
-                       system-filepath,
-                       template-haskell >=2.17 && <2.24,
-                       text >= 0.2 && <2.2,
-                       text-short >=0.1.3 && <0.2,
-                       time,
-                       transformers >=0.4 && <0.7,
-                       turtle < 1.6.0 || >= 1.6.1 && < 1.7.0,
-                       vector >=0.11 && <0.14
+  build-depends:       
+      aeson >= 1.1.1.0 && < 2.3
+    , aeson-pretty
+    , attoparsec >= 0.13.0.1
+    , base64-bytestring >= 1.0.0.1 && < 1.3
+    , binary >=0.8.3
+    , bytestring >=0.10.6.0 && <0.13
+    , deepseq >=1.4 && <1.6
+    , cereal >= 0.5.1 && <0.6
+    , containers >=0.5 && <0.8
+    , contravariant >=1.4 && <1.6
+    , filepath
+    , foldl
+    , ghc-lib-parser >=9.2.8 && <9.13
+    , hashable
+    , insert-ordered-containers
+    , lens
+    , mtl >=2.2 && <2.4
+    , neat-interpolation
+    , parsec >= 3.1.9 && <3.2
+    , parsers >= 0.12 && <0.13
+    , pretty ==1.1.*
+    , pretty-show >= 1.6.12 && < 2
+    , QuickCheck >=2.10 && <2.17
+    , quickcheck-instances >=0.3.26 && < 0.4
+    , safe ==0.3.*
+    , split
+    , system-filepath
+    , template-haskell >=2.17 && <2.24
+    , text >= 0.2 && <2.2
+    , text-short >=0.1.3 && <0.2
+    , time
+    , transformers >=0.4 && <0.7
+    , turtle < 1.6.0 || >= 1.6.1 && < 1.7
+    , vector >=0.11 && <0.14
+
   if flag(attoparsec-aeson)
-    build-depends:     attoparsec-aeson >= 2.2.0.0
-  hs-source-dirs:      src
-  default-language:    Haskell2010
-  ghc-options:         -O2 -Wall
+    build-depends:
+      attoparsec-aeson >= 2.2.0.0
 
 test-suite tests
   import:           common
-  default-language: Haskell2010
   type:             exitcode-stdio-1.0
   main-is:          Main.hs
 
@@ -207,7 +228,6 @@ test-suite tests
   build-depends:
       aeson
     , attoparsec >= 0.13.0.1
-    , base >=4.15 && <5.0
     , base64-bytestring >= 1.0.0.1 && < 1.3
     , bytestring >=0.10.6.0 && <0.13
     , cereal >= 0.5.1 && <0.6
@@ -222,7 +242,6 @@ test-suite tests
     , pretty ==1.1.*
     , pretty-show >= 1.6.12 && < 2.0
     , proto3-suite
-    , proto3-wire >= 1.4.6 && < 1.5
     , QuickCheck >=2.10 && <2.17
     , record-hasfield
     , tasty >= 0.11 && <1.6
@@ -235,32 +254,33 @@ test-suite tests
     , turtle
     , vector >=0.11 && <0.14
 
-  ghc-options:         -O2 -Wall
-
 executable compile-proto-file
-  main-is:             Main.hs
-  hs-source-dirs:      tools/compile-proto-file
-  default-language:    Haskell2010
-  build-depends:       base >=4.15 && <5.0
-                       , ghc-lib-parser
-                       , optparse-applicative
-                       , proto3-suite
-                       , system-filepath
-                       , text
-                       , turtle
-  ghc-options:         -O2 -Wall
+  main-is:          Main.hs
+  hs-source-dirs:   tools/compile-proto-file
+  default-language: Haskell2010
+
+  build-depends: 
+      base >=4.15 && <5.0
+    , ghc-lib-parser
+    , optparse-applicative
+    , proto3-suite
+    , system-filepath
+    , text
+    , turtle
+
+  ghc-options:
+    -O2
+    -Wall
 
 executable canonicalize-proto-file
-  import:              common
-  main-is:             Main.hs
-  hs-source-dirs:      tools/canonicalize-proto-file
-  default-language:    Haskell2010
-  build-depends:       base >=4.15 && <5.0
-                       , containers >=0.5 && <0.8
-                       , mtl >=2.2 && <2.4
-                       , optparse-generic
-                       , proto3-suite
-                       , proto3-wire >= 1.4.6 && < 1.5
-                       , system-filepath
-                       , turtle
-  ghc-options:         -O2 -Wall
+  import:           common
+  main-is:          Main.hs
+  hs-source-dirs:   tools/canonicalize-proto-file
+
+  build-depends:       
+      containers >=0.5 && <0.8
+    , mtl >=2.2 && <2.4
+    , optparse-generic
+    , proto3-suite
+    , system-filepath
+    , turtle


### PR DESCRIPTION
Capitalizes `True` to meet Hackage standards.